### PR TITLE
[1258] Explicitly include sites on vacancy pages

### DIFF
--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -34,7 +34,7 @@ module Courses
   private
 
     def build_course
-      @course = Course.where(provider_code: params[:provider_code]).find(params[:code]).first
+      @course = Course.includes(site_statuses: [:site]).where(provider_code: params[:provider_code]).find(params[:code]).first
     end
 
     def build_site_statuses

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -39,7 +39,7 @@ feature 'Edit course vacancies', type: :feature do
     stub_omniauth
     stub_session_create
     stub_api_v2_request(
-      "/providers/AO/courses/#{course_attributes[:course_code]}",
+      "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site",
       course
     )
 
@@ -109,7 +109,7 @@ feature 'Edit course vacancies', type: :feature do
       )
 
       stub_api_v2_request(
-        "/providers/AO/courses/#{course_attributes[:course_code]}",
+        "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site",
         course_without_full_time_vacancy
       )
 
@@ -129,7 +129,7 @@ feature 'Edit course vacancies', type: :feature do
       choose 'There are no vacancies'
 
       stub_api_v2_request(
-        "/providers/AO/courses/#{course_attributes[:course_code]}",
+        "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site",
         course_without_vacancies
       )
 
@@ -154,7 +154,7 @@ feature 'Edit course vacancies', type: :feature do
   context 'adding vacancies' do
     before do
       stub_api_v2_request(
-        "/providers/AO/courses/#{course_attributes[:course_code]}",
+        "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site",
         course_without_full_time_vacancy
       )
       stub_request(
@@ -170,7 +170,7 @@ feature 'Edit course vacancies', type: :feature do
       )
 
       stub_api_v2_request(
-        "/providers/AO/courses/#{course_attributes[:course_code]}",
+        "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site",
         course
       )
 

--- a/spec/requests/courses/vacancies/edit_spec.rb
+++ b/spec/requests/courses/vacancies/edit_spec.rb
@@ -22,7 +22,7 @@ describe 'Edit vacancies' do
       stub_omniauth
       stub_session_create
       stub_api_v2_request(
-        "/providers/AO/courses/#{course_code}",
+        "/providers/AO/courses/#{course_code}?include=site_statuses.site",
         course
       )
       get(edit_vacancies_path)


### PR DESCRIPTION
### Context

This is needed to match up with changes on the backend: https://github.com/DFE-Digital/manage-courses-backend/pull/245

### Changes proposed in this pull request

These changes cause the API request to ask for site statuses and sites
to be included in the course.

### Guidance to review