### PR TITLE
Fix ignoring provided expectation message warning

### DIFF
--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     has_vacancies? { false }
     site_statuses { [] }
     provider      { nil }
+    study_mode    { 'full_time' }
 
     trait :with_vacancy do
       has_vacancies? { true }
@@ -20,16 +21,28 @@ FactoryBot.define do
 
     trait :with_full_time_or_part_time_vacancy do
       with_vacancy
-      study_mode { 'full_time_or_part_time' }
+      full_time_or_part_time
     end
 
     trait :with_full_time_vacancy do
       with_vacancy
-      study_mode { 'full_time' }
+      full_time
     end
 
     trait :with_part_time_vacancy do
       with_vacancy
+      part_time
+    end
+
+    trait :full_time_or_part_time do
+      study_mode { 'full_time_or_part_time' }
+    end
+
+    trait :full_time do
+      study_mode { 'full_time' }
+    end
+
+    trait :part_time do
       study_mode { 'part_time' }
     end
 

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -54,7 +54,7 @@ feature 'Edit course vacancies', type: :feature do
     let(:course_without_vacancies) do
       jsonapi(
         :course,
-        :with_full_time_or_part_time_vacancy,
+        :full_time_or_part_time,
         course_code:   course_attributes[:course_code],
         site_statuses: [
           jsonapi(:site_status, :no_vacancies, id: site_status.id, site: site)
@@ -104,7 +104,7 @@ feature 'Edit course vacancies', type: :feature do
       expect(page.find('.govuk-success-summary')).to have_content(
         'Course vacancies published'
       )
-      expect(page).to have_field('There are no vacancies'), chosen: true
+      expect(page).to have_field('There are no vacancies', checked: true)
       expect(page).to have_field(
         "#{site.attributes[:location_name]} (Full time)",
         checked: false


### PR DESCRIPTION
### Context

Our pipeline was failing because of this message

> WARNING: ignoring the provided expectation message argument ({:chosen=>true}) since it is not a string or a proc.

I've fixed the test triggering this, which was also broken.

### Changes proposed in this pull request

* Added study mode traits to course factory
* Fixed test to get rid of warning (and actually fix the test)

### Guidance to review