### PR TITLE
Setup proper staging and qa environment

### DIFF
--- a/config/environments/qa.rb
+++ b/config/environments/qa.rb
@@ -1,0 +1,1 @@
+require Rails.root.join("config/environments/production")

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,1 @@
+require Rails.root.join("config/environments/production")

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,0 +1,9 @@
+dfe_signin:
+  issuer: https://signin-test-oidc-as.azurewebsites.net
+  profile: https://signin-test-pfl-as.azurewebsites.net
+  secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
+  base_url: https://bat-dev-manage-courses-frontend-app.azurewebsites.net
+manage_backend:
+  base_url: https://bat-dev-manage-courses-backend-app.azurewebsites.net
+manage_ui:
+  base_url: https://bat-dev-manage-courses-ui-app.azurewebsites.net

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,0 +1,9 @@
+dfe_signin:
+  issuer: https://signin-test-oidc-as.azurewebsites.net
+  profile: https://signin-test-pfl-as.azurewebsites.net
+  secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
+  base_url: https://bat-staging-manage-courses-frontend-app.azurewebsites.net
+manage_backend:
+  base_url: https://bat-staging-manage-courses-backend-app.azurewebsites.net
+manage_ui:
+  base_url: https://bat-staging-manage-courses-ui-app.azurewebsites.net

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -80,7 +80,7 @@ test:
   <<: *default
   compile: true
 
-production:
+production: &production
   <<: *default
 
   # Production depends on precompilation of packs prior to booting for performance.
@@ -88,3 +88,9 @@ production:
 
   # Cache manifest.json for performance
   cache_manifest: true
+
+staging:
+  <<: *production
+
+qa:
+  <<: *production


### PR DESCRIPTION
### Context
Proper environments i.e. `staging` and `qa` (for https://bat-dev-manage-courses-frontend-app.azurewebsites.net/)

### Changes proposed in this pull request
- Add `{staging, qa}.rb` - duplicates of `production.rb`
- Add settings for `staging` and `qa`

### Guidance to review
`bin/rails server -e staging -b "ssl://localhost:3000?key=config/localhost/https/localhost.key&cert=config/localhost/https/localhost.crt" `
