### PR TITLE
[1207] Fix Manage Courses UI course page link

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -10,4 +10,8 @@ module ViewHelper
   def manage_ui_url(relative_path)
     Settings.manage_ui.base_url + relative_path
   end
+
+  def manage_ui_course_page_url(provider_code:, course_code:)
+    manage_ui_url("/organisation/#{provider_code}/courses/#{course_code}")
+  end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -12,6 +12,6 @@ module ViewHelper
   end
 
   def manage_ui_course_page_url(provider_code:, course_code:)
-    manage_ui_url("/organisation/#{provider_code}/courses/#{course_code}")
+    manage_ui_url("/organisation/#{provider_code}/course/self/#{course_code}")
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,9 +1,13 @@
 module ViewHelper
-  def manage_ui_link_to(body, url, html_options = { class: 'govuk-link' })
-    link_to body, "#{Settings.manage_ui.base_url}#{url}", html_options
+  def govuk_link_to(body, url, html_options = { class: 'govuk-link' })
+    link_to body, url, html_options
   end
 
-  def manage_ui_link_to_back(url)
-    manage_ui_link_to('Back', url, class: "govuk-back-link")
+  def govuk_back_link_to(url)
+    govuk_link_to('Back', url, class: "govuk-back-link")
+  end
+
+  def manage_ui_url(relative_path)
+    Settings.manage_ui.base_url + relative_path
   end
 end

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Vacancies" %>
 
-<%= manage_ui_link_to_back("/organisation/#{params[:provider_code]}/courses/#{@course.course_code}") %>
+<%= govuk_back_link_to(manage_ui_url("/organisation/#{params[:provider_code]}/courses/#{@course.course_code}")) %>
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <%= render partial: "layouts/flash" if flash.any? %>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Vacancies" %>
 
-<%= govuk_back_link_to(manage_ui_url("/organisation/#{params[:provider_code]}/courses/#{@course.course_code}")) %>
+<%= govuk_back_link_to(manage_ui_course_page_url(provider_code: params[:provider_code], course_code: @course.course_code)) %>
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <%= render partial: "layouts/flash" if flash.any? %>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -54,7 +54,7 @@
           </fieldset>
           <p class="govuk-body">Changes will appear on Find straight away. UCAS Apply will be updated overnight.</p>
           <%= f.submit "Publish changes", class: "govuk-button" %>
-          <p class="govuk-body"><%= link_to "Cancel changes", "/organisation/#{params[:provider_code]}/courses/#{@course.course_code}", class: "govuk-link" %></p>
+          <p class="govuk-body"><%= govuk_link_to "Cancel changes", manage_ui_course_page_url(provider_code: params[:provider_code], course_code: @course.course_code) %></p>
         </div>
       <% end %>
     </div>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -17,7 +17,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl"><%= @provider[:institution_name] %></h1>
-      <h2 class="govuk-heading-m"><%= manage_ui_link_to "About your organisation", "/organisation/#{@provider[:institution_code]}/details" %></h2>
+      <h2 class="govuk-heading-m"><%= govuk_link_to "About your organisation", manage_ui_url("/organisation/#{@provider[:institution_code]}/details") %></h2>
       <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
         <li>write about your organisation</li>
@@ -29,7 +29,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m"><%= manage_ui_link_to "Courses", "/organisation/#{@provider[:institution_code]}/courses" %></h2>
+      <h2 class="govuk-heading-m"><%= govuk_link_to "Courses", manage_ui_url("/organisation/#{@provider[:institution_code]}/courses") %></h2>
       <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
         <li>write about each course</li>
@@ -41,7 +41,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m"><%= manage_ui_link_to "Request access for someone else", "/organisation/#{@provider[:institution_code]}/request-access" %></h2>
+      <h2 class="govuk-heading-m"><%= govuk_link_to "Request access for someone else", manage_ui_url("/organisation/#{@provider[:institution_code]}/request-access") %></h2>
       <p class="govuk-body govuk-!-margin-bottom-8">You can request a DfE Sign-in account for others who manage your courses.</p>
     </div>
   </div>

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -125,7 +125,7 @@ feature 'Edit course vacancies', type: :feature do
 
     expect(page).to have_link(
       'Back',
-      href: "#{Settings.manage_ui.base_url}/organisation/AO/courses/C1D3"
+      href: "#{Settings.manage_ui.base_url}/organisation/AO/course/self/C1D3"
     )
     expect(page).to have_link(
       'Cancel changes',

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -127,6 +127,10 @@ feature 'Edit course vacancies', type: :feature do
       'Back',
       href: "#{Settings.manage_ui.base_url}/organisation/AO/courses/C1D3"
     )
+    expect(page).to have_link(
+      'Cancel changes',
+      href: "#{Settings.manage_ui.base_url}/organisation/AO/course/self/C1D3"
+    )
     expect(find('h1')).to have_content('Edit vacancies')
     expect(find('.govuk-caption-xl')).to have_content('English (C1D3)')
   end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -18,4 +18,10 @@ RSpec.feature 'View helpers', type: :helper do
       expect(helper.manage_ui_url('/organisations/A0')).to eq("https://localhost:44364/organisations/A0")
     end
   end
+
+  describe "#manage_ui_url" do
+    it "returns full Manage Courses UI URL to the passed path" do
+      expect(helper.manage_ui_course_page_url(provider_code: 'A1', course_code: 'X130')).to eq("https://localhost:44364/organisation/A1/courses/X130")
+    end
+  end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -1,15 +1,21 @@
 require 'rails_helper'
 
 RSpec.feature 'View helpers', type: :helper do
-  describe "#manage_ui_link_to" do
-    it "returns a valid URL" do
-      expect(helper.manage_ui_link_to('ACME SCITT', '/organisations/A0')).to eq("<a class=\"govuk-link\" href=\"https://localhost:44364/organisations/A0\">ACME SCITT</a>")
+  describe "#govuk_link_to" do
+    it "returns an anchor tag with the govuk-link class" do
+      expect(helper.govuk_link_to('ACME SCITT', 'https://localhost:44364/organisations/A0')).to eq("<a class=\"govuk-link\" href=\"https://localhost:44364/organisations/A0\">ACME SCITT</a>")
     end
   end
 
-  describe "#manage_ui_link_to_back" do
-    it "returns a valid URL" do
-      expect(helper.manage_ui_link_to_back('/organisations')).to eq("<a class=\"govuk-back-link\" href=\"https://localhost:44364/organisations\">Back</a>")
+  describe "#govuk_back_link_to" do
+    it "returns an anchor tag with the govuk-back-link class" do
+      expect(helper.govuk_back_link_to('https://localhost:44364/organisations/A0')).to eq("<a class=\"govuk-back-link\" href=\"https://localhost:44364/organisations/A0\">Back</a>")
+    end
+  end
+
+  describe "#manage_ui_url" do
+    it "returns full Manage Courses UI URL to the passed path" do
+      expect(helper.manage_ui_url('/organisations/A0')).to eq("https://localhost:44364/organisations/A0")
     end
   end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'View helpers', type: :helper do
 
   describe "#manage_ui_url" do
     it "returns full Manage Courses UI URL to the passed path" do
-      expect(helper.manage_ui_course_page_url(provider_code: 'A1', course_code: 'X130')).to eq("https://localhost:44364/organisation/A1/courses/X130")
+      expect(helper.manage_ui_course_page_url(provider_code: 'A1', course_code: 'X130')).to eq("https://localhost:44364/organisation/A1/course/self/X130")
     end
   end
 end


### PR DESCRIPTION
### Context
The link from the vacancies edit page in this app to Manage Course UI doesn't work.

### Changes proposed in this pull request
- fix the 'Cancel changes' link
- fix the course page URL
- re-cut helper responsibility

### Guidance to review
Alternative to #121 with some more code tidy-up. Best reviewed commit-by-commit.