### PR TITLE
[1207] Fix deep link on vacancies edit page

### DIFF
--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Vacancies" %>
 
-<%= manage_ui_link_to_back("/organisation/#{params[:provider_code]}/courses/#{@course.course_code}") %>
+<%= manage_ui_link_to_back("/organisation/#{params[:provider_code]}/courses/self/#{@course.course_code}") %>
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <%= render partial: "layouts/flash" if flash.any? %>
@@ -54,9 +54,9 @@
           </fieldset>
           <p class="govuk-body">Changes will appear on Find straight away. UCAS Apply will be updated overnight.</p>
           <%= f.submit "Publish changes", class: "govuk-button" %>
-          <p class="govuk-body"><%= link_to "Cancel changes", "/organisation/#{params[:provider_code]}/courses/#{@course.course_code}", class: "govuk-link" %></p>
+          <p class="govuk-body"><p class="govuk-body"><%= manage_ui_link_to("Cancel changes", "/organisation/#{params[:provider_code]}/courses/self/#{@course.course_code}", class: "govuk-link")%></p></p>
         </div>
-      <% end %>
+        <% end %>
     </div>
   </div>
 </main>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -56,7 +56,7 @@
           <%= f.submit "Publish changes", class: "govuk-button" %>
           <p class="govuk-body"><p class="govuk-body"><%= manage_ui_link_to("Cancel changes", "/organisation/#{params[:provider_code]}/courses/self/#{@course.course_code}", class: "govuk-link")%></p></p>
         </div>
-        <% end %>
+      <% end %>
     </div>
   </div>
 </main>

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -125,7 +125,11 @@ feature 'Edit course vacancies', type: :feature do
 
     expect(page).to have_link(
       'Back',
-      href: "#{Settings.manage_ui.base_url}/organisation/AO/courses/C1D3"
+      href: "#{Settings.manage_ui.base_url}/organisation/AO/courses/self/C1D3"
+    )
+    expect(page).to have_link(
+      'Cancel changes',
+      href: "#{Settings.manage_ui.base_url}/organisation/AO/courses/self/C1D3"
     )
     expect(find('h1')).to have_content('Edit vacancies')
     expect(find('.govuk-caption-xl')).to have_content('English (C1D3)')


### PR DESCRIPTION
### Context
Manage course ui deep link on vacancies edit page

### Changes proposed in this pull request
Fix deep link on vacancies edit page
