### PR TITLE
[1067] Amended the session to expire in 5 minutes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,8 @@ module ManageCoursesFrontend
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
-    config.session_store :cookie_store, key: '_publish_teacher_training_courses_session'
+    config.session_store :cookie_store,
+                          key: '_publish_teacher_training_courses_session',
+                          expire_after: 5.minutes
   end
 end


### PR DESCRIPTION
### Context
Previous default was when user close the browser

### Changes proposed in this pull request
Amended the session to expire in 5 minutes

### Guidance to review
Sign in stay inactivity for 5+ minutes then traverse the site
When traversing the site browser first go to sign in and sign in via `openconnect` seamlessly.

After a period of time has elapse the user will not sign in via `openconnect` seamlessly, instead they will need to reenter their credentials.
