### PR TITLE
Extend default rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,12 +29,12 @@ gem 'omniauth', '~> 1.8'
 gem 'omniauth_openid_connect', '~> 0.1'
 
 # App Insights for Azure
-gem 'pkg-config', '~> 1.3.4'
 gem 'application_insights'
+gem 'pkg-config', '~> 1.3.4'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
 
   # GOV.UK interpretation of rubocop for linting Ruby
   gem 'govuk-lint'
@@ -50,8 +50,8 @@ end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'web-console', '>= 3.3.0'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
@@ -71,4 +71,4 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/README.md
+++ b/README.md
@@ -27,10 +27,24 @@ docker-compose up --build
 
 *Warning*: Running docker seems to slow down local development significantly on macOS.
 
+## Running specs and linter (SCSS and Ruby)
+```
+bundle exec rake
+```
+
+## Running specs
+```
+bundle exec rspec
+```
+
 ## Linting
 
 It's best to lint just your app directories and not those belonging to the framework, e.g.
 
 ```bash
-bundle exec govuk-lint-ruby app config db lib spec --format clang
+bundle exec govuk-lint-ruby app config db lib spec Gemfile --format clang -a
+
+or
+
+bundle exec govuk-lint-sass app/webpacker/styles
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,7 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
+
+task lint_ruby: ['lint:ruby']
+task lint_scss: ['lint:scss']
+task default: %i[spec lint_ruby lint_scss]

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -1,0 +1,12 @@
+desc "Lint ruby code"
+namespace :lint do
+  task :ruby do
+    puts 'Linting ruby...'
+    system 'bundle exec govuk-lint-ruby app config db lib spec Gemfile --format clang -a'
+  end
+
+  task :scss do
+    puts 'Linting scss...'
+    system 'bundle exec govuk-lint-sass app/webpacker/stylesheets'
+  end
+end


### PR DESCRIPTION
### Context
We often forget to lint our code before raising a PR (which causing a build failure) so if we get into the habit of running `rake` then you know the code(pending review) is good to go 👌 

### Changes proposed in this pull request
- Override `rake` to run the specs and linters (ruby and scss)

### Guidance to review
```
bundle exec rake
```