### PR TITLE
[1210] Implement content_status in courses table

### DIFF
--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -1,0 +1,23 @@
+module CourseHelper
+  def course_has_unpublished_changes(course)
+    course.attributes[:content_status] == "published_with_unpublished_changes"
+  end
+
+  def course_content_tag_content(course)
+    {
+      "published" => "Published",
+      "empty" => "Empty",
+      "draft" => "Draft",
+      "published_with_unpublished_changes" => "Published *"
+    }[course.attributes[:content_status]]
+  end
+
+  def course_content_tag_css_class(course)
+    {
+      "published" => "phase-tag--published",
+      "empty" => "phase-tag--no-content",
+      "draft" => "phase-tag--draft",
+      "published_with_unpublished_changes" => "phase-tag--published"
+    }[course.attributes[:content_status]]
+  end
+end

--- a/app/views/courses/_content_status_tag.html.erb
+++ b/app/views/courses/_content_status_tag.html.erb
@@ -1,1 +1,7 @@
-<span class="govuk-tag phase-tag--small phase-tag--published" style="border: 3px solid red">Published</span>
+<div class="govuk-tag phase-tag--small <%= course_content_tag_css_class(course) %>">
+  <%= course_content_tag_content(course) %>
+</div>
+
+<% if course_has_unpublished_changes(course) %>
+  <div class="govuk-body govuk-body-s govuk-!-margin-0">* Unpublished changes</div>
+<% end %>

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -9,8 +9,8 @@
   <td class="govuk-table__cell" style="border: 3px solid red">
     Running
   </td>
-  <td class="govuk-table__cell">
-    <%= render partial: 'content_status_tag' %>
+  <td class="govuk-table__cell" data-qa="courses-table__content-status">
+    <%= render partial: 'content_status_tag', locals: { course: course } %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__findable">
     <% if course.attributes[:findable?] %>

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     site_statuses { [] }
     provider      { nil }
     study_mode    { 'full_time' }
+    content_status { "published" }
 
     trait :with_vacancy do
       has_vacancies? { true }

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -18,6 +18,8 @@ feature 'Index courses', type: :feature do
     expect(first('[data-qa="courses-table__course"]')).to have_content('PGCE with QTS')
     expect(page).to have_selector("a[href=\"https://localhost:44364/organisation/A0/course/self/X101\"]")
 
+    expect(first('[data-qa="courses-table__content-status"]')).to have_content('Published')
+
     expect(first('[data-qa="courses-table__findable"]')).to have_content('Yes - view online')
     expect(page).to have_selector("a[href=\"https://localhost:5000/course/A0/X101\"]")
 

--- a/spec/helpers/course_helper_spec.rb
+++ b/spec/helpers/course_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.feature 'View helpers', type: :helper do
+  describe "#course_has_unpublished_changes" do
+    it "returns true when course has the right content_status" do
+      expect(helper.course_has_unpublished_changes(build(:course, content_status: 'published_with_unpublished_changes'))).to eq(true)
+    end
+
+    it "returns false when course has a different content_status" do
+      expect(helper.course_has_unpublished_changes(build(:course, content_status: 'foo'))).to eq(false)
+    end
+  end
+
+  describe "#course_content_tag_content" do
+    it "returns correct content" do
+      expect(helper.course_content_tag_content(build(:course, content_status: 'published'))).to eq('Published')
+      expect(helper.course_content_tag_content(build(:course, content_status: 'empty'))).to eq('Empty')
+      expect(helper.course_content_tag_content(build(:course, content_status: 'draft'))).to eq('Draft')
+      expect(helper.course_content_tag_content(build(:course, content_status: 'published_with_unpublished_changes'))).to eq('Published *')
+    end
+  end
+
+  describe "#course_content_tag_css_class" do
+    it "returns correct css_class" do
+      expect(helper.course_content_tag_css_class(build(:course, content_status: 'published'))).to eq('phase-tag--published')
+      expect(helper.course_content_tag_css_class(build(:course, content_status: 'empty'))).to eq('phase-tag--no-content')
+      expect(helper.course_content_tag_css_class(build(:course, content_status: 'draft'))).to eq('phase-tag--draft')
+      expect(helper.course_content_tag_css_class(build(:course, content_status: 'published_with_unpublished_changes'))).to eq('phase-tag--published')
+    end
+  end
+end


### PR DESCRIPTION
This is now being pulled in from the API and displayed in the table.

### After

<img width="1080" alt="Screenshot 2019-04-03 at 11 43 00" src="https://user-images.githubusercontent.com/1650875/55473135-c6b3ad00-5605-11e9-98f6-5977053e6ce8.png">
