### PR TITLE
[1139] Redirect to manage-courses-ui when providers list is empty

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, except: :not_found
-  rescue_from JsonApiClient::Errors::NotAuthorized, with: :render_not_authorised
+  rescue_from JsonApiClient::Errors::NotAuthorized, with: :render_manage_ui
 
   def not_found
     respond_to do |format|
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def render_not_authorised
+  def render_manage_ui
     redirect_to Settings.manage_ui.base_url
   end
 

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -3,6 +3,7 @@ class ProvidersController < ApplicationController
 
   def index
     @providers = Provider.all
+    render_manage_ui if @providers.empty?
   end
 
   def show

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ProvidersController, type: :controller do
+  context "with authenticated user" do
+    before do
+      stub_omniauth
+      stub_session_create
+    end
+
+    describe 'GET #index' do
+      context 'with providers' do
+        before do
+          stub_api_v2_request('/providers', 'providers.json')
+        end
+
+        it 'returns the index page' do
+          get :index
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      fcontext 'without any providers' do
+        before do
+          stub_api_v2_request('/providers', 'providers-empty.json')
+        end
+
+        it 'redirects to manage-courses-ui' do
+          get :index
+          expect(response).to redirect_to(Settings.manage_ui.base_url)
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/providers-empty.json
+++ b/spec/fixtures/providers-empty.json
@@ -1,0 +1,6 @@
+{
+  "data": [],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,4 +1,4 @@
-module FeatureHelpers
+module Helpers
   def stub_omniauth(disable_completely: true)
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:dfe] = {
@@ -38,5 +38,6 @@ module FeatureHelpers
 end
 
 RSpec.configure do |config|
-  config.include FeatureHelpers, type: :feature
+  config.include Helpers, type: :feature
+  config.include Helpers, type: :controller
 end


### PR DESCRIPTION
Users should be redirected to the "We don’t know which organisation you’re part of" page in manage-courses-ui when the providers list is empty.