### PR TITLE
Fix courses vacancies edit

### DIFF
--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -14,8 +14,8 @@ module Courses
         &.values&.each do |vacancy_status|
           site_status            = find_site_status vacancy_status[:id]
           site_status.vac_status = VacancyStatusDeterminationService.call(
-            vacancy_status_full_time: vacancy_status[:vac_status_full_time],
-            vacancy_status_part_time: vacancy_status[:vac_status_part_time],
+            vacancy_status_full_time: vacancy_status[:full_time],
+            vacancy_status_part_time: vacancy_status[:part_time],
             course:                   @course
           )
           site_status.save

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -221,6 +221,11 @@ feature 'Edit course vacancies', type: :feature do
       course
     end
 
+    let(:course_with_vacancy) do
+      course[:included][0][:attributes][:vac_status] = 'full_time_vacancies'
+      course
+    end
+
     before do
       stub_request :patch, 'http://localhost:3001/api/v2/site_statuses/1'
       stub_request :patch, 'http://localhost:3001/api/v2/site_statuses/2'
@@ -238,6 +243,18 @@ feature 'Edit course vacancies', type: :feature do
       expect(current_path).to eq vacancies_provider_course_path('AO', 'C1D3')
       expect(page.find('input#course_site_status_attributes_0_full_time'))
         .not_to be_checked
+    end
+
+    scenario 'adding a vacancy' do
+      visit '/organisations/AO/courses/C1D3/vacancies'
+
+      page.find('input#course_site_status_attributes_0_full_time').check
+      stub_api_v2_request '/providers/AO/courses/C1D3', course_with_vacancy
+      click_on 'Publish changes'
+
+      expect(current_path).to eq vacancies_provider_course_path('AO', 'C1D3')
+      expect(page.find('input#course_site_status_attributes_0_full_time'))
+        .to be_checked
     end
   end
 end


### PR DESCRIPTION
### Context
The attributes on the checkboxes changed in this big PR https://github.com/DFE-Digital/manage-courses-frontend/pull/106 and this change missed.

The happy path is working but adding vacancies for a course where the vacancy status is nil isn't working. This should fix it

### Changes proposed in this pull request
Update checkbox input attributes in the controller

### Guidance to review
Example course `https://localhost:3000/organisations/2DQ/courses/3272/vacancies`

The test here doesn't actually test the failure but it's good to add. Once we have proper factories from https://github.com/DFE-Digital/manage-courses-frontend/pull/109 then we should add some tests and probably a controller test.
