### PR TITLE
[1112] extend session timeout to 6 hours

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,6 @@ module ManageCoursesFrontend
 
     config.session_store :cookie_store,
                           key: '_publish_teacher_training_courses_session',
-                          expire_after: 5.minutes
+                          expire_after: 6.hours
   end
 end


### PR DESCRIPTION
We tried 5 minutes to see how sign-in would behave but ran afoul of it's ~20-30
minute session expiry. We need to implement access token renewal with the
refresh token, but until we do that (hopefully before go-live) we'll extend the
session to 6 hours here.
