### PR TITLE
[1136] Update all site statuses if radio button is checked

### DIFF
--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -12,12 +12,17 @@ module Courses
     def update
       params.dig(:course, :site_status_attributes)
         &.values&.each do |vacancy_status|
-          site_status            = find_site_status vacancy_status[:id]
-          site_status.vac_status = VacancyStatusDeterminationService.call(
-            vacancy_status_full_time: vacancy_status[:full_time],
-            vacancy_status_part_time: vacancy_status[:part_time],
-            course:                   @course
-          )
+          site_status = find_site_status vacancy_status[:id]
+          # Set all site_status.vac_status to 'no_vacancies' if radio button is checked
+          site_status.vac_status = if params[:course][:has_vacancies] == 'false'
+                                     'no_vacancies'
+                                   else
+                                     VacancyStatusDeterminationService.call(
+                                       vacancy_status_full_time: vacancy_status[:full_time],
+                                       vacancy_status_part_time: vacancy_status[:part_time],
+                                       course:                   @course
+                                     )
+                                   end
           site_status.save
         end
 

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -247,6 +247,20 @@ feature 'Edit course vacancies', type: :feature do
         .not_to be_checked
     end
 
+    scenario 'removing all vacancies' do
+      visit '/organisations/AO/courses/C1D3/vacancies'
+
+      page.find('input#course_has_vacancies_false').click
+      stub_api_v2_request '/providers/AO/courses/C1D3', course_with_vacancy
+      click_on 'Publish changes'
+
+      expect(current_path).to eq vacancies_provider_course_path('AO', 'C1D3')
+      expect(page.find('.govuk-success-summary'))
+        .to have_content 'Course vacancies published'
+      expect(page.find('input#course_has_vacancies_false'))
+        .to be_truthy
+    end
+
     scenario 'adding a vacancy' do
       visit '/organisations/AO/courses/C1D3/vacancies'
 


### PR DESCRIPTION
### Context
Course vacancies

### Changes proposed in this pull request
When a user selects the no vacancies radio button we should set all the site statuses to `no_vacancies`

### Guidance to review
e.g. `https://localhost:3000/organisations/2DQ/courses/3272/vacancies`
<img width="1552" alt="Screenshot 2019-03-28 at 15 40 28" src="https://user-images.githubusercontent.com/3071606/55171286-f8dd8e80-516f-11e9-9b26-8b9b8ed93d8d.png">