### PR TITLE
[1219] Change provider factory to produce JSONAPI

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,5 +1,7 @@
 class Provider < Base
+  has_many :courses, param: :provider_code
+
   def course_count
-    relationships.courses[:meta][:count]
+    courses.count
   end
 end

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ProvidersController, type: :controller do
     describe 'GET #index' do
       context 'with 2 or more providers' do
         before do
-          stub_api_v2_request('/providers', build(:providers_response))
+          stub_api_v2_request('/providers', jsonapi(:providers_response))
         end
 
         it 'returns the index page' do
@@ -20,21 +20,21 @@ RSpec.describe ProvidersController, type: :controller do
       end
 
       context 'with 1 provider' do
-        let(:the_provider) { build(:provider) }
+        let(:the_provider) { jsonapi(:provider) }
 
         before do
-          stub_api_v2_request('/providers', build(:providers_response, data: [the_provider]))
+          stub_api_v2_request('/providers', jsonapi(:providers_response, data: [the_provider]))
         end
 
         it 'returns the show page' do
           get :index
-          expect(response).to redirect_to(action: :show, code: the_provider["attributes"][:institution_code])
+          expect(response).to redirect_to(action: :show, code: the_provider.attributes[:institution_code])
         end
       end
 
       context 'with 0 providers' do
         before do
-          stub_api_v2_request('/providers', build(:providers_response, data: []))
+          stub_api_v2_request('/providers', jsonapi(:providers_response, data: []))
         end
 
         it 'redirects to manage-courses-ui' do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -53,9 +53,9 @@ FactoryBot.define do
   factory :courses_response, class: Hash do
     data {
       [
-        build(:course),
-        build(:course),
-        build(:course)
+        jsonapi(:course),
+        jsonapi(:course),
+        jsonapi(:course)
       ]
     }
 

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -1,30 +1,37 @@
 FactoryBot.define do
   factory :provider, class: Hash do
+    transient do
+      relationships { %i[courses] }
+    end
+
+    sequence(:id)
     sequence(:institution_code) { |n| "A#{n}" }
     institution_name { "ACME SCITT #{institution_code}" }
+    courses { [] }
 
-    initialize_with do
-      {
-        "id" => 1,
-        "attributes" => attributes,
-        "type" => "providers",
-        "relationships" => {
-          "courses" => {
-            "meta" => {
-              "count" => 1
-            }
-          }
-        }
-      }
+    initialize_with do |_evaluator|
+      data_attributes = attributes.except(:id, *relationships)
+      relationships_map = Hash[
+        relationships.map do |relationship|
+          [relationship, __send__(relationship)]
+        end
+      ]
+
+      JSONAPIMockSerializable.new(
+        id,
+        'providers',
+        attributes: data_attributes,
+        relationships: relationships_map
+      )
     end
   end
 
   factory :providers_response, class: Hash do
     data {
       [
-        build(:provider, institution_code: "A0"),
-        build(:provider, institution_code: "A1"),
-        build(:provider, institution_code: "A2")
+        jsonapi(:provider, institution_code: "A0"),
+        jsonapi(:provider, institution_code: "A1"),
+        jsonapi(:provider, institution_code: "A2")
       ]
     }
 

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -4,8 +4,8 @@ feature 'Index courses', type: :feature do
   before do
     stub_omniauth
     stub_session_create
-    stub_api_v2_request('/providers', build(:providers_response))
-    stub_api_v2_request('/providers/AO/courses', build(:courses_response))
+    stub_api_v2_request('/providers', jsonapi(:providers_response))
+    stub_api_v2_request('/providers/AO/courses', jsonapi(:courses_response))
   end
 
   scenario 'it shows a list of courses' do

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'View providers', type: :feature do
   scenario 'Navigate to /organisations' do
     stub_omniauth
     stub_session_create
-    stub_api_v2_request('/providers', build(:providers_response))
+    stub_api_v2_request('/providers', jsonapi(:providers_response))
 
     visit('/organisations')
     expect(find('h1')).to have_content('Organisations')
@@ -14,8 +14,8 @@ RSpec.feature 'View providers', type: :feature do
   scenario 'Navigate to /organisations/AO' do
     stub_omniauth
     stub_session_create
-    stub_api_v2_request('/providers', build(:providers_response, data: [build(:provider, institution_code: "A0")]))
-    stub_api_v2_request('/providers/A0', build(:providers_response, data: [build(:provider, institution_code: "A0")]))
+    stub_api_v2_request('/providers', jsonapi(:providers_response, data: [jsonapi(:provider, institution_code: "A0")]))
+    stub_api_v2_request('/providers/A0', jsonapi(:providers_response, data: [jsonapi(:provider, institution_code: "A0")]))
 
     visit('/organisations/A0')
     expect(find('h1')).to have_content('ACME SCITT A0')

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Sign in', type: :feature do
   scenario 'using DfE Sign-in' do
     stub_omniauth(disable_completely: false)
     stub_session_create
-    stub_api_v2_request('/providers', build(:providers_response))
+    stub_api_v2_request('/providers', jsonapi(:providers_response))
 
     visit root_path
 


### PR DESCRIPTION
### Context

The provider factory was never modified to produce JSONAPI responses in the same manner as the course and site factories. This PR is a precursor to 1219.

### Changes proposed in this pull request

* Provider factory now produces JSONAPI responses
* Provider now `has_many :courses`

### Guidance to review
