### PR TITLE
[1194] Add provider count cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ config/localhost/https/localhost.crt
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+*.log

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
     if current_user
       add_token_to_connection
 
-      set_user_session if current_user[:user_id].blank?
+      set_user_session if current_user['user_id'].blank?
     else
       redirect_to '/signin'
     end
@@ -39,7 +39,7 @@ private
 
   def set_user_session
     user = Session.create(first_name: current_user_info[:first_name], last_name: current_user_info[:last_name])
-    session[:auth_user][:user_id] = user.id
+    session[:auth_user]['user_id'] = user.id
 
     add_provider_count_cookie
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,16 @@ private
   def set_user_session
     user = Session.create(first_name: current_user_info[:first_name], last_name: current_user_info[:last_name])
     session[:auth_user][:user_id] = user.id
+
+    add_provider_count_cookie
+  end
+
+  def add_provider_count_cookie
+    begin
+      session[:auth_user][:provider_count] = Provider.all.size
+    rescue StandardError => e
+      logger.error "Error setting the provider_count cookie: #{e.class.name}, #{e.message}"
+    end
   end
 
   def add_token_to_connection

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -8,7 +8,8 @@ class ProvidersController < ApplicationController
   end
 
   def show
-    @has_multiple_providers = Provider.all.size > 1
+    provider_count = session.try(:[], :auth_user).try(:[], :provider_count)
+    @has_multiple_providers = provider_count.nil? || provider_count > 1
     @provider = Provider.find(params[:code]).first.attributes
   end
 end

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -105,7 +105,7 @@
             <tr class="govuk-table__row">
               <td class="govuk-table__cell "><span class="break-word">_publish_teacher_training_courses_session</span></td>
               <td class="govuk-table__cell ">Used to remember your identity when signed in</td>
-              <td class="govuk-table__cell ">never</td>
+              <td class="govuk-table__cell ">6 hours</td>
             </tr>
           </tbody>
         </table>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -42,15 +42,32 @@ RSpec.describe ApplicationController, type: :controller do
 
         before do
           allow(Session).to receive(:create)
+          allow(Provider).to receive(:all)
+            .and_raise('Could not connect to backend')
 
           controller.request.session = { auth_user: { "info" => user_info, :user_id => user_id } }
           controller.authenticate
         end
 
-        it "has performed jwt encoding" do expect(JWT).to have_received(:encode) end
-        it "has set connection" do expect(Base).to have_received(:connection) end
-        it "has not called session create" do expect(Session).to_not have_received(:create) end
-        it "has set user_id" do expect(controller.request.session[:auth_user][:user_id]).to eq user_id end
+        it "has performed jwt encoding" do
+          expect(JWT).to have_received(:encode)
+        end
+
+        it "has set connection" do
+          expect(Base).to have_received(:connection)
+        end
+
+        it "has not called session create" do
+          expect(Session).to_not have_received(:create)
+        end
+
+        it "has set user_id" do
+          expect(controller.request.session[:auth_user][:user_id]).to eq user_id
+        end
+
+        it "has set provider_count" do
+          expect(controller.request.session[:auth_user][:provider_count]).to eq nil
+        end
       end
 
       context 'user_id is blank' do
@@ -66,13 +83,30 @@ RSpec.describe ApplicationController, type: :controller do
           allow(Session).to receive(:create)
             .with(first_name: user_info[:first_name], last_name: user_info[:last_name])
             .and_return(double(id: 999))
+          allow(Provider).to receive(:all)
+            .and_return(%w[one two])
           controller.authenticate
         end
 
-        it "has performed jwt encoding" do expect(JWT).to have_received(:encode) end
-        it "has set connection" do expect(Base).to have_received(:connection) end
-        it "has called session create" do expect(Session).to have_received(:create) end
-        it "has set user_id" do expect(controller.request.session[:auth_user][:user_id]).to eq 999 end
+        it "has performed jwt encoding" do
+          expect(JWT).to have_received(:encode)
+        end
+
+        it "has set connection" do
+          expect(Base).to have_received(:connection)
+        end
+
+        it "has called session create" do
+          expect(Session).to have_received(:create)
+        end
+
+        it "has set user_id" do
+          expect(controller.request.session[:auth_user][:user_id]).to eq 999
+        end
+
+        it "has set provider_count" do
+          expect(controller.request.session[:auth_user][:provider_count]).to eq 2
+        end
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ApplicationController, type: :controller do
           allow(Provider).to receive(:all)
             .and_raise('Could not connect to backend')
 
-          controller.request.session = { auth_user: { "info" => user_info, :user_id => user_id } }
+          controller.request.session = { auth_user: { "info" => user_info, 'user_id' => user_id } }
           controller.authenticate
         end
 
@@ -62,7 +62,7 @@ RSpec.describe ApplicationController, type: :controller do
         end
 
         it "has set user_id" do
-          expect(controller.request.session[:auth_user][:user_id]).to eq user_id
+          expect(controller.request.session[:auth_user]['user_id']).to eq user_id
         end
 
         it "has set provider_count" do
@@ -101,7 +101,7 @@ RSpec.describe ApplicationController, type: :controller do
         end
 
         it "has set user_id" do
-          expect(controller.request.session[:auth_user][:user_id]).to eq 999
+          expect(controller.request.session[:auth_user]['user_id']).to eq 999
         end
 
         it "has set provider_count" do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SessionsController, type: :controller do
         get :create
 
         expect(subject).to redirect_to("/")
-        expect(@request.session[:auth_user][:user_id]).to eq user_id
+        expect(@request.session[:auth_user]['user_id']).to eq user_id
         expect(@request.session[:auth_user]["info"]).to eq user_info
         expect(Base).to have_received(:connection).with(true)
       end

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -19,6 +19,6 @@ RSpec.feature 'View providers', type: :feature do
 
     visit('/organisations/A0')
     expect(find('h1')).to have_content('ACME SCITT A0')
-    expect(page).not_to have_selector(".govuk-breadcrumbs")
+    expect(page).to have_selector(".govuk-breadcrumbs")
   end
 end


### PR DESCRIPTION
### Context

We currently do a request for the whole list of providers when we hit the `organisation#show` page. This is fairly inefficient, and moreover, we'll need this in the future on every page that has breadcrumbs (almost all of them).

### Changes proposed in this pull request

When initialising a user session, query the list of providers in order to get the total count and save it to a cookie. This can then be referenced from the controller/view templates in order to decide whether we need to show the breadcrumbs.

Note that this call in the session is still quite slow (for a God user), so it slows down initial signin, but it's only done once. We can choose to further optimise it down the line.

### Guidance to review

This is a spike more or less, so haven't touched the tests, but if the idea looks good, just request changes and I'll add/update the requisite tests. :)