### PR TITLE
[1219] Sync course with search and compare

### DIFF
--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -26,6 +26,8 @@ module Courses
           site_status.save
         end
 
+      @course.sync_with_search_and_compare(provider_code: params[:provider_code])
+
       flash[:success] = 'Course vacancies published'
       redirect_to vacancies_provider_course_path(params[:provider_code], @course.course_code)
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,6 +3,10 @@ class Course < Base
   has_many :site_statuses
   has_many :sites, through: :site_statuses, source: :site
 
+  custom_endpoint :sync_with_search_and_compare, on: :member, request_method: :post
+
+  self.primary_key = :course_code
+
   def full_time?
     study_mode == 'full_time'
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -2,6 +2,8 @@ class Provider < Base
   has_many :courses, param: :provider_code
   has_many :sites
 
+  self.primary_key = :provider_code
+
   def course_count
     relationships.courses[:meta][:count]
   end

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -27,6 +27,13 @@ feature 'Edit course vacancies', type: :feature do
   let(:edit_vacancies_path) do
     "/organisations/AO/courses/#{course_attributes[:course_code]}/vacancies"
   end
+  let!(:sync_courses_request_stub) do
+    stub_request(
+      :post,
+      "http://localhost:3001/api/v2/providers/AO/courses/" \
+        "#{course_attributes[:course_code]}/sync_with_search_and_compare"
+    ).to_return(status: 201, body: "")
+  end
 
   before do
     stub_omniauth
@@ -35,12 +42,6 @@ feature 'Edit course vacancies', type: :feature do
       "/providers/AO/courses/#{course_attributes[:course_code]}",
       course
     )
-
-    stub_request(
-      :post,
-      "http://localhost:3001/api/v2/providers/AO/courses/" \
-        "#{course_attributes[:course_code]}/sync_with_search_and_compare"
-    ).to_return(status: 201, body: "")
 
     visit edit_vacancies_path
   end
@@ -96,6 +97,7 @@ feature 'Edit course vacancies', type: :feature do
         "#{site.attributes[:location_name]} (Full time)",
         checked: false
       )
+      expect(sync_courses_request_stub).to have_been_requested
     end
 
     scenario 'removing all vacancies' do
@@ -120,6 +122,7 @@ feature 'Edit course vacancies', type: :feature do
         "#{site.attributes[:location_name]} (Part time)",
         checked: false
       )
+      expect(sync_courses_request_stub).to have_been_requested
     end
   end
 
@@ -159,6 +162,7 @@ feature 'Edit course vacancies', type: :feature do
         "#{site.attributes[:location_name]} (Part time)",
         checked: true
       )
+      expect(sync_courses_request_stub).to have_been_requested
     end
   end
 end

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -5,7 +5,8 @@ feature 'Edit course vacancies', type: :feature do
     jsonapi(
       :course,
       :with_full_time_or_part_time_vacancy,
-      site_statuses: [site_status]
+      site_statuses: [site_status],
+      provider: jsonapi(:provider)
     ).render
   end
   let(:course_without_full_time_vacancy) do
@@ -34,6 +35,12 @@ feature 'Edit course vacancies', type: :feature do
       "/providers/AO/courses/#{course_attributes[:course_code]}",
       course
     )
+
+    stub_request(
+      :post,
+      "http://localhost:3001/api/v2/providers/AO/courses/" \
+        "#{course_attributes[:course_code]}/sync_with_search_and_compare"
+    ).to_return(status: 201, body: "")
 
     visit edit_vacancies_path
   end


### PR DESCRIPTION
### Context

After updating vacancies, call custom endpoint to cause course to by
synced with search and compare.

### Changes proposed in this pull request

* Added custom endpoint
* Perform call after **ALL** site statuses have been updated

### Guidance to review
