### PR TITLE
[1222] Add simple cov for test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ config/settings/*.local.yml
 config/environments/*.local.yml
 
 *.log
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,8 @@ group :test do
   gem 'webmock'
 
   gem 'factory_bot_rails'
+
+  gem 'simplecov', require: false
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     crass (1.0.4)
     deep_merge (1.2.1)
     diff-lcs (1.3)
+    docile (1.3.1)
     dry-configurable (0.8.2)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
@@ -138,6 +139,7 @@ GEM
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
     jaro_winkler (1.5.2)
+    json (2.2.0)
     json-jwt (1.10.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -287,6 +289,11 @@ GEM
       rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.9.0)
       faraday (>= 0.7.6, < 1.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -366,6 +373,7 @@ DEPENDENCIES
   rubocop
   selenium-webdriver
   sentry-raven
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
### Context
See test coverage

### Changes proposed in this pull request
Add [simplecov](https://github.com/colszowka/simplecov) gem and setup

### Guidance to review
`$ bundle exec rspec` 

```ruby
Coverage report generated for RSpec to /Users/Dan/Git/manage-courses-frontend/coverage. 705 / 740 LOC (95.27%) covered.
```