### PR TITLE
[1210] Add search-and-compare-ui base url to settings

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -105,6 +105,24 @@
             "metadata": {
                 "description": "Connection string for Sentry monitoring."
             }
+        },
+        "settingsManageBackendBaseUrl": {
+            "type": "string",
+            "metadata": {
+                "description": "Base URL for manage-courses-backend."
+            }
+        },
+        "settingsManageUiBaseUrl": {
+            "type": "string",
+            "metadata": {
+                "description": "Base URL for manage-courses-ui."
+            }
+        },
+        "settingsSearchUiBaseUrl": {
+            "type": "string",
+            "metadata": {
+                "description": "Base URL for search-and-compare-ui."
+            }
         }
     },
     "variables": {
@@ -216,6 +234,18 @@
                             {
                                 "name": "SENTRY_DSN",
                                 "value": "[parameters('sentryDSN')]"
+                            },
+                            {
+                                "name": "SETTINGS__MANAGE_BACKEND__BASE_URL",
+                                "value": "[parameters('settingsManageBackendBaseUrl')]"
+                            },
+                            {
+                                "name": "SETTINGS__MANAGE_UI__BASE_URL",
+                                "value": "[parameters('settingsManageUiBaseUrl')]"
+                            },
+                            {
+                                "name": "SETTINGS__SEARCH_UI__BASE_URL",
+                                "value": "[parameters('settingsSearchUiBaseUrl')]"
                             }
                         ]
                     },

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,3 +20,6 @@ manage_backend:
 manage_ui:
   # URL of the c# ui app (manage-courses-ui)
   base_url: https://localhost:44364
+search_ui:
+  # URL of the C# search ui app (search-and-compare-ui)
+  base_url: https://localhost:5000

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,6 +6,8 @@ manage_backend:
   base_url: http://localhost:3001
 manage_ui:
   base_url: https://localhost:44364
+search_ui:
+  base_url: https://localhost:5000
 authentication:
   algorithm: plain-text
   secret: nil

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -7,3 +7,5 @@ manage_backend:
   base_url: https://api2.publish-teacher-training-courses.service.gov.uk
 manage_ui:
   base_url: https://www.publish-teacher-training-courses.service.gov.uk
+search_ui:
+  base_url: https://www.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,3 +6,5 @@ manage_backend:
   base_url: http://localhost:3001
 manage_ui:
   base_url: https://localhost:44364
+search_ui:
+  base_url: https://localhost:5000


### PR DESCRIPTION
### Context

The courses table links directly to find, so we need to add this. Requires a Terraform change as well: https://github.com/DFE-Digital/bat-infrastructure/pull/120

Also updates the VSTS settings with some missing keys.