### PR TITLE
[1252] add course delete and withdraw pages

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,11 +1,20 @@
 class CoursesController < ApplicationController
   before_action :authenticate
+  before_action :build_course, only: %i[show delete withdraw]
 
   def index
     @provider = Provider.includes(:courses).find(params[:provider_code]).first
   end
 
-  def show
+  def show; end
+
+  def withdraw; end
+
+  def delete; end
+
+private
+
+  def build_course
     @course = Course.where(provider_code: params[:provider_code]).find(params[:code]).first
   end
 end

--- a/app/views/courses/delete.html.erb
+++ b/app/views/courses/delete.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Delete" %>
+<%= content_for :page_title, "Are you sure you want to delete #{@course.name} (#{@course.course_code})?" %>
 
 <main class="govuk-main-wrapper " id="main-content" role="main">
   <div class="govuk-grid-row">
@@ -20,7 +20,7 @@
 
       <h2 class="govuk-heading-m">Contact support to delete this course</h2>
 
-      <p class="govuk-body">Contact the <%= mail_to 'becomingateacher@digital.education.gov.uk', 'Becoming a teacher team', class: "govuk-link" %> by email to delete this course.</p>
+      <p class="govuk-body">Contact the <%= mail_to 'becomingateacher@digital.education.gov.uk', 'Becoming a teacher team', subject: "Delete #{@course.name} (#{@course.course_code})", class: "govuk-link" %> by email to delete this course.</p>
 
       <p class="govuk-body">In your email include:</p>
       <ul class="govuk-list govuk-list--bullet">

--- a/app/views/courses/delete.html.erb
+++ b/app/views/courses/delete.html.erb
@@ -1,0 +1,32 @@
+<%= content_for :page_title, "Delete" %>
+
+<main class="govuk-main-wrapper " id="main-content" role="main">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @course.name %> (<%= @course.course_code %>)</span>
+        Are you sure you want to delete this course?
+      </h1>
+
+      <p class="govuk-body">You can only delete a course if it hasn’t been published in this cycle.</p>
+
+      <p class="govuk-body">Delete a course if you:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>created it by mistake</li>
+        <li>won’t offer it again</li>
+      </ul>
+
+      <p class="govuk-body">Deleting a course is permanent – you can’t undo it. If you need to recreate a course after deleting it, it will have a new course code.</p>
+
+      <h2 class="govuk-heading-m">Contact support to delete this course</h2>
+
+      <p class="govuk-body">Contact the <%= mail_to 'becomingateacher@digital.education.gov.uk', 'Becoming a teacher team', class: "govuk-link" %> by email to delete this course.</p>
+
+      <p class="govuk-body">In your email include:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>course code</li>
+        <li>course title</li>
+      </ul>
+    </div>
+  </div>
+</main>

--- a/app/views/courses/withdraw.html.erb
+++ b/app/views/courses/withdraw.html.erb
@@ -1,0 +1,31 @@
+<%= content_for :page_title, "Withdraw" %>
+
+<main class="govuk-main-wrapper " id="main-content" role="main">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @course.name %> (<%= @course.course_code %>)</span>
+        Are you sure you want to withdraw this course?
+      </h1>
+
+      <p class="govuk-body">Withdrawing this course will:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>immediately remove it from Find</li>
+        <li>close applications for it (this happens when UCAS Apply updates overnight)</li>
+      </ul>
+
+      <p class="govuk-body">Once you’ve withdrawn a course, you can’t publish it again this cycle.</p>
+
+      <h2 class="govuk-heading-m">Contact support to withdraw this course</h2>
+
+      <p class="govuk-body">Contact the <%= mail_to 'becomingateacher@digital.education.gov.uk', 'Becoming a teacher team', class: "govuk-link" %> by email to withdraw this course.</p>
+
+      <p class="govuk-body">In your email include:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>course code</li>
+        <li>course title</li>
+        <li>a reason why this course needs to  be withdrawn</li>
+      </ul>
+    </div>
+  </div>
+</main>

--- a/app/views/courses/withdraw.html.erb
+++ b/app/views/courses/withdraw.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Withdraw" %>
+<%= content_for :page_title, "Are you sure you want to withdraw #{@course.name} (#{@course.course_code})?" %>
 
 <main class="govuk-main-wrapper " id="main-content" role="main">
   <div class="govuk-grid-row">
@@ -18,13 +18,13 @@
 
       <h2 class="govuk-heading-m">Contact support to withdraw this course</h2>
 
-      <p class="govuk-body">Contact the <%= mail_to 'becomingateacher@digital.education.gov.uk', 'Becoming a teacher team', class: "govuk-link" %> by email to withdraw this course.</p>
+      <p class="govuk-body">Contact the <%= mail_to 'becomingateacher@digital.education.gov.uk', 'Becoming a teacher team', subject: "Withdraw #{@course.name} (#{@course.course_code})", class: "govuk-link" %> by email to withdraw this course.</p>
 
       <p class="govuk-body">In your email include:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>course code</li>
         <li>course title</li>
-        <li>a reason why this course needs to  be withdrawn</li>
+        <li>a reason why this course needs to be withdrawn</li>
       </ul>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
     resources :courses, param: :code do
       get '/vacancies', on: :member, to: 'courses/vacancies#edit'
       put '/vacancies', on: :member, to: 'courses/vacancies#update'
+      get '/withdraw', on: :member, to: 'courses#withdraw'
+      get '/delete', on: :member, to: 'courses#delete'
     end
 
     resources :sites, path: 'locations', on: :member, only: :index

--- a/spec/features/courses/delete_spec.rb
+++ b/spec/features/courses/delete_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+feature 'Delete course', type: :feature do
+  let(:course) do
+    jsonapi(
+      :course,
+      provider: jsonapi(:provider)
+    ).render
+  end
+  let(:course_attributes) { course[:data][:attributes] }
+
+  before do
+    stub_omniauth
+    stub_session_create
+    stub_api_v2_request(
+      "/providers/AO/courses/#{course_attributes[:course_code]}",
+      course
+    )
+  end
+
+  scenario 'viewing the show courses page' do
+    visit "/organisations/AO/courses/#{course_attributes[:course_code]}/delete"
+
+    expect(find('.govuk-caption-xl')).to have_content(
+      "#{course_attributes[:name]} (#{course_attributes[:course_code]})"
+    )
+    expect(find('.govuk-heading-xl')).to have_content(
+      "Are you sure you want to delete this course?"
+    )
+  end
+end

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -25,14 +25,14 @@ feature 'Index courses', type: :feature do
 
     expect(first('[data-qa="courses-table__course"]')).to have_content(course_1.attributes[:name])
     expect(first('[data-qa="courses-table__course"]')).to have_content(course_2.attributes[:name])
-    expect(page).to have_selector("a[href=\"https://localhost:44364/organisation/#{provider.attributes[:provider_code]}/course/self/X101\"]")
+    expect(page).to have_selector("a[href=\"https://localhost:44364/organisation/#{provider.attributes[:provider_code]}/course/self/#{course_1.attributes[:course_code]}\"]")
 
     expect(first('[data-qa="courses-table__ucas-status"]')).to have_content('Running')
 
     expect(first('[data-qa="courses-table__content-status"]')).to have_content('Published')
 
     expect(first('[data-qa="courses-table__findable"]')).to have_content('Yes - view online')
-    expect(page).to have_selector("a[href=\"https://localhost:5000/course/#{provider.attributes[:provider_code]}/X101\"]")
+    expect(page).to have_selector("a[href=\"https://localhost:5000/course/#{provider.attributes[:provider_code]}/#{course_1.attributes[:course_code]}\"]")
 
     expect(first('[data-qa="courses-table__applications"]')).to have_content('Closed')
     expect(first('[data-qa="courses-table__vacancies"]')).to have_content('No (Edit)')

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -1,29 +1,23 @@
 require 'rails_helper'
 
 feature 'Show course', type: :feature do
-  let(:course) do
-    jsonapi(
-      :course,
-      provider: jsonapi(:provider)
-    ).render
-  end
-  let(:course_attributes) { course[:data][:attributes] }
-
+  let(:course) { jsonapi :course }
+  let(:course_response) { course.render }
   before do
     stub_omniauth
     stub_session_create
     stub_api_v2_request(
-      "/providers/AO/courses/#{course_attributes[:course_code]}",
-      course
+      "/providers/A0/courses/#{course.attributes[:course_code]}",
+      course_response
     )
   end
 
   scenario 'viewing the show courses page' do
-    visit "/organisations/AO/courses/#{course_attributes[:course_code]}"
+    visit "/organisations/A0/courses/#{course.attributes[:course_code]}"
 
-    expect(find('.govuk-caption-xl')).to have_content(course_attributes[:description])
+    expect(find('.govuk-caption-xl')).to have_content(course.attributes[:description])
     expect(find('.govuk-heading-xl')).to have_content(
-      "#{course_attributes[:name]} (#{course_attributes[:course_code]})"
+      "#{course.attributes[:name]} (#{course.attributes[:course_code]})"
     )
   end
 end

--- a/spec/features/courses/withdraw_spec.rb
+++ b/spec/features/courses/withdraw_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+feature 'Withdraw course', type: :feature do
+  let(:course) do
+    jsonapi(
+      :course,
+      provider: jsonapi(:provider)
+    ).render
+  end
+  let(:course_attributes) { course[:data][:attributes] }
+
+  before do
+    stub_omniauth
+    stub_session_create
+    stub_api_v2_request(
+      "/providers/AO/courses/#{course_attributes[:course_code]}",
+      course
+    )
+  end
+
+  scenario 'viewing the show courses page' do
+    visit "/organisations/AO/courses/#{course_attributes[:course_code]}/withdraw"
+
+    expect(find('.govuk-caption-xl')).to have_content(
+      "#{course_attributes[:name]} (#{course_attributes[:course_code]})"
+    )
+    expect(find('.govuk-heading-xl')).to have_content(
+      "Are you sure you want to withdraw this course?"
+    )
+  end
+end


### PR DESCRIPTION
### Context
Withdrawing and delete courses

### Changes proposed in this pull request
- Add /withdraw
- Add /delete

### Guidance to review
Find a course on the frontend app and navigate to `/courses/XXX/withdraw` and `/courses/XXX/delete`

# After
![localhost_3000_organisations_2AT_courses_3CXL_withdraw (1)](https://user-images.githubusercontent.com/3071606/55611502-9b53ce00-577d-11e9-9516-1232e5ce4869.png)
![localhost_3000_organisations_2AT_courses_3CXL_delete](https://user-images.githubusercontent.com/3071606/55611485-93942980-577d-11e9-93e0-99ca7b7f1838.png)