### PR TITLE
[1247] add transition info page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,4 +8,6 @@ class PagesController < ApplicationController
   def privacy; end
 
   def guidance; end
+
+  def transition; end
 end

--- a/app/views/pages/transition.html.erb
+++ b/app/views/pages/transition.html.erb
@@ -1,0 +1,25 @@
+<%= content_for :page_title, "New features" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Important new features</h1>
+    <p class="govuk-body">You now have access to new features, allowing you to:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>create new courses</li>
+      <li>add and edit your locations</li>
+      <li>update the vacancy status of courses</li>
+      <li>edit course details (eg titles, outcomes, and fee or salary status)</li>
+    </ul>
+
+    <h2 class="govuk-heading-m">Stop using UCAS to manage your courses</h2>
+
+    <p class="govuk-body">You can no longer use UCAS to add or edit courses. All course management must now be done in this service.</p>
+
+    <p class="govuk-body">You’ll still need to use UCAS to view and manage course applications. This is because candidates will continue to apply for courses through UCAS.</p>
+
+    <hr class="govuk-section-break govuk-section-break--m">
+
+    <%= link_to "Continue", providers_path, class: "govuk-button" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
   get "/terms-conditions", to: "pages#terms", as: :terms
   get "/privacy-policy", to: "pages#privacy", as: :privacy
   get "/guidance", to: "pages#guidance", as: :guidance
+  get "/transition", to: "pages#transition", as: :transition
 
   match '/404', to: 'errors#not_found', via: :all
   match '/403', to: 'errors#forbidden', via: :all

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -29,4 +29,13 @@ RSpec.feature 'View pages', type: :feature do
     visit "/guidance"
     expect(find('h1')).to have_content('Guidance for Publish teacher training courses')
   end
+
+  scenario "Navigate to /transition" do
+    stub_omniauth
+    stub_session_create
+
+    visit "/transition"
+    expect(find('h1')).to have_content('Important new features')
+    expect(page).to have_link('Continue')
+  end
 end


### PR DESCRIPTION
### Context
Transition 🎉 

### Changes proposed in this pull request
- Add static `/transition` page ready to be hooked up the users in a later story/pr

### Guidance to review
# After
![localhost_3000_transition](https://user-images.githubusercontent.com/3071606/55680934-43050380-5918-11e9-9599-325f71ca4b4a.png)
