### PR TITLE
Add back link helper for manage ui

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -2,4 +2,8 @@ module ViewHelper
   def manage_ui_link_to(body, url, html_options = { class: 'govuk-link' })
     link_to body, "#{Settings.manage_ui.base_url}#{url}", html_options
   end
+
+  def manage_ui_link_to_back(url)
+    manage_ui_link_to('Back', url, class: "govuk-back-link")
+  end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -6,4 +6,10 @@ RSpec.feature 'View helpers', type: :helper do
       expect(helper.manage_ui_link_to('ACME SCITT', '/organisations/A0')).to eq("<a class=\"govuk-link\" href=\"https://localhost:44364/organisations/A0\">ACME SCITT</a>")
     end
   end
+
+  describe "#manage_ui_link_to_back" do
+    it "returns a valid URL" do
+      expect(helper.manage_ui_link_to_back('/organisations')).to eq("<a class=\"govuk-back-link\" href=\"https://localhost:44364/organisations\">Back</a>")
+    end
+  end
 end


### PR DESCRIPTION
### Context
`<%= manage_ui_link_to_back("/organisation/#{params[:provider_code]}/courses/#{@course.course_code}") %>` 

vs

`<%= manage_ui_link_to "Back", "/organisation/#{params[:provider_code]}/courses/#{@course[:course_code]}", class: "govuk-back-link" %>`

### Changes proposed in this pull request
Add helper method for back link to manage courses ui
