### PR TITLE
1238 running site statuses

### DIFF
--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -36,7 +36,7 @@ module Courses
     end
 
     def build_site_statuses
-      @site_statuses = @course.site_statuses
+      @site_statuses = @course.site_statuses.select { |site_status| site_status.status == 'running' }
     end
 
     def find_site_status(id)

--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -3,8 +3,7 @@ module Courses
     before_action(
       :authenticate,
       :build_course,
-      :build_site_statuses,
-      :build_first_course
+      :build_site_statuses
     )
 
     def edit; end
@@ -33,15 +32,11 @@ module Courses
   private
 
     def build_course
-      @course = Course.where(provider_code: params[:provider_code]).find(params[:code])
+      @course = Course.where(provider_code: params[:provider_code]).find(params[:code]).first
     end
 
     def build_site_statuses
-      @site_statuses = @course.map(&:site_statuses).flatten
-    end
-
-    def build_first_course
-      @course = @course.first
+      @site_statuses = @course.site_statuses
     end
 
     def find_site_status(id)

--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -36,7 +36,7 @@ module Courses
     end
 
     def build_site_statuses
-      @site_statuses = @course.site_statuses.select { |site_status| site_status.status == 'running' }
+      @site_statuses = @course.site_statuses.select(&:running?)
     end
 
     def find_site_status(id)

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -10,4 +10,8 @@ class SiteStatus < Base
   def full_time_and_part_time_vacancies?
     vac_status == 'both_full_time_and_part_time_vacancies'
   end
+
+  def running?
+    status == 'running'
+  end
 end

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -38,7 +38,7 @@
                 <div class="govuk-form-group">
                   <fieldset class="govuk-fieldset" aria-describedby="has_vacancies_true_hint">
                     <div class="govuk-checkboxes">
-                      <%= f.fields_for :site_status, @course.site_statuses do |sf| %>
+                      <%= f.fields_for :site_status, @site_statuses do |sf| %>
                         <% if @course.study_mode == 'full_time_or_part_time' %>
                           <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :part_time } %>
                           <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :full_time } %>

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :site_status, class: Hash do
     sequence(:id)
+    status { 'running' }
 
     trait :full_time_and_part_time do
       vac_status { 'both_full_time_and_part_time_vacancies' }

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -50,6 +50,31 @@ feature 'Edit course vacancies', type: :feature do
     )
   end
 
+  context 'site_statuses#running' do
+    let(:course) do
+      jsonapi(
+        :course,
+        :with_full_time_or_part_time_vacancy,
+        site_statuses: [running_site_status, non_running_site_status]
+      ).render
+    end
+
+    let(:site_running) { jsonapi(:site, location_name: 'Big Uni') }
+    let(:site_not_running) { jsonapi(:site, location_name: 'Small Uni') }
+
+    let(:running_site_status) do
+      jsonapi(:site_status, :full_time_and_part_time, site: site_running, status: 'running')
+    end
+    let(:non_running_site_status) do
+      jsonapi(:site_status, :full_time_and_part_time, site: site_not_running, status: 'suspended')
+    end
+
+    scenario 'only render site_statuses that are running' do
+      expect(page).to have_field("Big Uni (Full time)")
+      expect(page).to_not have_field("Small Uni (Full time)")
+    end
+  end
+
   context 'removing vacancies' do
     let(:course_without_vacancies) do
       jsonapi(


### PR DESCRIPTION
### Context
Running `site_statuses`

### Changes proposed in this pull request
- Refactor vacancies controller
- Filter `site_statuses` to those only with a status of running

### Guidance to review

# After
<img width="1551" alt="Screenshot 2019-04-03 at 20 10 03" src="https://user-images.githubusercontent.com/3071606/55506089-7dd31700-564c-11e9-9f05-13b15ddf5310.png">

# Before
<img width="1551" alt="Screenshot 2019-04-03 at 20 11 36" src="https://user-images.githubusercontent.com/3071606/55506186-b3780000-564c-11e9-9153-d44b9dc54c2c.png">
