### PR TITLE
[1257] remove uneeded setting env vars for base urls

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -105,24 +105,6 @@
             "metadata": {
                 "description": "Connection string for Sentry monitoring."
             }
-        },
-        "settingsManageBackendBaseUrl": {
-            "type": "string",
-            "metadata": {
-                "description": "Base URL for manage-courses-backend."
-            }
-        },
-        "settingsManageUiBaseUrl": {
-            "type": "string",
-            "metadata": {
-                "description": "Base URL for manage-courses-ui."
-            }
-        },
-        "settingsSearchUiBaseUrl": {
-            "type": "string",
-            "metadata": {
-                "description": "Base URL for search-and-compare-ui."
-            }
         }
     },
     "variables": {
@@ -234,18 +216,6 @@
                             {
                                 "name": "SENTRY_DSN",
                                 "value": "[parameters('sentryDSN')]"
-                            },
-                            {
-                                "name": "SETTINGS__MANAGE_BACKEND__BASE_URL",
-                                "value": "[parameters('settingsManageBackendBaseUrl')]"
-                            },
-                            {
-                                "name": "SETTINGS__MANAGE_UI__BASE_URL",
-                                "value": "[parameters('settingsManageUiBaseUrl')]"
-                            },
-                            {
-                                "name": "SETTINGS__SEARCH_UI__BASE_URL",
-                                "value": "[parameters('settingsSearchUiBaseUrl')]"
                             }
                         ]
                     },


### PR DESCRIPTION
Remove unnecessary settings env vars from Azure template. They're being set in the appropriate settings files for the envs.