### PR TITLE
[1108] Handle unknown users

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,10 +8,14 @@ class SessionsController < ApplicationController
 
     add_token_to_connection
 
-    user = Session.create(first_name: current_user_info[:first_name], last_name: current_user_info[:last_name])
-    session[:auth_user][:user_id] = user.id
+    begin
+      user = Session.create(first_name: current_user_info[:first_name], last_name: current_user_info[:last_name])
+      session[:auth_user][:user_id] = user.id
 
-    redirect_to root_path
+      redirect_to root_path
+    rescue JsonApiClient::Errors::NotAuthorized
+      redirect_to Settings.manage_ui.base_url
+    end
   end
 
   def signout

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -16,31 +16,53 @@ RSpec.describe SessionsController, type: :controller do
   end
 
   describe "GET create" do
-    user_info = {
-      "first_name" => "John",
-      "last_name" => "Smith",
-      "email" => "email@example.com"
+    let(:user_info) {
+      {
+        first_name: "John",
+        last_name: "Smith",
+        email: "email@example.com",
+      }
     }
+    let(:user_id) { 101 }
 
-    user_id = 101
-    before do
-      allow(Session).to receive(:create)
-        .with(first_name: user_info[:first_name], last_name: user_info[:last_name])
-        .and_return(double(id: user_id))
-      allow(Base).to receive(:connection)
+    context "if session creation succeeds" do
+      before do
+        allow(Session).to receive(:create)
+          .with(first_name: user_info[:first_name], last_name: user_info[:last_name])
+          .and_return(double(id: user_id))
+        allow(Base).to receive(:connection)
+      end
+
+      it "creates the session and redirects to root" do
+        @request.env["omniauth.auth"] = {
+          "info" => user_info
+        }
+
+        get :create
+
+        expect(subject).to redirect_to("/")
+        expect(@request.session[:auth_user][:user_id]).to eq user_id
+        expect(@request.session[:auth_user]["info"]).to eq user_info
+        expect(Base).to have_received(:connection)
+      end
     end
 
-    it "creates the session and redirects to root" do
-      @request.env["omniauth.auth"] = {
-        "info" => user_info
-      }
+    context "if session creation fails" do
+      before do
+        allow(Session).to receive(:create)
+          .and_raise(JsonApiClient::Errors::NotAuthorized, "not authorised")
+        allow(Base).to receive(:connection)
+      end
 
-      get :create
+      it "redirects to Manage UI root" do
+        @request.env["omniauth.auth"] = {
+          "info" => user_info
+        }
 
-      expect(subject).to redirect_to("/")
-      expect(@request.session[:auth_user][:user_id]).to eq user_id
-      expect(@request.session[:auth_user]["info"]).to eq user_info
-      expect(Base).to have_received(:connection)
+        get :create
+
+        expect(subject).to redirect_to(Settings.manage_ui.base_url)
+      end
     end
   end
 


### PR DESCRIPTION
### Context
It's possible for an existing DfE Sign-in user to try accessing Publish, but they're not a known user in the Manage Courses database.

### Changes proposed in this pull request
This is a temporary stop-gap which redirects unknown users to Manage Courses UI.
Manage Courses UI then shows a "we don't know who you are" page to those users.

### Guidance to review
I paired with @defong on this.
