### PR TITLE
[1210] Fix stubbed out link to course page in courses table

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -47,7 +47,10 @@
       <% @courses.each do |course| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" data-qa="courses-table__course">
-            <a href="#TODO" class="govuk-link govuk-heading-s govuk-!-margin-bottom-0" style="border: 3px solid red"><%= course.attributes[:name] %> (<%= course.attributes[:course_code] %>)</a>
+            <%= govuk_link_to "#{ course.attributes[:name] } (#{ course.attributes[:course_code] })",
+              manage_ui_course_page_url(provider_code: @provider[:institution_code], course_code: course.attributes[:course_code]),
+              class: "govuk-link govuk-heading-s govuk-!-margin-bottom-0"
+            %>
             <span class="govuk-body-s"><%= course.attributes[:description] %></span>
           </td>
           <td class="govuk-table__cell" style="border: 3px solid red">

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -15,6 +15,9 @@ feature 'Index courses', type: :feature do
     expect(page).to have_selector('tbody tr', count: 3)
 
     expect(first('[data-qa="courses-table__course"]')).to have_content('English (X101)')
+    expect(first('[data-qa="courses-table__course"]')).to have_content('PGCE with QTS')
+    expect(page).to have_selector("a[href=\"https://localhost:44364/organisation/A0/course/self/X101\"]")
+
     expect(first('[data-qa="courses-table__findable"]')).to have_content('Yes - view online')
     expect(first('[data-qa="courses-table__applications"]')).to have_content('Closed')
     expect(first('[data-qa="courses-table__vacancies"]')).to have_content('No (Edit)')


### PR DESCRIPTION
Very small but self contained so may as well get it out while I do the rest.

### After

![Screen Shot 2019-03-29 at 18 30 37](https://user-images.githubusercontent.com/1650875/55254799-c6579280-5250-11e9-9226-868a4a5a4ddc.png)
