### PR TITLE
[1260] Rename institution_name to provider_name

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -9,7 +9,7 @@
         </li>
       <% end %>
       <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @provider[:institution_name], provider_path(code: @provider[:provider_code]), class: "govuk-breadcrumbs__link" %>
+        <%= link_to @provider[:provider_name], provider_path(code: @provider[:provider_code]), class: "govuk-breadcrumbs__link" %>
       </li>
       <li class="govuk-breadcrumbs__list-item" aria-current="page">
         Courses

--- a/app/views/providers/_provider.html.erb
+++ b/app/views/providers/_provider.html.erb
@@ -1,6 +1,6 @@
 <li>
   <h2 class="govuk-heading-m">
-    <%= link_to provider.institution_name, provider_path(provider.provider_code), class: "govuk-link" %>
+    <%= link_to provider.provider_name, provider_path(provider.provider_code), class: "govuk-link" %>
     <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block"><%= pluralize(provider.course_count, 'course') %></span>
   </h2>
 </li>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, @provider[:institution_name] %>
+<%= content_for :page_title, @provider[:provider_name] %>
 
 <% if @has_multiple_providers then %>
   <% content_for :before_content do %>
@@ -8,7 +8,7 @@
           <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
         </li>
         <li class="govuk-breadcrumbs__list-item" aria-current="page">
-          <%= @provider[:institution_name] %>
+          <%= @provider[:provider_name] %>
         </li>
       </ol>
     </nav>
@@ -17,7 +17,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= @provider[:institution_name] %></h1>
+    <h1 class="govuk-heading-xl"><%= @provider[:provider_name] %></h1>
     <h2 class="govuk-heading-m"><%= govuk_link_to "About your organisation", manage_ui_url("/organisation/#{@provider[:provider_code]}/details") %></h2>
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -4,7 +4,7 @@
   <nav class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @provider.attributes[:institution_name], provider_path(code: @provider.attributes[:provider_code]), class: "govuk-breadcrumbs__link" %>
+        <%= link_to @provider.attributes[:provider_name], provider_path(code: @provider.attributes[:provider_code]), class: "govuk-breadcrumbs__link" %>
       </li>
     </ol>
   </nav>

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
     sequence(:id)
     sequence(:provider_code) { |n| "A#{n}" }
-    institution_name { "ACME SCITT #{provider_code}" }
+    provider_name { "ACME SCITT #{provider_code}" }
     opted_in { false }
     courses { [] }
     sites { [] }


### PR DESCRIPTION
### Context

This is needed to match the frontend with the backend API V2. See https://github.com/DFE-Digital/manage-courses-backend/pull/251

### Changes proposed in this pull request

Just rename all mentions of `institution_name` to `provider_name`, no other changes were needed.

### Guidance to review
n/a