### PR TITLE
[1259] Rename institution_code to provider_code

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -4,7 +4,7 @@ class ProvidersController < ApplicationController
   def index
     @providers = Provider.all
     render_manage_ui if @providers.empty?
-    redirect_to provider_path(@providers.first.institution_code) if @providers.size == 1
+    redirect_to provider_path(@providers.first.provider_code) if @providers.size == 1
   end
 
   def show

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -1,7 +1,7 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell" data-qa="courses-table__course">
     <%= govuk_link_to "#{ course.attributes[:name] } (#{ course.attributes[:course_code] })",
-      manage_ui_course_page_url(provider_code: @provider[:institution_code], course_code: course.attributes[:course_code]),
+      manage_ui_course_page_url(provider_code: @provider[:provider_code], course_code: course.attributes[:course_code]),
       class: "govuk-link govuk-heading-s govuk-!-margin-bottom-0"
     %>
     <span class="govuk-body-s"><%= course.attributes[:description] %></span>
@@ -15,7 +15,7 @@
   <td class="govuk-table__cell" data-qa="courses-table__findable">
     <% if course.attributes[:findable?] %>
       <%= govuk_link_to "Yes - view online",
-        search_ui_course_page_url(provider_code: @provider[:institution_code], course_code: course.attributes[:course_code])
+        search_ui_course_page_url(provider_code: @provider[:provider_code], course_code: course.attributes[:course_code])
       %>
     <% else %>
       No

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -8,7 +8,7 @@
       </li>
     <% end %>
     <li class="govuk-breadcrumbs__list-item">
-      <%= link_to @provider[:institution_name], provider_path(code: @provider[:institution_code]), class: "govuk-breadcrumbs__link" %>
+      <%= link_to @provider[:institution_name], provider_path(code: @provider[:provider_code]), class: "govuk-breadcrumbs__link" %>
     </li>
     <li class="govuk-breadcrumbs__list-item" aria-current="page">
       Courses

--- a/app/views/providers/_provider.html.erb
+++ b/app/views/providers/_provider.html.erb
@@ -1,6 +1,6 @@
 <li>
   <h2 class="govuk-heading-m">
-    <%= link_to provider.institution_name, provider_path(provider.institution_code), class: "govuk-link" %>
+    <%= link_to provider.institution_name, provider_path(provider.provider_code), class: "govuk-link" %>
     <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block"><%= pluralize(provider.course_count, 'course') %></span>
   </h2>
 </li>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -17,7 +17,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl"><%= @provider[:institution_name] %></h1>
-      <h2 class="govuk-heading-m"><%= govuk_link_to "About your organisation", manage_ui_url("/organisation/#{@provider[:institution_code]}/details") %></h2>
+      <h2 class="govuk-heading-m"><%= govuk_link_to "About your organisation", manage_ui_url("/organisation/#{@provider[:provider_code]}/details") %></h2>
       <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
         <li>write about your organisation</li>
@@ -29,14 +29,14 @@
 
   <div class="govuk-grid-row ">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m"><%= link_to "Locations", provider_sites_path(@provider[:institution_code]), class: "govuk-link" %></h2>
+      <h2 class="govuk-heading-m"><%= link_to "Locations", provider_sites_path(@provider[:provider_code]), class: "govuk-link" %></h2>
       <p class="govuk-body govuk-!-margin-bottom-8">Use this section to add locations</p>
     </div>
   </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m"><%= govuk_link_to "Courses", manage_ui_url("/organisation/#{@provider[:institution_code]}/courses") %></h2>
+      <h2 class="govuk-heading-m"><%= govuk_link_to "Courses", manage_ui_url("/organisation/#{@provider[:provider_code]}/courses") %></h2>
       <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
         <li>write about each course</li>
@@ -48,7 +48,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m"><%= govuk_link_to "Request access for someone else", manage_ui_url("/organisation/#{@provider[:institution_code]}/request-access") %></h2>
+      <h2 class="govuk-heading-m"><%= govuk_link_to "Request access for someone else", manage_ui_url("/organisation/#{@provider[:provider_code]}/request-access") %></h2>
       <p class="govuk-body govuk-!-margin-bottom-8">You can request a DfE Sign-in account for others who manage your courses.</p>
     </div>
   </div>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -3,7 +3,7 @@
 <nav class="govuk-breadcrumbs">
   <ol class="govuk-breadcrumbs__list">
     <li class="govuk-breadcrumbs__list-item">
-      <%= link_to @provider.attributes[:institution_name], provider_path(code: @provider.attributes[:institution_code]), class: "govuk-breadcrumbs__link" %>
+      <%= link_to @provider.attributes[:institution_name], provider_path(code: @provider.attributes[:provider_code]), class: "govuk-breadcrumbs__link" %>
     </li>
   </ol>
 </nav>

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ProvidersController, type: :controller do
 
         it 'returns the show page' do
           get :index
-          expect(response).to redirect_to(action: :show, code: the_provider.attributes[:institution_code])
+          expect(response).to redirect_to(action: :show, code: the_provider.attributes[:provider_code])
         end
       end
 

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -6,8 +6,8 @@ FactoryBot.define do
     end
 
     sequence(:id)
-    sequence(:institution_code) { |n| "A#{n}" }
-    institution_name { "ACME SCITT #{institution_code}" }
+    sequence(:provider_code) { |n| "A#{n}" }
+    institution_name { "ACME SCITT #{provider_code}" }
     opted_in { false }
     courses { [] }
     sites { [] }
@@ -37,9 +37,9 @@ FactoryBot.define do
   factory :providers_response, class: Hash do
     data {
       [
-        jsonapi(:provider, institution_code: "A0", include_counts: %i[courses]).render,
-        jsonapi(:provider, institution_code: "A1", include_counts: %i[courses]).render,
-        jsonapi(:provider, institution_code: "A2", include_counts: %i[courses]).render
+        jsonapi(:provider, provider_code: "A0", include_counts: %i[courses]).render,
+        jsonapi(:provider, provider_code: "A1", include_counts: %i[courses]).render,
+        jsonapi(:provider, provider_code: "A2", include_counts: %i[courses]).render
       ].map { |d| d[:data] }
     }
 

--- a/spec/features/locations_spec.rb
+++ b/spec/features/locations_spec.rb
@@ -18,8 +18,8 @@ feature 'Index locations', type: :feature do
   before do
     stub_omniauth
     stub_session_create
-    stub_api_v2_request("/providers/#{provider_attributes[:institution_code]}?include=sites", provider)
-    visit provider_sites_path(provider_attributes[:institution_code])
+    stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}?include=sites", provider)
+    visit provider_sites_path(provider_attributes[:provider_code])
   end
 
   scenario 'it shows a list of location' do

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -14,8 +14,8 @@ RSpec.feature 'View providers', type: :feature do
   scenario 'Navigate to /organisations/AO' do
     stub_omniauth
     stub_session_create
-    stub_api_v2_request('/providers', jsonapi(:providers_response, data: [jsonapi(:provider, institution_code: "A0")]))
-    stub_api_v2_request('/providers/A0', jsonapi(:providers_response, data: [jsonapi(:provider, institution_code: "A0")]))
+    stub_api_v2_request('/providers', jsonapi(:providers_response, data: [jsonapi(:provider, provider_code: "A0")]))
+    stub_api_v2_request('/providers/A0', jsonapi(:providers_response, data: [jsonapi(:provider, provider_code: "A0")]))
 
     visit('/organisations/A0')
     expect(find('h1')).to have_content('ACME SCITT A0')


### PR DESCRIPTION
### Context

This is needed to match the frontend with the backend API V2. See https://github.com/DFE-Digital/manage-courses-backend/pull/249

### Changes proposed in this pull request

Just rename all mentions of `institution_code` to `provider_code`, no other changes were needed.

### Guidance to review