### PR TITLE
Use Rubocop instead of govuk-lint-ruby for linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_gem:
+  govuk-lint: configs/rubocop/all.yml

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ group :development, :test do
 
   # Testing framework
   gem 'rspec-rails', '~> 3.8'
+
+  # A Ruby static code analyzer and formatter
+  gem 'rubocop', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,6 +363,7 @@ DEPENDENCIES
   rails (~> 5.2.2)
   rspec-rails (~> 3.8)
   rspec_junit_formatter
+  rubocop
   selenium-webdriver
   sentry-raven
   spring

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ bundle exec rspec
 It's best to lint just your app directories and not those belonging to the framework, e.g.
 
 ```bash
-bundle exec govuk-lint-ruby app config db lib spec Gemfile --format clang -a
+bundle exec rubocop app config db lib spec Gemfile --format clang -a
 
 or
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ steps:
   inputs:
     command: Run an image
     imageName: $(IMAGE_NAME)
-    containerCommand: govuk-lint-ruby app config db lib spec --format clang
+    containerCommand: rubocop app config db lib spec --format clang
     runInBackground: false
 
 - task: Docker@1

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -32,5 +32,5 @@ echo "Running tests..."
 bundle-run "rails spec"
 
 echo "Running linters..."
-bundle-run "govuk-lint-ruby app config db lib spec --format clang"
+bundle-run "rubocop app config db lib spec --format clang"
 bundle-run "govuk-lint-sass app/webpacker/stylesheets"

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -2,7 +2,7 @@ desc "Lint ruby code"
 namespace :lint do
   task :ruby do
     puts 'Linting ruby...'
-    system 'bundle exec govuk-lint-ruby app config db lib spec Gemfile --format clang -a'
+    system 'bundle exec rubocop app config db lib spec Gemfile --format clang -a'
   end
 
   task :scss do


### PR DESCRIPTION
GOV.UK Lint is being deperacated, this is the new way of using it.

### Context

GOV.UK Lint is being deprecated, it's recommended to be used in this way instead.

I haven left the SCSS listing in there, they recommend using node based tooling for that instead.

### Changes proposed in this pull request

Switch from govuk-lint-ruby to Rubocop configured to use govuk-lint's rules.

### Guidance to review