### PR TITLE
[1108] Rebuild the connection when adding session token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,7 +43,7 @@ private
                           Settings.authentication.algorithm)
     end
 
-    Base.connection do |connection|
+    Base.connection(true) do |connection|
       connection.use FaradayMiddleware::OAuth2, token, token_type: :bearer
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SessionsController, type: :controller do
         expect(subject).to redirect_to("/")
         expect(@request.session[:auth_user][:user_id]).to eq user_id
         expect(@request.session[:auth_user]["info"]).to eq user_info
-        expect(Base).to have_received(:connection)
+        expect(Base).to have_received(:connection).with(true)
       end
     end
 


### PR DESCRIPTION
Without the `(true)` parameter, Base.connection will re-use the same instance of the connection class between connections. If multiple users are hitting the app simultaneously, this can cause re-use of tokens among them and undesirable behaviours.