### PR TITLE
[1246] Add a guidance page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,4 +6,6 @@ class PagesController < ApplicationController
   def terms; end
 
   def privacy; end
+
+  def guidance; end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -100,6 +100,9 @@
                 <%= mail_to "becomingateacher@digital.education.gov.uk", "Give feedback", subject: "Publish teacher training courses feedback", class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">
+                <%= link_to "Publishing guidance", guidance_path, class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
                 <%= link_to "Cookies", cookies_path, class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -1,0 +1,73 @@
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Guidance for Publish teacher training courses</h1>
+
+      <h2 class="govuk-heading-l">New features</h2>
+
+      <p class="govuk-body">We’re introducing a range of new features to Publish. These will allow you to:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>create new courses</li>
+        <li>add and edit your locations</li>
+        <li>update the vacancy status of courses</li>
+        <li>edit course details (eg titles, outcomes, and fee or salary status)</li>
+      </ul>
+
+      <p class="govuk-body">You can access some of these now. Others will be introduced soon.</p>
+
+      <h3 class="govuk-heading-m">Video highlighting these new features</h3>
+
+      <iframe width="100%" height="315" src="https://www.youtube-nocookie.com/embed/nxmtXGy1cCY?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+      <details class="govuk-details govuk-!-margin-top-4">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">Read a transcript of the video here</span>
+        </summary>
+        <div class="govuk-details__text">
+          <p class="govuk-body">In this video we'll show you how to change the vacancy status of a course in Publish teacher training courses. First we'll show you how to switch vacancies off for a course. And then we'll show you how to switch vacancies on.</p>
+
+          <h2 class="govuk-heading-m">To switch vacancies off</h2>
+
+          <p class="govuk-body">First, scroll down to the Courses section on your Organisation Overview page.</p>
+
+          <p class="govuk-body">The Courses section now contains an option allowing you to manage vacancies. Click through.</p>
+
+          <p class="govuk-body">Here - on the Courses page - you'll see the courses table.</p>
+
+          <p class="govuk-body">This shows: your course title and code; its publication status (including whether it's live on the Find tool); whether candidates can currently apply to it; and finally, whether it still has vacancies.</p>
+
+          <p class="govuk-body">To turn vacancies off, scroll down to the course you'd like to update. And then click the Edit option in the Vacancies column.</p>
+
+          <p class="govuk-body">This takes you through to the Edit Vacancies page for this course.</p>
+
+          <p class="govuk-body">Here, you're given two options. You can confirm that the course has no vacancies. Or you can confirm that there are still vacancies for this course.</p>
+
+          <p class="govuk-body">If there are no longer any vacancies - if you're no longer recruiting candidates - click the upper box.</p>
+
+          <p class="govuk-body">Once you click 'Publish changes', this course will be closed to applications. Changes will be published immediately to Find.</p>
+
+          <p class="govuk-body">Click 'Publish changes'. You'll see that the vacancy status of the course has now been updated - a message will tell you that the changes you've just made have been published.</p>
+
+          <p class="govuk-body">If you now go back to the main Courses page, you'll see that the Vacancies column has been updated too. This course is no longer accepting applications.</p>
+
+          <h2 class="govuk-heading-m">To switch vacancies on</h2>
+
+          <p class="govuk-body">Scroll down the Courses page to the courses table. And select the relevant course.</p>
+
+          <p class="govuk-body">As you can see in the Vacancies column, this course currently doesn't have any vacancies.</p>
+
+          <p class="govuk-body">Click 'Edit'.</p>
+
+          <p class="govuk-body">As before, you're given two options. Click the lower box to confirm there are vacancies. You'll see a drop down list - this shows the locations related to this course. Tick those locations that still have vacancies. If any location doesn't have vacancies, untick it.</p>
+
+          <p class="govuk-body">Once you've confirmed that there are vacancies, click 'Publish changes' to open the course to new applications.</p>
+
+          <p class="govuk-body">You'll see a message confirming that the vacancy status of this course has now been updated - the changes you've made have now been published.</p>
+
+          <p class="govuk-body">If you go back to the main Courses page, you'll see that the Vacancies column has been updated in the course table. Candidates will now be able to apply for this course through Find.</p>
+        </div>
+      </details>
+    </div>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get "/cookies", to: "pages#cookies", as: :cookies
   get "/terms-conditions", to: "pages#terms", as: :terms
   get "/privacy-policy", to: "pages#privacy", as: :privacy
+  get "/guidance", to: "pages#guidance", as: :guidance
 
   match '/404', to: 'errors#not_found', via: :all
   match '/403', to: 'errors#forbidden', via: :all

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -24,4 +24,12 @@ RSpec.feature 'View pages', type: :feature do
     visit "/privacy-policy"
     expect(find('h1')).to have_content('Privacy policy')
   end
+
+  scenario "Navigate to /guidance" do
+    stub_omniauth
+    stub_session_create
+
+    visit "/guidance"
+    expect(find('h1')).to have_content('Guidance for Publish teacher training courses')
+  end
 end


### PR DESCRIPTION
### Context

This will be used by providers to learn how to use the new features.

### After

<img width="766" alt="Screenshot 2019-04-04 at 11 43 59" src="https://user-images.githubusercontent.com/1650875/55549939-f4185d80-56ce-11e9-8df4-313d69a7ddf2.png">
