### PR TITLE
[1207] Fix it on the route level

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,15 @@ Rails.application.routes.draw do
     resources :courses, param: :code do
       get '/vacancies', on: :member, to: 'courses/vacancies#edit'
       put '/vacancies', on: :member, to: 'courses/vacancies#update'
+
+
+      # redirect back to manage course ui
+      get '/preview', to: redirect("#{Settings.manage_ui.base_url}/organisation/%{provider_code}/course/self/%{course_code}/preview", status: 302)
+      get '/about', to: redirect("#{Settings.manage_ui.base_url}/organisation/%{provider_code}/course/self/%{course_code}/about", status: 302)
+      get '/requirements', to: redirect("#{Settings.manage_ui.base_url}/organisation/%{provider_code}/course/self/%{course_code}/requirements", status: 302)
+      get '/salary', to: redirect("#{Settings.manage_ui.base_url}/organisation/%{provider_code}/course/self/%{course_code}/salary", status: 302)
+      get '/fees-and-length', to: redirect("#{Settings.manage_ui.base_url}/organisation/%{provider_code}/course/self/%{course_code}/fees-and-length", status: 302)
+      get '/', to: redirect("#{Settings.manage_ui.base_url}/organisation/%{provider_code}/course/self/%{course_code}", status: 302)
     end
   end
 


### PR DESCRIPTION
### Context
Probably easier to do on the route level.

manage course ui`self` url is a leftover from the time before dawn (tabbed view/ variant page).

In all likelihood ie (bookmarked pages) needs to redirect with `self` url to the restful version, so the reverse of whats on show needed to be added.

ie rails `self` urls redirects to rails restful urls

### Changes proposed in this pull request

rails restful course urls redirect to csharp self urls



### Guidance to review
in complete but you get the idea

https://github.com/DFE-Digital/manage-courses-frontend/blob/master/app/views/courses/vacancies/edit.html.erb


Below are the the actual fix required for the above vacancies edit page. (there is two different mistakes)



`<%= manage_ui_link_to_back("/organisation/#{params[:provider_code]}/courses/#{@course.course_code}") %>`

vs

`<%= manage_ui_link_to_back("/organisation/#{params[:provider_code]}/course/self/#{@course.course_code}") %>`



`<p class="govuk-body"><%= link_to "Cancel changes", "/organisation/#{params[:provider_code]}/courses/#{@course.course_code}", class: "govuk-link" %></p>`

vs

`<p class="govuk-body"><%= manage_ui_link_to("Cancel changes", "/organisation/#{params[:provider_code]}/course/self/#{@course.course_code}", class: "govuk-link") , %></p>`


Maybe we get in a position to drop this `manage_ui_link` and use the more railsy way thingy thing