### PR TITLE
[1136] refactor vacancy checkbox helper method

### DIFF
--- a/app/helpers/vacancy_helper.rb
+++ b/app/helpers/vacancy_helper.rb
@@ -1,20 +1,27 @@
 module VacancyHelper
-  # TODO: Refactor this, consider moving elsewhere.
-  def are_vacancies_available_for_course_site_status?(course, site_status, vacancy_study_mode = nil)
-    if course.full_time? && site_status.full_time_vacancies?
-      true
-    elsif course.part_time? && site_status.part_time_vacancies?
-      true
-    elsif course.full_time_or_part_time?
-      if vacancy_study_mode == :part_time && site_status.part_time_vacancies?
-        true
-      elsif vacancy_study_mode == :full_time && site_status.full_time_vacancies?
-        true
-      elsif site_status.full_time_and_part_time_vacancies?
-        true
-      else
-        false
-      end
+  def vacancy_available_for_course_site_status?(course, site_status, vacancy_study_mode = nil)
+    case course.study_mode
+    when 'full_time'
+      site_status.full_time_vacancies?
+    when 'part_time'
+      site_status.part_time_vacancies?
+    when 'full_time_or_part_time'
+      vacancy_available_for_study_mode?(site_status, vacancy_study_mode)
+    else
+      false
+    end
+  end
+
+private
+
+  def vacancy_available_for_study_mode?(site_status, vacancy_study_mode)
+    return true if site_status.full_time_and_part_time_vacancies?
+
+    case vacancy_study_mode
+    when :part_time
+      site_status.part_time_vacancies?
+    when :full_time
+      site_status.full_time_vacancies?
     else
       false
     end

--- a/app/views/courses/vacancies/_site_status_checkbox.html.erb
+++ b/app/views/courses/vacancies/_site_status_checkbox.html.erb
@@ -1,4 +1,4 @@
 <div class='govuk-checkboxes__item'>
-  <%= f.check_box(study_mode, checked: are_vacancies_available_for_course_site_status?(course, f.object, study_mode), class: 'govuk-checkboxes__input') %>
+  <%= f.check_box(study_mode, checked: vacancy_available_for_course_site_status?(course, f.object, study_mode), class: 'govuk-checkboxes__input') %>
   <%= f.label(study_mode, "#{f.object.site.location_name} (#{study_mode.to_s.humanize})", class: 'govuk-label govuk-checkboxes__label') %>
 </div>

--- a/spec/helpers/vacancy_helper_spec.rb
+++ b/spec/helpers/vacancy_helper_spec.rb
@@ -1,13 +1,11 @@
 require 'rails_helper'
 
-RSpec.feature 'Vacancy helpers', type: :helper do
-  # TODO: Refactor this, the site status doubles in particular.
-
-  describe '#are_vacancies_available_for_course_site_status' do
+feature 'Vacancy helpers', type: :helper do
+  describe '#vacancy_available_for_course_site_status' do
     let(:vacancy_study_mode) { nil }
 
     subject do
-      helper.are_vacancies_available_for_course_site_status?(
+      helper.vacancy_available_for_course_site_status?(
         course,
         site_status,
         vacancy_study_mode
@@ -15,14 +13,7 @@ RSpec.feature 'Vacancy helpers', type: :helper do
     end
 
     context 'with a full time or part time course' do
-      let(:course) do
-        double(
-          :course,
-          full_time_or_part_time?: true,
-          full_time?: false,
-          part_time?: false
-        )
-      end
+      let(:course) { double(:course, study_mode: 'full_time_or_part_time') }
 
       context 'when the vacancy study mode is full time' do
         let(:vacancy_study_mode) { :full_time }
@@ -192,14 +183,8 @@ RSpec.feature 'Vacancy helpers', type: :helper do
     end
 
     context 'with a full time course and vacancy' do
-      let(:course) do
-        double(
-          :course,
-          full_time_or_part_time?: false,
-          full_time?: true,
-          part_time?: false
-        )
-      end
+      let(:course) { double(:course, study_mode: 'full_time') }
+
       context 'with a full time vacancy' do
         let(:site_status) do
           double(
@@ -228,14 +213,7 @@ RSpec.feature 'Vacancy helpers', type: :helper do
     end
 
     context 'with a part time course' do
-      let(:course) do
-        double(
-          :course,
-          full_time_or_part_time?: false,
-          full_time?: false,
-          part_time?: true
-        )
-      end
+      let(:course) { double(:course, study_mode: 'part_time') }
 
       context 'with a part time vacancy' do
         let(:site_status) do


### PR DESCRIPTION
### Context
Refactoring a repetitive and confusing helper method.

This helper is to return true or false in order to check individual the checkboxes on Courses#Vacancies#Edit. We compare the course `study_mode` and the site status `vac_status`

### Changes proposed in this pull request
Refactor main helper method into two smaller helpers

### Guidance to review
N/A - probably best to ignore whitespace when viewing the diff
