### PR TITLE
[1165] Redirect to manage-courses-ui when API returns 403

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, except: :not_found
   rescue_from JsonApiClient::Errors::NotAuthorized, with: :render_manage_ui
+  rescue_from JsonApiClient::Errors::AccessDenied, with: :render_manage_ui
 
   def not_found
     respond_to do |format|

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -64,6 +64,24 @@ RSpec.describe SessionsController, type: :controller do
         expect(subject).to redirect_to(Settings.manage_ui.base_url)
       end
     end
+
+    context "if user has not accepted terms and conditions" do
+      before do
+        allow(Session).to receive(:create)
+          .and_raise(JsonApiClient::Errors::AccessDenied, "forbidden")
+        allow(Base).to receive(:connection)
+      end
+
+      it "redirects to Manage UI root" do
+        @request.env["omniauth.auth"] = {
+          "info" => user_info
+        }
+
+        get :create
+
+        expect(subject).to redirect_to(Settings.manage_ui.base_url)
+      end
+    end
   end
 
   describe "GET destroy" do


### PR DESCRIPTION
### Context

When a new user logs into the service, they should be asked to tick the terms and conditions if they haven't done so already.