### PR TITLE
[1136] add success flash to course vacancies

### DIFF
--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -21,6 +21,7 @@ module Courses
           site_status.save
         end
 
+      flash[:success] = 'Course vacancies published'
       redirect_to vacancies_provider_course_path(params[:provider_code], @course.course_code)
     end
 

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -3,6 +3,7 @@
 <%= manage_ui_link_to_back("/organisation/#{params[:provider_code]}/courses/#{@course.course_code}") %>
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
+  <%= render partial: "layouts/flash" if flash.any? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= form_for @course, url: vacancies_provider_course_path(params[:provider_code], @course.course_code), method: :put do |f| %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,9 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <% flash.each do |key, value| %>
+      <div class="govuk-<%= key %>-summary" role="alert" aria-labelledby="<%= key %>-summary-heading" tabindex="-1" data-module="error-summary">
+        <h3 class="govuk-<%= key %>-summary__title" id="<%= key %>-summary-heading"><%= value %></h3>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/webpacker/stylesheets/_flash.scss
+++ b/app/webpacker/stylesheets/_flash.scss
@@ -1,0 +1,22 @@
+.govuk-success-summary {
+  @include govuk-focusable;
+  @include govuk-text-colour;
+  @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(8, "bottom");
+
+  border: $govuk-border-width-mobile solid $success-green;
+
+  @include govuk-media-query($from: tablet) {
+    border: $govuk-border-width solid $success-green;
+  }
+
+  *:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.govuk-success-summary__title {
+  @include govuk-font($size: 24, $weight: bold);
+  @include govuk-responsive-margin(4, "bottom");
+  margin-top: 0;
+}

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -1,2 +1,4 @@
+$success-green: #00823b;
 @import "../../../node_modules/govuk-frontend/all";
 @import "cookie-banner";
+@import "flash";

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -236,6 +236,8 @@ feature 'Edit course vacancies', type: :feature do
       click_on 'Publish changes'
 
       expect(current_path).to eq vacancies_provider_course_path('AO', 'C1D3')
+      expect(page.find('.govuk-success-summary'))
+        .to have_content 'Course vacancies published'
       expect(page.find('input#course_site_status_attributes_0_full_time'))
         .not_to be_checked
     end


### PR DESCRIPTION
### Context
Show user success state

### Changes proposed in this pull request
- Setup flash messages
- Add flash success to courses#vacancies#edit

### Guidance to review
#### After
<img width="1552" alt="Screenshot 2019-03-28 at 09 15 38" src="https://user-images.githubusercontent.com/3071606/55145179-2dceee80-513a-11e9-99ea-393fc42fd1c5.png">