### PR TITLE
[1257] add 'ucas' rails env

### DIFF
--- a/config/environments/ucas.rb
+++ b/config/environments/ucas.rb
@@ -1,0 +1,1 @@
+require Rails.root.join("config/environments/production")

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -7,3 +7,5 @@ manage_backend:
   base_url: https://bat-staging-manage-courses-backend-app.azurewebsites.net
 manage_ui:
   base_url: https://bat-staging-manage-courses-ui-app.azurewebsites.net
+search_ui:
+  base_url: https://bat-staging-search-and-compare-ui-app.azurewebsites.net

--- a/config/settings/ucas.yml
+++ b/config/settings/ucas.yml
@@ -4,8 +4,8 @@ dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   base_url: https://bat-dev-manage-courses-frontend-app.azurewebsites.net
 manage_backend:
-  base_url: https://bat-dev-manage-courses-backend-app.azurewebsites.net
+  base_url: https://bat-ucas-mcbe-as.azurewebsites.net
 manage_ui:
-  base_url: https://bat-dev-manage-courses-ui-app.azurewebsites.net
+  base_url: https://bat-ucas-mcui-as.azurewebsites.net
 search_ui:
-  base_url: https://bat-dev-search-and-compare-ui-app.azurewebsites.net
+  base_url: https://bat-ucas-sacui-as.azurewebsites.net

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -94,3 +94,6 @@ staging:
 
 qa:
   <<: *production
+
+ucas:
+  <<: *production


### PR DESCRIPTION
Also minor fixes to qa and staging envs.

https://trello.com/c/0zd6xRn9/1257-add-ucas-rails-environment-to-mc-fe

### Context

The UCAS environment  is running in `development`. We want this env to run like the others with it's own `RAILS_ENV` so that we can configure parts of it in the app itself. Part of the reason we want to change this is that the ucas environment is currently broken because it needs the env var `SETTINGS__MANAGE_BACKEND__BASE_URL` but we don't have access to add that in VSTS. If we add a proper Rails env we can just set it using the standard env settings.

### Changes proposed in this pull request

Add `ucas` environment.

### Guidance to review

The `qa` and `staging` environments were both missing the setting `Settings.search_ui.base_url` in the settings file. In `qa` this was being supplied in the application settings in Azure, but for `staging` this was completely missing. Aside from this fix, these changes shouldn't affect any envs other than creating the UCAS one.
