### PR TITLE
Add failOnStderr property to linting task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,37 +10,67 @@ pool:
   vmImage: 'Ubuntu-16.04'
 
 variables:
-  imageName: 'manage-courses-frontend-poc'
+  IMAGE_NAME: 'manage-courses-frontend-poc'
 
 steps:
 - script: |
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
-    tag=$(dockerHubUsername)/$(imageName):$GIT_SHORT_SHA
+    IMAGE_NAME_WITH_TAG=$(IMAGE_NAME):GIT_SHORT_SHA
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
-    echo "##vso[task.setvariable variable=tag;]$tag"
+    echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG;]$IMAGE_NAME_WITH_TAG"
   displayName: 'Set version number'
 
-- bash: |
-    bash docker-build-az.sh
-  displayName: 'Build image'
-  env:
-    password: $(dockerHubPassword)
-
-- task: CopyFiles@2
-  displayName: 'Copy Files to: $(build.artifactstagingdirectory)'
+- task: Docker@1
+  displayName: Build image
   inputs:
-    Contents: |
-     azure/**
-    TargetFolder: '$(build.artifactstagingdirectory)'
-    OverWrite: true
+    command: Build an image
+    imageName: $(IMAGE_NAME)
+    dockerFile: Dockerfile
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact'
+- task: Docker@1
+  displayName: Run webpack
   inputs:
-    PathtoPublish: '$(build.artifactstagingdirectory)'
+    command: Run an image
+    imageName: $(IMAGE_NAME)
+    containerCommand: rails webpacker:compile
 
-- task: PublishTestResults@2
-  condition: succeededOrFailed()
+- task: Docker@1
+  displayName: Run tests
   inputs:
-    testRunner: JUnit
-    testResultsFiles: '*.xml'
+    command: Run an image
+    imageName: $(IMAGE_NAME)
+    containerCommand: rails spec SPEC_OPTS='--format RspecJunitFormatter' | sed -e 1d >> rspec-results.xml ; test "${PIPESTATUS[0]}" -eq 0
+
+- task: Docker@1
+  displayName: Run ruby linter
+  inputs:
+    command: Run an image
+    imageName: $(IMAGE_NAME)
+    containerCommand: govuk-lint-ruby app config db lib spec --format clang
+
+- task: Docker@1
+  displayName: Run sass linter
+  inputs:
+    command: Run an image
+    imageName: $(IMAGE_NAME)
+    containerCommand: govuk-lint-sass app/webpacker/stylesheets
+
+- task: Docker@1
+  displayName: Tag image with current build number $(Build.BuildNumber)
+  inputs:
+    command: Tag image
+    imageName: $(IMAGE_NAME)
+    arguments: $(IMAGE_NAME_WITH_TAG)
+
+- task: Docker@1
+  displayName: Docker Hub login
+  inputs:
+    command: "login"
+    containerregistrytype: Container Registry
+    dockerRegistryEndpoint: DfE Docker Hub
+
+- task: Docker@1
+  displayName: Push tagged image
+  inputs:
+    command: Push an image
+    imageName: $(IMAGE_NAME_WITH_TAG)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,7 @@ steps:
     docker run "$(tag)" /bin/sh -c "govuk-lint-ruby app config db lib spec --format clang"
     docker run "$(tag)" /bin/sh -c "govuk-lint-sass app/webpacker/stylesheets"
   displayName: 'Execute linters'
+  failOnStderr: true
 
 - script: |
     echo $password | docker login --username $(dockerHubUsername) --password-stdin

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ steps:
     containerCommand: rails webpacker:compile
     runInBackground: false
 
-- bash: docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS=--format RspecJunitFormatter | sed -e 1d >> rspec-results.xml ; test ${PIPESTATUS[0]} -eq 0
+- bash: docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter' | sed -e 1d >> rspec-results.xml ; test ${PIPESTATUS[0]} -eq 0
   displayName: 'Run tests'
   failOnStderr: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,28 +20,9 @@ steps:
     echo "##vso[task.setvariable variable=tag;]$tag"
   displayName: 'Set version number'
 
-- script: |
-    docker build -f Dockerfile -t $(tag) .
-  displayName: 'Build image'
-
-- script: |
-    docker run "$(tag)" /bin/sh -c "rails webpacker:compile"
-  displayName: 'Execute webpack'
-
-- script: |
-    docker run "$(tag)" /bin/sh -c 'rails spec SPEC_OPTS="--format RspecJunitFormatter"' | sed -e 1d >> rspec-results.xml
-  displayName: 'Execute tests'
-
 - bash: |
-    docker run "$(tag)" /bin/sh -c "govuk-lint-ruby app config db lib spec --format clang"
-    docker run "$(tag)" /bin/sh -c "govuk-lint-sass app/webpacker/stylesheets"
-  displayName: 'Execute linters'
-  failOnStderr: true
-
-- script: |
-    echo $password | docker login --username $(dockerHubUsername) --password-stdin
-    docker push "$(tag)"
-  displayName: 'Push image'
+    bash docker-build-az.sh
+  displayName: 'Build image'
   env:
     password: $(dockerHubPassword)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,3 +75,22 @@ steps:
   inputs:
     command: Push an image
     imageName: $(IMAGE_NAME_WITH_TAG)
+
+- task: CopyFiles@2
+  displayName: 'Copy Files to: $(build.artifactstagingdirectory)'
+  inputs:
+    Contents: |
+     azure/**
+    TargetFolder: '$(build.artifactstagingdirectory)'
+    OverWrite: true
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact'
+  inputs:
+    PathtoPublish: '$(build.artifactstagingdirectory)'
+
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testRunner: JUnit
+    testResultsFiles: '*.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pool:
   vmImage: 'Ubuntu-16.04'
 
 variables:
-  IMAGE_NAME: 'manage-courses-frontend-poc'
+  IMAGE_NAME: '$(dockerHubUserName)/manage-courses-frontend-poc'
 
 steps:
 - script: |
@@ -36,13 +36,9 @@ steps:
     containerCommand: rails webpacker:compile
     runInBackground: false
 
-- task: Docker@1
-  displayName: Run tests
-  inputs:
-    command: Run an image
-    imageName: $(IMAGE_NAME)
-    containerCommand: rails spec SPEC_OPTS="--format RspecJunitFormatter" | sed -e 1d >> rspec-results.xml ; test "${PIPESTATUS[0]}" -eq 0
-    runInBackground: false
+- bash: docker run --rm manage-courses-frontend-poc rails spec SPEC_OPTS=--format RspecJunitFormatter | sed -e 1d >> rspec-results.xml ; test ${PIPESTATUS[0]} -eq 0
+  displayName: 'Run tests'
+  failOnStderr: true
 
 - task: Docker@1
   displayName: Run ruby linter

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,7 @@ steps:
     command: Build an image
     imageName: $(IMAGE_NAME)
     dockerFile: Dockerfile
+    addDefaultLabels: false
 
 - task: Docker@1
   displayName: Run webpack

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ steps:
     containerCommand: rails webpacker:compile
     runInBackground: false
 
-- bash: docker run --rm manage-courses-frontend-poc rails spec SPEC_OPTS=--format RspecJunitFormatter | sed -e 1d >> rspec-results.xml ; test ${PIPESTATUS[0]} -eq 0
+- bash: docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS=--format RspecJunitFormatter | sed -e 1d >> rspec-results.xml ; test ${PIPESTATUS[0]} -eq 0
   displayName: 'Run tests'
   failOnStderr: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ steps:
   inputs:
     command: Run an image
     imageName: $(IMAGE_NAME)
-    containerCommand: rails spec SPEC_OPTS='--format RspecJunitFormatter'
+    containerCommand: rails spec SPEC_OPTS="--format RspecJunitFormatter"
     runInBackground: false
 
 - task: Docker@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ steps:
   inputs:
     command: Run an image
     imageName: $(IMAGE_NAME)
-    containerCommand: rails spec SPEC_OPTS="--format RspecJunitFormatter"
+    containerCommand: rails spec SPEC_OPTS="--format RspecJunitFormatter" | sed -e 1d >> rspec-results.xml ; test "${PIPESTATUS[0]}" -eq 0
     runInBackground: false
 
 - task: Docker@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,7 @@ steps:
     containerCommand: rails webpacker:compile
     runInBackground: false
 
+# Run a custom bash task for tests so we can redirect test output to rspec-results.xml and capture the exit code from the docker run command
 - bash: docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter' | sed -e 1d >> rspec-results.xml ; test ${PIPESTATUS[0]} -eq 0
   displayName: 'Run tests'
   failOnStderr: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ steps:
   inputs:
     command: Run an image
     imageName: $(IMAGE_NAME)
-    containerCommand: rails spec SPEC_OPTS='--format RspecJunitFormatter' | sed -e 1d >> rspec-results.xml ; test "${PIPESTATUS[0]}" -eq 0
+    containerCommand: rails spec SPEC_OPTS='--format RspecJunitFormatter'
     runInBackground: false
 
 - task: Docker@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ steps:
     docker run "$(tag)" /bin/sh -c 'rails spec SPEC_OPTS="--format RspecJunitFormatter"' | sed -e 1d >> rspec-results.xml
   displayName: 'Execute tests'
 
-- script: |
+- bash: |
     docker run "$(tag)" /bin/sh -c "govuk-lint-ruby app config db lib spec --format clang"
     docker run "$(tag)" /bin/sh -c "govuk-lint-sass app/webpacker/stylesheets"
   displayName: 'Execute linters'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ variables:
 steps:
 - script: |
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
-    IMAGE_NAME_WITH_TAG=$(IMAGE_NAME):GIT_SHORT_SHA
+    IMAGE_NAME_WITH_TAG=$(IMAGE_NAME):$GIT_SHORT_SHA
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG;]$IMAGE_NAME_WITH_TAG"
   displayName: 'Set version number'
@@ -33,6 +33,7 @@ steps:
     command: Run an image
     imageName: $(IMAGE_NAME)
     containerCommand: rails webpacker:compile
+    runInBackground: false
 
 - task: Docker@1
   displayName: Run tests
@@ -40,6 +41,7 @@ steps:
     command: Run an image
     imageName: $(IMAGE_NAME)
     containerCommand: rails spec SPEC_OPTS='--format RspecJunitFormatter' | sed -e 1d >> rspec-results.xml ; test "${PIPESTATUS[0]}" -eq 0
+    runInBackground: false
 
 - task: Docker@1
   displayName: Run ruby linter
@@ -47,6 +49,7 @@ steps:
     command: Run an image
     imageName: $(IMAGE_NAME)
     containerCommand: govuk-lint-ruby app config db lib spec --format clang
+    runInBackground: false
 
 - task: Docker@1
   displayName: Run sass linter
@@ -54,6 +57,7 @@ steps:
     command: Run an image
     imageName: $(IMAGE_NAME)
     containerCommand: govuk-lint-sass app/webpacker/stylesheets
+    runInBackground: false
 
 - task: Docker@1
   displayName: Tag image with current build number $(Build.BuildNumber)

--- a/docker-build-az.sh
+++ b/docker-build-az.sh
@@ -1,29 +1,30 @@
 #!/bin/bash
+# Build, test and push a custom docker image
 set -e
 
-# DEBUG: print env
+if [ $SYSTEM_DEBUG="true" ];
+then
+  env
+fi
 
-env
-
-# Set up script vars
 DOCKER_IMAGE_TAG=$TAG
-DOCKER_RUN="docker run $DOCKER_IMAGE_TAG /bin/sh -c"
 DOCKER_HUB_USERNAME=$DOCKERHUBUSERNAME
 DOCKER_HUB_PASSWORD=$password
+DOCKER_RUN="docker run $DOCKER_IMAGE_TAG /bin/sh -c"
 
 echo "Building image: $DOCKER_IMAGE_TAG"
 docker build -f Dockerfile -t $DOCKER_IMAGE_TAG .
 
-echo "Run webpacker"
+echo "Run webpack"
 $DOCKER_RUN "rails webpacker:compile"
 
 echo "Run tests"
-$DOCKER_RUN 'rails spec SPEC_OPTS="--format RspecJunitFormatter"' | sed -e 1d >> rspec-results.xml
+$DOCKER_RUN "rails spec SPEC_OPTS='--format RspecJunitFormatter'" | sed -e 1d >> rspec-results.xml
 
 echo "Run linters"
 $DOCKER_RUN "govuk-lint-ruby app config db lib spec --format clang"
 $DOCKER_RUN "govuk-lint-sass app/webpacker/stylesheets"
 
-echo "Pushing image"
+echo "Push image"
 echo $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME --password-stdin
 docker push $DOCKER_IMAGE_TAG

--- a/docker-build-az.sh
+++ b/docker-build-az.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Set up script vars
+DOCKER_IMAGE_TAG=$tag
+DOCKER_RUN="docker run $DOCKER_IMAGE_TAG /bin/sh -c"
+DOCKER_HUB_USERNAME=$dockerHubUsername
+DOCKER_HUB_PASSWORD=$password
+
+echo "Building image: $DOCKER_IMAGE_TAG"
+docker build -f Dockerfile -t $DOCKER_IMAGE_TAG .
+
+echo "Run webpacker"
+$DOCKER_RUN "rails webpacker:compile"
+
+echo "Run tests"
+$DOCKER_RUN 'rails spec SPEC_OPTS="--format RspecJunitFormatter"' | sed -e 1d >> rspec-results.xml
+
+echo "Run linters"
+$DOCKER_RUN "govuk-lint-sass app/webpacker/stylesheets"
+$DOCKER_RUN "govuk-lint-ruby app config db lib spec --format clang"
+
+echo "Pushing image"
+echo $password | docker login --username $DOCKER_HUB_USERNAME --password-stdin
+docker push $DOCKER_IMAGE_TAG

--- a/docker-build-az.sh
+++ b/docker-build-az.sh
@@ -6,9 +6,9 @@ set -e
 env
 
 # Set up script vars
-DOCKER_IMAGE_TAG=$tag
+DOCKER_IMAGE_TAG=$TAG
 DOCKER_RUN="docker run $DOCKER_IMAGE_TAG /bin/sh -c"
-DOCKER_HUB_USERNAME=$dockerHubUsername
+DOCKER_HUB_USERNAME=$DOCKERHUBUSERNAME
 DOCKER_HUB_PASSWORD=$password
 
 echo "Building image: $DOCKER_IMAGE_TAG"
@@ -21,9 +21,9 @@ echo "Run tests"
 $DOCKER_RUN 'rails spec SPEC_OPTS="--format RspecJunitFormatter"' | sed -e 1d >> rspec-results.xml
 
 echo "Run linters"
-$DOCKER_RUN "govuk-lint-sass app/webpacker/stylesheets"
+$DOCKER_RUN "govuk-lint-sass app/webpacker/stylesheets"s
 $DOCKER_RUN "govuk-lint-ruby app config db lib spec --format clang"
 
 echo "Pushing image"
-echo $password | docker login --username $DOCKER_HUB_USERNAME --password-stdin
+echo $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME --password-stdin
 docker push $DOCKER_IMAGE_TAG

--- a/docker-build-az.sh
+++ b/docker-build-az.sh
@@ -21,8 +21,8 @@ echo "Run tests"
 $DOCKER_RUN 'rails spec SPEC_OPTS="--format RspecJunitFormatter"' | sed -e 1d >> rspec-results.xml
 
 echo "Run linters"
-$DOCKER_RUN "govuk-lint-sass app/webpacker/stylesheets"s
 $DOCKER_RUN "govuk-lint-ruby app config db lib spec --format clang"
+$DOCKER_RUN "govuk-lint-sass app/webpacker/stylesheets"
 
 echo "Pushing image"
 echo $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME --password-stdin

--- a/docker-build-az.sh
+++ b/docker-build-az.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# DEBUG: print env
+
+env
+
 # Set up script vars
 DOCKER_IMAGE_TAG=$tag
 DOCKER_RUN="docker run $DOCKER_IMAGE_TAG /bin/sh -c"

--- a/docker-build-az.sh
+++ b/docker-build-az.sh
@@ -2,7 +2,7 @@
 # Build, test and push a custom docker image
 set -e
 
-if [ $SYSTEM_DEBUG="true" ];
+if [ "$SYSTEM_DEBUG" = 'true' ];
 then
   env
 fi
@@ -13,18 +13,18 @@ DOCKER_HUB_PASSWORD=$password
 DOCKER_RUN="docker run $DOCKER_IMAGE_TAG /bin/sh -c"
 
 echo "Building image: $DOCKER_IMAGE_TAG"
-docker build -f Dockerfile -t $DOCKER_IMAGE_TAG .
+docker build -f Dockerfile -t "$DOCKER_IMAGE_TAG" .
 
 echo "Run webpack"
 $DOCKER_RUN "rails webpacker:compile"
 
 echo "Run tests"
-$DOCKER_RUN "rails spec SPEC_OPTS='--format RspecJunitFormatter'" | sed -e 1d >> rspec-results.xml
+$DOCKER_RUN "rails spec SPEC_OPTS='--format RspecJunitFormatter'" | sed -e 1d >> rspec-results.xml ; test "${PIPESTATUS[0]}" -eq 0
 
 echo "Run linters"
 $DOCKER_RUN "govuk-lint-ruby app config db lib spec --format clang"
 $DOCKER_RUN "govuk-lint-sass app/webpacker/stylesheets"
 
 echo "Push image"
-echo $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME --password-stdin
-docker push $DOCKER_IMAGE_TAG
+echo "$DOCKER_HUB_PASSWORD" | docker login --username "$DOCKER_HUB_USERNAME" --password-stdin
+docker push "$DOCKER_IMAGE_TAG"

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -5,6 +5,6 @@ RSpec.feature 'Sign in', type: :feature do
     stub_omniauth
     visit root_path
     # Redirect to DfE Signin and come back
-    expect(page).to have_content("Sign out (TEST Smith)")
+    expect(page).to have_content("Sign out (TEST Smith)" )
   end
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -5,6 +5,6 @@ RSpec.feature 'Sign in', type: :feature do
     stub_omniauth
     visit root_path
     # Redirect to DfE Signin and come back
-    expect(page).to have_content("Sign out (John Smith)")
+    expect(page).to have_content("Sign out (John Smith)" )
   end
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -5,6 +5,6 @@ RSpec.feature 'Sign in', type: :feature do
     stub_omniauth
     visit root_path
     # Redirect to DfE Signin and come back
-    expect(page).to have_content("Sign out (TEST Smith)" )
+    expect(page).to have_content("Sign out (John Smith)" )
   end
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -5,6 +5,6 @@ RSpec.feature 'Sign in', type: :feature do
     stub_omniauth
     visit root_path
     # Redirect to DfE Signin and come back
-    expect(page).to have_content("Sign out (John Smith)")
+    expect(page).to have_content("Sign out (TEST Smith)")
   end
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -5,6 +5,6 @@ RSpec.feature 'Sign in', type: :feature do
     stub_omniauth
     visit root_path
     # Redirect to DfE Signin and come back
-    expect(page).to have_content("Sign out (John Smith)" )
+    expect(page).to have_content("Sign out (John Smith)")
   end
 end


### PR DESCRIPTION
### Context
@defong pointed out that even though linters were failing the build was still passing.

This PR adds failOnStderr to the linting task so that the build will fail in the correct place

### Changes proposed in this pull request
Add failOnStderr propert to linting task

### Guidance to review
Does this fail builds as expected?
