### PR TITLE
[1146] Redirect to organisations#show page when there is 1 provider

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -4,9 +4,11 @@ class ProvidersController < ApplicationController
   def index
     @providers = Provider.all
     render_manage_ui if @providers.empty?
+    redirect_to provider_path(@providers.first.institution_code) if @providers.size == 1
   end
 
   def show
+    @has_multiple_providers = Provider.all.size > 1
     @provider = Provider.find(params[:code]).first.attributes
   end
 end

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -1,15 +1,17 @@
 <%= content_for :page_title, @provider[:institution_name] %>
 
-<nav class="govuk-breadcrumbs">
-  <ol class="govuk-breadcrumbs__list">
-    <li class="govuk-breadcrumbs__list-item">
-      <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
-    </li>
-    <li class="govuk-breadcrumbs__list-item" aria-current="page">
-      <%= @provider[:institution_name] %>
-    </li>
-  </ol>
-</nav>
+<% if @has_multiple_providers then %>
+  <nav class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <%= @provider[:institution_name] %>
+      </li>
+    </ol>
+  </nav>
+<% end %>
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProvidersController, type: :controller do
     end
 
     describe 'GET #index' do
-      context 'with providers' do
+      context 'with 2 or more providers' do
         before do
           stub_api_v2_request('/providers', build(:providers_response))
         end
@@ -19,7 +19,20 @@ RSpec.describe ProvidersController, type: :controller do
         end
       end
 
-      context 'without any providers' do
+      context 'with 1 provider' do
+        let(:the_provider) { build(:provider) }
+
+        before do
+          stub_api_v2_request('/providers', build(:providers_response, data: [the_provider]))
+        end
+
+        it 'returns the show page' do
+          get :index
+          expect(response).to redirect_to(action: :show, code: the_provider["attributes"][:institution_code])
+        end
+      end
+
+      context 'with 0 providers' do
         before do
           stub_api_v2_request('/providers', build(:providers_response, data: []))
         end

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -14,9 +14,11 @@ RSpec.feature 'View providers', type: :feature do
   scenario 'Navigate to /organisations/AO' do
     stub_omniauth
     stub_session_create
+    stub_api_v2_request('/providers', build(:providers_response, data: [build(:provider, institution_code: "A0")]))
     stub_api_v2_request('/providers/A0', build(:providers_response, data: [build(:provider, institution_code: "A0")]))
 
     visit('/organisations/A0')
     expect(find('h1')).to have_content('ACME SCITT A0')
+    expect(page).not_to have_selector(".govuk-breadcrumbs")
   end
 end


### PR DESCRIPTION
### Context

Redirects the index action if there's only one provider.

The breadcrumbs are also hidden because they are not useful in this scenario. This is done by querying the full Providers endpoint for the full list, which is a bit annoying/slow, but can be changed in the future if necessary.