### PR TITLE
Fix add location link

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -3,6 +3,6 @@ class SitesController < ApplicationController
 
   def index
     @provider = Provider.includes(:sites).find(params[:provider_code]).first
-    @sites = @provider.sites
+    @sites = @provider.sites.sort_by(&:location_name)
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -7,4 +7,8 @@ class Provider < Base
   def course_count
     relationships.courses[:meta][:count]
   end
+
+  def opted_in?
+    opted_in == true
+  end
 end

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -40,9 +40,10 @@
           <%= render @sites %>
         </tbody>
       </table>
-
-      <%= link_to "Add a location", "https://forms.gle/Bvkuf6JMY8kPVHPNA", rel: "noopener noreferrer", class: "govuk-button govuk-!-margin-bottom-2", target: :blank %>
-      <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your location details.</p>
+      <% if @provider.opted_in? %>
+        <%= link_to "Add a location", "https://forms.gle/Bvkuf6JMY8kPVHPNA", rel: "noopener noreferrer", class: "govuk-button govuk-!-margin-bottom-2", target: :blank %>
+        <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your location details.</p>
+      <% end %>
     </div>
   </div>
 </main>

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -8,8 +8,13 @@ FactoryBot.define do
     sequence(:id)
     sequence(:institution_code) { |n| "A#{n}" }
     institution_name { "ACME SCITT #{institution_code}" }
+    opted_in { false }
     courses { [] }
     sites { [] }
+
+    trait :opted_in do
+      opted_in { true }
+    end
 
     initialize_with do |_evaluator|
       data_attributes = attributes.except(:id, *relationships)

--- a/spec/features/locations_spec.rb
+++ b/spec/features/locations_spec.rb
@@ -26,5 +26,16 @@ feature 'Index locations', type: :feature do
     expect(find('h1')).to have_content('Locations')
     expect(page).to have_selector('tbody tr', count: 3)
     expect(first('.govuk-table__cell')).to have_content('Main site 1')
+    expect(page).to_not have_link('Add a location')
+  end
+
+  context 'when the provider is opted_in' do
+    let(:provider) do
+      jsonapi(:provider, :opted_in, sites: sites).render
+    end
+
+    scenario 'should show Add Location CTA' do
+      expect(page).to have_link('Add a location')
+    end
   end
 end


### PR DESCRIPTION
### Context
Opted in providers

### Changes proposed in this pull request
- Only show new location CTA if the provider is opted in
- Sort location by name

### Guidance to review
Example: `/organisations/1MN/locations`
