### PR TITLE
Add page title, footers links and remove copyright

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,23 +1,23 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title>Rails DfE Boilerplate</title>
+    <title><%= content_for(:page_title) %> - Publish teacher training courses - GOV.UK</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>
-    <%= tag :meta, property: 'viewport', content: 'width=device-width, initial-scale=1' %>
-    <%= tag :meta, property: 'og:image', content: image_url('govuk-opengraph-image.png') %>
-    <%= tag :meta, property: 'theme-color', content: '#0b0c0c' %>
-    <%= favicon_link_tag 'favicon.ico' %>
-    <%= favicon_link_tag 'govuk-mask-icon.svg', rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-    <%= favicon_link_tag 'govuk-apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png' %>
-    <%= favicon_link_tag 'govuk-apple-touch-icon-152x152.png', rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-    <%= favicon_link_tag 'govuk-apple-touch-icon-167x167.png', rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-    <%= favicon_link_tag 'govuk-apple-touch-icon-180x180.png', rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
-    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= tag :meta, property: "viewport", content: "width=device-width, initial-scale=1" %>
+    <%= tag :meta, property: "og:image", content: image_url("govuk-opengraph-image.png") %>
+    <%= tag :meta, property: "theme-color", content: "#0b0c0c" %>
+    <%= favicon_link_tag "favicon.ico" %>
+    <%= favicon_link_tag "govuk-mask-icon.svg", rel: "mask-icon", type: "image/svg", color: "#0b0c0c" %>
+    <%= favicon_link_tag "govuk-apple-touch-icon.png", rel: "apple-touch-icon", type: 'image/png' %>
+    <%= favicon_link_tag "govuk-apple-touch-icon-152x152.png", rel: "apple-touch-icon", type: "image/png", size: "152x152" %>
+    <%= favicon_link_tag "govuk-apple-touch-icon-167x167.png", rel: "apple-touch-icon", type: "image/png", size: "167x167" %>
+    <%= favicon_link_tag "govuk-apple-touch-icon-180x180.png", rel: "apple-touch-icon", type: "image/png", size: "180x180" %>
+    <%= stylesheet_link_tag "application", media: "all" %>
   </head>
 
-  <body class="govuk-template__body ">
+  <body class="govuk-template__body <%= content_for(:body_classes) %>">
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
@@ -27,7 +27,7 @@
     <header class="govuk-header " role="banner" data-module="header">
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
-          <%= link_to "/", class: "govuk-header__link govuk-header__link--homepage" do %>
+          <%= link_to "https://www.gov.uk", class: "govuk-header__link govuk-header__link--homepage" do %>
             <span class="govuk-header__logotype">
               <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
                 <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
@@ -40,7 +40,7 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to "Rails DfE Boilerplate", "/", class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to "Publish teacher training courses", "/", class: "govuk-header__link govuk-header__link--service-name" %>
           <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
@@ -70,15 +70,21 @@
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-
-            <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-              />
-            </svg>
-            <span class="govuk-footer__licence-description">
-              All content is available under the
-              <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-            </span>
+            <h2 class="govuk-visually-hidden">Support links</h2>
+            <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
+              <li class="govuk-footer__inline-list-item">
+                <%= mail_to "mailto:becomingateacher@digital.education.gov.uk?subject=Publish%20teacher%20training%20courses%20feedback", "Give feedback", class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to "Cookies", cookies_path, class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to "Privacy Policy", privacy_path, class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to "Terms and conditions", terms_path, class: "govuk-footer__link" %>
+              </li>
+            </ul>
           </div>
           <div class="govuk-footer__meta-item">
             <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,0 +1,120 @@
+<%= content_for :page_title, "Cookies" %>
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Cookies</h1>
+      <p class="govuk-body">‘Publish postgraduate teacher training courses’ puts small files (known as ‘cookies’) onto your computer to collect information about how you use the site.</p>
+
+      <p class="govuk-body">Cookies are used to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>measure how you use the this service so it can be updated and improved based on your needs</li>
+        <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
+        <li>remember who you are when you have logged in so we can show you your information and information relevant to you</li>
+      </ul>
+
+      <p class="govuk-body">‘Publish postgraduate teacher training courses’ cookies aren’t used to identify you personally.</p>
+      <p class="govuk-body">Find out more about <a href="http://www.aboutcookies.org/" rel="external" class="govuk-link">how to manage cookies</a>.</p>
+
+      <h2 class="govuk-heading-l">How we use cookies</h2>
+
+      <h3 class="govuk-heading-m">Measuring website usage (Google Analytics)</h3>
+
+      <p class="govuk-body">We use Google Analytics software to collect information about how you use ‘Publish postgraduate teacher training courses’. We do this to help make sure the site is meeting the needs of its users and to help us make improvements. </p>
+
+      <p class="govuk-body">Google Analytics stores information about:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the pages you visit on ‘Publish postgraduate teacher training courses’</li>
+        <li>how long you spend on each page</li>
+        <li>how you got to the site</li>
+        <li>what you click on while you’re visiting the site</li>
+      </ul>
+
+      <p class="govuk-body">We don’t allow Google to use or share our analytics data.</p>
+
+      <p class="govuk-body">Google Analytics sets the following cookies:</p>
+
+      <div class="body-text">
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col">Name</th>
+              <th class="govuk-table__header" scope="col">Purpose</th>
+              <th class="govuk-table__header" scope="col">Expires</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell ">_ga</td>
+              <td class="govuk-table__cell ">Used to distinguish anonymous users</td>
+              <td class="govuk-table__cell ">2 years</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell ">_gid</td>
+              <td class="govuk-table__cell ">Used to distinguish anonymous users</td>
+              <td class="govuk-table__cell ">24 hours</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell ">_gat_gtag_UA_114739594_3</td>
+              <td class="govuk-table__cell ">Throttle requests</td>
+              <td class="govuk-table__cell ">10 minutes</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p class="govuk-body">You can opt out of <a href="https://tools.google.com/dlpage/gaoptout" rel="external">Google Analytics</a>.</p>
+
+      <h3 class="govuk-heading-m">Our introductory message</h3>
+
+      <p class="govuk-body">You may see a pop-up welcome message when you first visit ‘Publish postgraduate teacher training courses’. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.</p>
+
+      <div class="body-text">
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col">Name</th>
+              <th class="govuk-table__header" scope="col">Purpose</th>
+              <th class="govuk-table__header" scope="col">Expires</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell ">seen_cookie_message</td>
+              <td class="govuk-table__cell ">Show cookie policy banner on first visit only</td>
+              <td class="govuk-table__cell ">1 month</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3 class="govuk-heading-m">
+        Other cookies
+      </h3>
+      <p class="govuk-body">Other ‘Publish postgraduate teacher training courses’ cookies may include:</p>
+      <div class="body-text">
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col">Name</th>
+              <th class="govuk-table__header" scope="col">Purpose</th>
+              <th class="govuk-table__header" scope="col">Expires</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell "><span class="break-word">7f2a1a341274e6f7b14867772283c0c8</span></td>
+              <td class="govuk-table__cell ">Load balancing</td>
+              <td class="govuk-table__cell ">never</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell "><span class="break-word">.AspNetCore.Cookies</span></td>
+              <td class="govuk-table__cell ">Used to remember your identity when signed in</td>
+              <td class="govuk-table__cell ">never</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</main>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Home" %>
+
 <% if @current_user.present? %>
   <h1 class="govuk-heading-l">Welcome, <%= @current_user['email'] -%></h1>
 <% end %>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,0 +1,103 @@
+<%= content_for :page_title, "Privacy policy" %>
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Privacy policy</h1>
+      <h2 class="govuk-heading-l">Who we are</h2>
+      <p class="govuk-body">This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of ‘Publish postgraduate teacher training courses’.</p>
+
+      <h2 class="govuk-heading-l">What personal information we will store</h2>
+      <p class="govuk-body">For all users, we will store:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>part of your IP address to track user journeys. We do not collect IP addresses in their entirety to avoid the personal identification of users</li>
+        <li>email addresses that are shared with us by you</li>
+        <li>telephone numbers that are shared with us by you</li>
+      </ul>
+
+      <p class="govuk-body">When we create an account for you, we will store:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>name</li>
+        <li>email address</li>
+        <li>personal information such as the name and email of a contact person at your training provider or school, if you choose to share this in a course listing you post to ‘Publish postgraduate teacher training courses’</li>
+      </ul>
+
+      <h2 class="govuk-heading-l">How we will use your information</h2>
+      <p class="govuk-body">
+        We process your anonymised Internet Protocol (IP) address in order to track traffic to the service and continuously improve our service to better meet users’ needs.
+      </p>
+      <p class="govuk-body">
+        Personally identifiable contact information that is published in course listings may be passed on to a third party that will use our course listing data (UCAS) via an application programming interface (API), as described in our Terms and Conditions, in order to feed their postgraduate teacher training application system. Any personal information provided in a course listing will be subject to the third party’s (UCAS) data handling obligations. We are not responsible for how a third party handles any personal information you choose to include in a course listing.
+      </p>
+
+      <h2 class="govuk-heading-l">Why our use of your personal data is lawful</h2>
+      <p class="govuk-body">
+        In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation. For the purpose of this project, this processing is necessary to complete a task in the public interest as stated under GDPR Article 6 (1)(e).
+      </p>
+      <h2 class="govuk-heading-l">Who we will make your personal data available to</h2>
+      <p class="govuk-body">
+        We sometimes need to make personal data available to other organisations. These might include contracted partners (who we have employed to process your personal data on our behalf) and/or other organisations (with whom we need to share your personal data for specific purposes).
+      </p>
+      <p class="govuk-body">
+        Where we need to share your personal data with others, we ensure that this data sharing complies with data protection legislation. We share specific types of personal data with our contracted suppliers, who have been contracted by DfE to manage the delivery of the digital service.
+      </p>
+
+      <p class="govuk-body">Our contracted suppliers use your data data in the following way</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>for user research that informs development of the service: if you share your name, email address and phone number our contracted suppliers will store these in its research library</li>
+        <li>
+          for security purposes: our contracted suppliers collect part of the IP addresses of people visiting the Publish postgraduate teacher training courses website (for example, if we were receiving continuous direct denial of service attacks from an IP address range then we could block it)
+        </li>
+        <li>to enable users to use the service and receive updates: our contracted suppliers collect the names and emails of those publishing course listings on ‘Publish postgraduate teacher training courses’</li>
+      </ul>
+
+      <h2 class="govuk-heading-l">How long we will keep your personal data</h2>
+      <p class="govuk-body">
+        Neither DfE nor its contracted suppliers will keep your personal data longer than we need it for the purpose(s) of research, security and/or delivery of the service, and in any case not longer than 7 years. Your data will be securely deleted when DfE and its contracted suppliers no longer need it for these purposes, or when 7 years have passed, whichever comes first.
+      </p>
+      <p class="govuk-body">
+        Anonymised IP addresses will be deleted after 26 months.
+      </p>
+      <p class="govuk-body">
+        If you share personal information in a course listing we will retain this while the course is live and for one year after it has expired.
+      </p>
+
+
+      <h2 class="govuk-heading-l">Your data protection rights</h2>
+      <p class="govuk-body">You have the right:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>to ask us for access to information about you that we hold</li>
+        <li>to have your personal data rectified, if it is inaccurate or incomplete</li>
+        <li>to request the deletion or removal of personal data where there is no compelling reason for its continued processing</li>
+        <li>to restrict our processing of your personal data (i.e. permitting its storage but no further processing)</li>
+        <li>to object to direct marketing (including profiling) and processing for the purposes of scientific/historical research and statistics</li>
+        <li>not to be subject to decisions based purely on automated processing where it produces a legal or similarly significant effect on you</li>
+      </ul>
+      <p class="govuk-body">
+
+        If you need to contact us regarding any of the above, please do so via the DfE site at: <a href="https://www.gov.uk/contact-dfe" class="govuk-link">https://www.gov.uk/contact-dfe</a>.
+      </p>
+
+      <p class="govuk-body">
+        You can <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights" class="govuk-link">find out more about your data protection rights</a> on the Information Commissioner’s website.
+      </p>
+
+      <h2 class="govuk-heading-l">The right to lodge a complaint</h2>
+
+      <p class="govuk-body">
+        You have the right to raise any concerns with the Information Commissioner’s Office (ICO) via their website at <a href="https://ico.org.uk/concerns/" class="govuk-link">https://ico.org.uk/concerns/</a>.
+      </p>
+      <h2 class="govuk-heading-l">Contact Info</h2>
+
+      <p class="govuk-body">
+        If you have any questions about how your personal information will be used, please contact us at <a href="mailto:becomingateacher@digital.education.gov.uk" class="govuk-link">becomingateacher@digital.education.gov.uk</a> and enter data privacy as a reference. For the Data Protection Officer (DPO) please contact us via gov.uk and mark it for the attention of the ‘DPO’.
+      </p>
+
+      <h2 class="govuk-heading-l">Last updated</h2>
+      <p class="govuk-body">
+        We may need to update this privacy notice periodically so we recommend that you revisit this information from time to time.
+        This version was last updated on 29 June 2018.
+      </p>
+    </div>
+  </div>
+</main>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,0 +1,151 @@
+<%= content_for :page_title, "Terms and Conditions" %>
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Terms and Conditions</h1>
+      <h2 class="govuk-heading-l">Users of the Service</h2>
+      <h3 class="govuk-heading-m">Using our website</h3>
+      <p class="govuk-body">
+        Please read these Terms of Use (“General Terms”) carefully before using this Publish postgraduate teacher training courses (the “Service”).
+      </p>
+      <p class="govuk-body">
+        This Service is maintained for your personal use and viewing. Access and use by you of this Service constitutes your acceptance of these General Terms. This takes effect from the date on which you first use this website. If you do not agree to these terms, you must not use this website.
+      </p>
+      <p class="govuk-body">
+        If we change these General Terms we will post the revised document here with an updated effective date. If we make significant changes to these terms, we may notify you by other means such as sending an email or posting a notice on our home page.
+
+      </p>
+      <h3 class="govuk-heading-m">Information About Us</h3>
+      <p class="govuk-body">
+        This Service is operated by [the Department for Education] (“we”, “our”, or “us”). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
+      </p>
+      <p class="govuk-body">
+        You can contact us using the following email address: <a href="mailto:becomingateacher@digital.education.gov.uk" class="govuk-link">becomingateacher@digital.education.gov.uk</a>
+      </p>
+
+      <h3 class="govuk-heading-m">Access to the Service</h3>
+      <p class="govuk-body">
+        We will not be liable if for any reason the Service is unavailable at any time or for any period. From time to time, we may restrict access to all or some parts of the Service to users who have registered with us.
+      </p>
+      <p class="govuk-body">
+        If you choose, or are provided with, a user verification code, password or any other piece of information as part of our security procedures, you must treat such information as confidential, and you must not disclose it to any third party.
+      </p>
+      <p class="govuk-body">
+        We reserve the right to restrict or deny you access to all or some part of the Service if in our opinion you have failed to comply with these Terms and Conditions.
+      </p>
+      <p class="govuk-body">
+        The Department for Education withholds the right to withdraw without notice listings that breach these terms and to withdraw the access of users who breach them.
+      </p>
+
+      <h3 class="govuk-heading-m">Hyperlinking to the Publish postgraduate teacher training courses website</h3>
+      <p class="govuk-body">
+        We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The ‘Publish postgraduate teacher training courses’ pages must be displayed in the user's entire browser window.
+      </p>
+      <p class="govuk-body">
+        You may not charge your website's users to click on a link to any page on the Service.
+      </p>
+
+      <h3 class="govuk-heading-m">Third Party Content and Hyperlinking from the Service</h3>
+      <p class="govuk-body">
+        We are not liable or responsible for the third party content on the Service. Third party content includes, for example, material posted by other users of the Service and course listings.
+      </p>
+      <p class="govuk-body">
+        Where the Service contains links to other sites and resources, we are not liable or responsible for the content or reliability of those websites and resources and do not necessarily endorse the views expressed within them.
+      </p>
+      <p class="govuk-body">
+        We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.
+      </p>
+
+      <h3 class="govuk-heading-m">Virus protection</h3>
+      <p class="govuk-body">
+        We make every effort to check and test material at all stages of production. We do not guarantee our service will be secure or free from bugs or viruses. We cannot accept any responsibility for any loss, disruption or damage to your data or your computer system which may occur whilst using material derived from this website.
+      </p>
+      <p class="govuk-body">
+        We will report misuse, unauthorised access or other breaches of the Computer Misuse Act 1990 to the relevant law enforcement authorities and co-operate with them to determine your identity.
+      </p>
+
+      <h3 class="govuk-heading-m">Disclaimer and Liability</h3>
+      <p class="govuk-body">
+        The content of this Service includes both content created by us (included but not limited to content that helps you use the Service) and third-party content (included but not limited to course listings). We do not:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>endorse third-party content</li>
+        <li>vouch for its accuracy</li>
+        <li>guarantee that the views, instructions and/or assertions expressed in it are our own</li>
+      </ul>
+      <p class="govuk-body">
+        The content we create for the Service is not advice. You should verify any information on the Service yourself and use your own judgement before doing or not doing anything on the basis of the content.
+      </p>
+      <p class="govuk-body">
+        Unless expressly stated in writing by us, the Service and material relating to government information, products and services (or to third party information, products and services), is provided 'as is', without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.
+      </p>
+      <p class="govuk-body">
+        We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials.
+      </p>
+      <p class="govuk-body">In no event will we be liable for:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>any action you may take as a result of relying on any information/materials provided on the Service or for any loss or damage suffered by you as a result of you taking such action including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from or in connection with the use of the Service</li>
+        <li>any dealings you have with third parties (e.g. other users) that take place using or facilitated by the Service</li>
+      </ul>
+      <p class="govuk-body">
+        These terms and conditions shall be governed by and construed in accordance with the laws of England and Wales. Any dispute arising under these terms and conditions shall be subject to the exclusive jurisdiction of the courts of England and Wales.
+      </p>
+      <h3 class="govuk-heading-m">
+        Validity of these General Terms
+      </h3>
+      <p class="govuk-body">
+        If any of these terms and conditions are held to be invalid, unenforceable or illegal for any reason, the remaining terms and conditions will still apply.
+      </p>
+      <h3 class="govuk-heading-m">
+        Applicable Law and Jurisdiction
+      </h3>
+      <p class="govuk-body">
+        These General Terms are governed by the laws of England and Wales. Any dispute arising under these General Terms will be subject to the exclusive jurisdiction of the courts of England and Wales.
+      </p>
+      <h3 class="govuk-heading-m">
+        Using the Service
+      </h3>
+      <p class="govuk-body">
+        Access and use by you of this Service constitutes your acceptance of these Terms and Conditions. This takes effect from the date on which you first use this website. If you do not agree to these terms, you must not use this website.
+      </p><p class="govuk-body">
+        By using Publish postgraduate teacher training courses you agree to abide by the following terms and conditions.
+      </p>
+      <h3 class="govuk-heading-m">
+        Unacceptable Use
+      </h3>
+      <p class="govuk-body">
+        You must not publish:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          listings for postgraduate teacher training courses that aren’t relevant to the service, such as but not limited to non-teacher training courses, undergraduate courses, non-primary and secondary courses and non-English courses
+        </li>
+        <li>
+          listings for unconfirmed or non-existent courses
+        </li>
+        <li>
+          offensive or inappropriate language, including but not limited to profanities or language pejorative of any group, such as racist, sexist or homophobic comments
+        </li>
+        <li>
+          discriminatory content: you must not state or imply in a course listing that you will discriminate against anyone (subject to certain exceptions under the Equality Act 2010 particularly those applying to schools with a religious character); for further information see GOV.UK’s guidance on employment discrimination
+        </li>
+        <li>
+          material that infringes any intellectual property rights, such as copyright and trademarks (this means generally that you must own the rights in everything you submit or must obtain permission from the rights owner to submit the material)
+        </li>
+        <li>
+          material that is technically harmful (including, without limitation, computer viruses, logic bombs, Trojan horses, worms, harmful components, corrupted data or other malicious software or harmful data)
+        </li>
+        <li>
+          material that encourages or teaches conduct that is a criminal offence, gives rise to civil liability, or is otherwise unlawful
+        </li>
+      </ul>
+      <h3 class="govuk-heading-m">
+        Listing Data
+      </h3>
+      <p class="govuk-body">
+        Data ownership: training providers and schools have sole responsibility for maintaining the accuracy and appropriateness of the data contained in their listings.
+      </p>
+    </div>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
   get "/pages/:page", to: "pages#show"
+
+  get "/cookies", to: "pages#cookies", as: :cookies
+  get "/terms-conditions", to: "pages#terms", as: :terms
+  get "/privacy-policy", to: "pages#privacy", as: :privacy
 end


### PR DESCRIPTION
### Context
SEO and legal pages

### Changes proposed in this pull request
- Add page title
- Create legal pages (cookies, privacy, terms) taken from manage-courses-ui
- Remove copyright content from footer
- Add service title into header
- Ensure crown links to gov.uk

### Guidance to review
- View `/terms-conditions`, `/cookies`, `/privacy-policy`
