### PR TITLE
[1241] Add support email link to footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -85,6 +85,13 @@
 
     <footer class="govuk-footer " role="contentinfo">
       <div class="govuk-width-container ">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds govuk-footer__content-container">
+            <p class="govuk-footer__content">
+              <%= mail_to "becomingateacher@digital.education.gov.uk", "Contact the Becoming a Teacher team", subject: "Publish teacher training courses feedback", class: "govuk-footer__link" %> for support.
+            </p>
+          </div>
+        </div>
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-visually-hidden">Support links</h2>


### PR DESCRIPTION
### Changes proposed in this pull request
Add support email link to footer

### Guidance to review

# After
<img width="1551" alt="Screenshot 2019-04-03 at 20 18 25" src="https://user-images.githubusercontent.com/3071606/55506571-a7407280-564d-11e9-889c-8301f3ade313.png">
