### PR TITLE
Refactor pages spec

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,9 @@
 class PagesController < ApplicationController
   before_action :authenticate
 
-  def show
-    render template: "pages/#{params[:page]}"
-  end
+  def cookies; end
+
+  def terms; end
+
+  def privacy; end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,6 @@ Rails.application.routes.draw do
 
   resources :providers, path: 'organisations'
 
-  get "/pages/:page", to: "pages#show"
-
   get "/cookies", to: "pages#cookies", as: :cookies
   get "/terms-conditions", to: "pages#terms", as: :terms
   get "/privacy-policy", to: "pages#privacy", as: :privacy

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Sign in', type: :feature do
   scenario 'using DfE Sign-in' do
-    stub_omniauth
+    stub_omniauth(disable_completely: false)
     stub_session_create
     stub_backend_api
 

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -1,13 +1,27 @@
 require 'rails_helper'
 
 RSpec.feature 'View pages', type: :feature do
-  scenario "Navigate to home" do
+  scenario "Navigate to /cookies" do
     stub_omniauth
     stub_session_create
-    stub_backend_api
 
-    visit "/pages/home"
-    # Redirect to DfE Signin and come back
-    expect(page).to have_text("Sign out (John Smith)")
+    visit "/cookies"
+    expect(find('h1')).to have_content('Cookies')
+  end
+
+  scenario "Navigate to /terms-conditions" do
+    stub_omniauth
+    stub_session_create
+
+    visit "/terms-conditions"
+    expect(find('h1')).to have_content('Terms and Conditions')
+  end
+
+  scenario "Navigate to /privacy-policy" do
+    stub_omniauth
+    stub_session_create
+
+    visit "/privacy-policy"
+    expect(find('h1')).to have_content('Privacy policy')
   end
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,5 +1,5 @@
 module FeatureHelpers
-  def stub_omniauth
+  def stub_omniauth(disable_completely: true)
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:dfe] = {
       provider: "dfe",
@@ -13,6 +13,11 @@ module FeatureHelpers
         token_id: "123"
       }
     }
+
+    # Temp solution until we implement `return_url` for DfE sign-in
+    if disable_completely
+      allow_any_instance_of(ApplicationController).to receive(:authenticate)
+    end
   end
 
   def stub_session_create


### PR DESCRIPTION
### Context
`pages#show` was from the boilerplate, we don't need that

### Changes proposed in this pull request
- Be explicit with our controller actions to ensure they match our routes
- Add specs for all `pages`
- Add temp override for authentication because we always redirect to root after success which needs updating at a later date
