### PR TITLE
[1217] Fix relation between provider and course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2,8 +2,7 @@ class CoursesController < ApplicationController
   before_action :authenticate
 
   def index
-    @provider = Provider.find(params[:code]).first.attributes
-    @courses = Course.where(provider_code: params[:provider_code])
+    @provider = Provider.includes(:courses).find(params[:provider_code]).first
   end
 
   def show

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,5 +1,5 @@
 class Provider < Base
-  has_many :courses, param: :provider_code
+  has_many :courses, param: :course_code
   has_many :sites
 
   self.primary_key = :provider_code

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -27,5 +27,5 @@
     <li>copy content between courses</li>
   </ul>
 
-  <%= render partial: 'course_table', locals: { courses: @courses } %>
+  <%= render partial: 'course_table', locals: { courses: @provider.courses } %>
 </main>

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -48,6 +48,10 @@ FactoryBot.define do
       study_mode { 'part_time' }
     end
 
+    after :initialize do |course|
+      course.provider_code = provider.provider_code if course.provider
+    end
+
     initialize_with do |_evaluator|
       data_attributes = attributes.except(:id, *relationships)
       relationships_map = Hash[

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -1,29 +1,38 @@
 require 'rails_helper'
 
 feature 'Index courses', type: :feature do
+  let(:course_1) { jsonapi :course }
+  let(:course_2) { jsonapi :course }
+  let(:courses)  { [course_1, course_2] }
+  let(:provider) do
+    jsonapi(:provider, courses: courses)
+  end
+  let(:provider_response) { provider.render }
   before do
     stub_omniauth
     stub_session_create
-    stub_api_v2_request('/providers', jsonapi(:providers_response))
-    stub_api_v2_request('/providers/AO/courses', jsonapi(:courses_response))
+    stub_api_v2_request(
+      "/providers/#{provider.attributes[:provider_code]}?include=courses",
+      provider_response
+    )
   end
 
   scenario 'it shows a list of courses' do
-    visit '/organisations/AO/courses'
+    visit "/organisations/#{provider.attributes[:provider_code]}/courses"
 
     expect(find('h1')).to have_content('Courses')
-    expect(page).to have_selector('tbody tr', count: 3)
+    expect(page).to have_selector('tbody tr', count: provider.relationships[:courses].size)
 
-    expect(first('[data-qa="courses-table__course"]')).to have_content('English (X101)')
-    expect(first('[data-qa="courses-table__course"]')).to have_content('PGCE with QTS')
-    expect(page).to have_selector("a[href=\"https://localhost:44364/organisation/A0/course/self/X101\"]")
+    expect(first('[data-qa="courses-table__course"]')).to have_content(course_1.attributes[:name])
+    expect(first('[data-qa="courses-table__course"]')).to have_content(course_2.attributes[:name])
+    expect(page).to have_selector("a[href=\"https://localhost:44364/organisation/#{provider.attributes[:provider_code]}/course/self/X101\"]")
 
     expect(first('[data-qa="courses-table__ucas-status"]')).to have_content('Running')
 
     expect(first('[data-qa="courses-table__content-status"]')).to have_content('Published')
 
     expect(first('[data-qa="courses-table__findable"]')).to have_content('Yes - view online')
-    expect(page).to have_selector("a[href=\"https://localhost:5000/course/A0/X101\"]")
+    expect(page).to have_selector("a[href=\"https://localhost:5000/course/#{provider.attributes[:provider_code]}/X101\"]")
 
     expect(first('[data-qa="courses-table__applications"]')).to have_content('Closed')
     expect(first('[data-qa="courses-table__vacancies"]')).to have_content('No (Edit)')


### PR DESCRIPTION
### Context

**Ignore the branch name, this is a precursor to doing that.** 

Before we were trying to map them with `provider_code`, which isn't an
attribute on course. The API returns the `provider_code` as
`institution_code` instead.

I've fixed these and fixed all the tests that failed by doing so. Most
of them were due to explicitly looking providers up by `provider_code`.

This allows us to look up a provider and do `provider.courses`, assuming
that we included courses in the provider lookup.

Likewise, we can do `course.provider`, assuming the provider was
included in the course lookup.

### Changes proposed in this pull request

Change all mentions of `provider_code` to correctly call `institution_code`. The exception to this is the routes and `params`, because the route is still `/provider` and this `code` becomes `provider_code`.

### Guidance to review

This probably needs some manual testing as we're too far removed from the actual API to know if this will work or not.