### PR TITLE
[1210] Add accrediting providers to the courses table

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -3,7 +3,19 @@ class CoursesController < ApplicationController
   before_action :build_course, only: %i[show delete withdraw]
 
   def index
-    @provider = Provider.includes(:courses).find(params[:provider_code]).first
+    @provider = Provider
+      .includes(courses: [:accrediting_provider])
+      .find(params[:provider_code])
+      .first
+
+    @courses_by_accrediting_provider = @provider
+      .courses
+      .group_by { |course| course.accrediting_provider&.provider_name || @provider[:provider_name] }
+      .sort_by { |accrediting_provider, _| accrediting_provider }
+      .map { |pair| [pair[0], pair[1].sort_by(&:name)] }
+      .to_h
+
+    @self_accredited_courses = @courses_by_accrediting_provider.delete(@provider[:provider_name])
   end
 
   def show; end

--- a/app/views/courses/_course_table.html.erb
+++ b/app/views/courses/_course_table.html.erb
@@ -1,8 +1,3 @@
-<h2 class="govuk-heading-m" style="border: 3px solid red">
-  <span class="govuk-caption-m">Accredited body</span>
-  Bradford College
-</h2>
-
 <table class="govuk-table ucas-info-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -3,16 +3,8 @@
 <% content_for :before_content do %>
   <nav class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
-      <% if @has_multiple_providers then %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
-        </li>
-      <% end %>
       <li class="govuk-breadcrumbs__list-item">
         <%= link_to @provider[:provider_name], provider_path(code: @provider[:provider_code]), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        Courses
       </li>
     </ol>
   </nav>
@@ -28,4 +20,13 @@
   <li>copy content between courses</li>
 </ul>
 
-<%= render partial: 'course_table', locals: { courses: @provider.courses } %>
+<%= render partial: 'course_table', locals: { courses: @self_accredited_courses } if @self_accredited_courses %>
+
+<% @courses_by_accrediting_provider.each do |accrediting_provider, courses| %>
+  <h2 class="govuk-heading-m">
+    <span class="govuk-caption-m">Accredited body</span>
+    <%= accrediting_provider %>
+  </h2>
+
+  <%= render partial: 'course_table', locals: { courses: courses } %>
+<% end %>

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :course, class: Hash do
     transient do
-      relationships { %i[site_statuses provider] }
+      relationships { %i[site_statuses provider accrediting_provider] }
+      include_nulls { [] }
     end
 
     sequence(:id)
@@ -16,6 +17,7 @@ FactoryBot.define do
     study_mode    { 'full_time' }
     content_status { "published" }
     ucas_status { 'running' }
+    accrediting_provider { nil }
 
     trait :with_vacancy do
       has_vacancies? { true }
@@ -64,20 +66,9 @@ FactoryBot.define do
         id,
         'courses',
         attributes: data_attributes,
-        relationships: relationships_map
+        relationships: relationships_map,
+        include_nulls: include_nulls
       )
     end
-  end
-
-  factory :courses_response, class: Hash do
-    data {
-      [
-        jsonapi(:course),
-        jsonapi(:course),
-        jsonapi(:course)
-      ]
-    }
-
-    initialize_with { attributes }
   end
 end

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -1,40 +1,72 @@
 require 'rails_helper'
 
 feature 'Index courses', type: :feature do
-  let(:course_1) { jsonapi :course }
-  let(:course_2) { jsonapi :course }
-  let(:courses)  { [course_1, course_2] }
+  let(:course_1) { jsonapi :course, include_nulls: [:accrediting_provider] }
+  let(:course_2) { jsonapi :course, include_nulls: [:accrediting_provider] }
+  let(:course_3) { jsonapi :course, include_nulls: [:accrediting_provider] }
+  let(:courses)  { [course_1, course_2, course_3] }
   let(:provider) do
     jsonapi(:provider, courses: courses)
   end
   let(:provider_response) { provider.render }
-  before do
-    stub_omniauth
-    stub_session_create
-    stub_api_v2_request(
-      "/providers/#{provider.attributes[:provider_code]}?include=courses",
-      provider_response
-    )
+
+  describe "without accrediting providers" do
+    before do
+      stub_omniauth
+      stub_session_create
+      stub_api_v2_request(
+        "/providers/#{provider.attributes[:provider_code]}?include=courses.accrediting_provider",
+        provider_response
+      )
+    end
+
+    scenario 'it shows a list of courses' do
+      visit "/organisations/#{provider.attributes[:provider_code]}/courses"
+
+      expect(find('h1')).to have_content('Courses')
+      expect(page).to have_selector('tbody tr', count: provider.relationships[:courses].size)
+
+      expect(first('[data-qa="courses-table__course"]')).to have_content(course_1.attributes[:name])
+      expect(first('[data-qa="courses-table__course"]')).to have_content(course_2.attributes[:name])
+      expect(first('[data-qa="courses-table__course"]')).to have_content(course_3.attributes[:name])
+      expect(page).to have_selector("a[href=\"https://localhost:44364/organisation/#{provider.attributes[:provider_code]}/course/self/#{course_1.attributes[:course_code]}\"]")
+
+      expect(first('[data-qa="courses-table__ucas-status"]')).to have_content('Running')
+
+      expect(first('[data-qa="courses-table__content-status"]')).to have_content('Published')
+
+      expect(first('[data-qa="courses-table__findable"]')).to have_content('Yes - view online')
+      expect(page).to have_selector("a[href=\"https://localhost:5000/course/#{provider.attributes[:provider_code]}/#{course_1.attributes[:course_code]}\"]")
+
+      expect(first('[data-qa="courses-table__applications"]')).to have_content('Closed')
+      expect(first('[data-qa="courses-table__vacancies"]')).to have_content('No (Edit)')
+    end
   end
 
-  scenario 'it shows a list of courses' do
-    visit "/organisations/#{provider.attributes[:provider_code]}/courses"
+  describe "with accrediting providers" do
+    let(:provider_1) { jsonapi :provider, id: "1", provider_name: "Zacme Scitt" }
+    let(:provider_2) { jsonapi :provider, id: "2", provider_name: "Aacme Scitt" }
 
-    expect(find('h1')).to have_content('Courses')
-    expect(page).to have_selector('tbody tr', count: provider.relationships[:courses].size)
+    let(:course_2) { jsonapi :course, accrediting_provider: provider_1 }
+    let(:course_3) { jsonapi :course, accrediting_provider: provider_2 }
 
-    expect(first('[data-qa="courses-table__course"]')).to have_content(course_1.attributes[:name])
-    expect(first('[data-qa="courses-table__course"]')).to have_content(course_2.attributes[:name])
-    expect(page).to have_selector("a[href=\"https://localhost:44364/organisation/#{provider.attributes[:provider_code]}/course/self/#{course_1.attributes[:course_code]}\"]")
+    before do
+      stub_omniauth
+      stub_session_create
+      stub_api_v2_request(
+        "/providers/#{provider.attributes[:provider_code]}?include=courses.accrediting_provider",
+        provider_response
+      )
+    end
 
-    expect(first('[data-qa="courses-table__ucas-status"]')).to have_content('Running')
+    scenario "it shows a list of courses" do
+      visit "/organisations/#{provider.attributes[:provider_code]}/courses"
 
-    expect(first('[data-qa="courses-table__content-status"]')).to have_content('Published')
+      expect(find('h1')).to have_content('Courses')
+      expect(page).to have_selector('table', count: 3)
 
-    expect(first('[data-qa="courses-table__findable"]')).to have_content('Yes - view online')
-    expect(page).to have_selector("a[href=\"https://localhost:5000/course/#{provider.attributes[:provider_code]}/#{course_1.attributes[:course_code]}\"]")
-
-    expect(first('[data-qa="courses-table__applications"]')).to have_content('Closed')
-    expect(first('[data-qa="courses-table__vacancies"]')).to have_content('No (Edit)')
+      expect(page.all('h2')[0]).to have_content('Accredited body Aacme Scitt')
+      expect(page.all('h2')[1]).to have_content('Accredited body Zacme Scitt')
+    end
   end
 end

--- a/spec/support/mock_jsonapi_serializable.rb
+++ b/spec/support/mock_jsonapi_serializable.rb
@@ -2,16 +2,18 @@ class JSONAPIMockSerializable
   attr_reader :attributes,
               :id,
               :include_counts,
+              :include_nulls,
               :missing_relationships,
               :present_relationships,
               :relationships,
               :type
 
-  def initialize(id, type, attributes:, relationships: {}, include_counts: [])
+  def initialize(id, type, attributes:, relationships: {}, include_counts: [], include_nulls: [])
     @attributes = attributes
     @id = id
     @relationships = relationships
     @include_counts = include_counts
+    @include_nulls = include_nulls
     @missing_relationships = relationships.select { |_r, v| v.nil? }
     @present_relationships = relationships.reject { |_r, v| v.nil? }
     @type = type
@@ -35,7 +37,11 @@ class JSONAPIMockSerializable
   def to_jsonapi_data
     relationships_jsonapi = relationships.map do |name, data|
       [
-        name, if data.nil?
+        name, if name.in?(include_nulls)
+                {
+                  data: nil
+                }
+              elsif data.nil?
                 {
                   meta: { included: false }
                 }


### PR DESCRIPTION
### Context

We need to display accrediting providers above each courses table on the courses page. Where the accrediting provider is set to the parent provider or is set to `null`, they should be displayed as self-accredited (no heading).

### Changes proposed in this pull request

- pulls in the accrediting provider relation from the API
- groups them by their provider name
- sorts the providers by their names
- sorts the courses by their names
- splits out the self-accredited ones to be rendered separately
- tests to go

### Guidance to review

Paired with @heidar, we think there might be a better way to do the `sort_by` and `map(sort_by)` but we did a bit of code golfing and couldn't immediately think of something clearer.

Review without whitespace changes.

### Screenshot

![Screen Shot 2019-04-05 at 16 55 17](https://user-images.githubusercontent.com/1650875/55640493-a0d40700-57c3-11e9-9fda-7b4cd3c188fb.png)
