### PR TITLE
[1241] Tweaks to contact links

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -15,6 +15,7 @@ class CoursesController < ApplicationController
 private
 
   def build_course
-    @course = Course.where(provider_code: params[:provider_code]).find(params[:code]).first
+    @provider_code = params[:provider_code]
+    @course = Course.where(provider_code: @provider_code).find(params[:code]).first
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,6 +1,4 @@
 module ViewHelper
-  BECOMING_A_TEACHER_MAILBOX_EMAIL = 'becomingateacher@digital.education.gov.uk'.freeze
-
   def govuk_link_to(body, url, html_options = { class: 'govuk-link' })
     link_to body, url, html_options
   end
@@ -25,7 +23,8 @@ module ViewHelper
     search_ui_url("/course/#{provider_code}/#{course_code}")
   end
 
-  def bat_contact_mail_to(name = BECOMING_A_TEACHER_MAILBOX_EMAIL, subject: nil, link_class: "govuk-link")
-    mail_to BECOMING_A_TEACHER_MAILBOX_EMAIL, name, subject: subject, class: link_class
+  def bat_contact_mail_to(name = nil, subject: nil, link_class: "govuk-link")
+    contact_email_address = Settings.service_support.contact_email_address
+    mail_to contact_email_address, name || contact_email_address, subject: subject, class: link_class
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,4 +1,6 @@
 module ViewHelper
+  BECOMING_A_TEACHER_MAILBOX_EMAIL = 'becomingateacher@digital.education.gov.uk'.freeze
+
   def govuk_link_to(body, url, html_options = { class: 'govuk-link' })
     link_to body, url, html_options
   end
@@ -21,5 +23,9 @@ module ViewHelper
 
   def search_ui_course_page_url(provider_code:, course_code:)
     search_ui_url("/course/#{provider_code}/#{course_code}")
+  end
+
+  def bat_contact_mail_to(name = BECOMING_A_TEACHER_MAILBOX_EMAIL, subject: nil, link_class: "govuk-link")
+    mail_to BECOMING_A_TEACHER_MAILBOX_EMAIL, name, subject: subject, class: link_class
   end
 end

--- a/app/views/courses/delete.html.erb
+++ b/app/views/courses/delete.html.erb
@@ -19,7 +19,7 @@
 
     <h2 class="govuk-heading-m">Contact support to delete this course</h2>
 
-    <p class="govuk-body">Contact the <%= mail_to 'becomingateacher@digital.education.gov.uk', 'Becoming a teacher team', subject: "Delete #{@course.name} (#{@course.course_code})", class: "govuk-link" %> by email to delete this course.</p>
+    <p class="govuk-body">Contact the <%= bat_contact_mail_to 'Becoming a teacher team', subject: "Delete #{@course.name} (#{@course.course_code})" %> by email to delete this course.</p>
 
     <p class="govuk-body">In your email include:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/courses/delete.html.erb
+++ b/app/views/courses/delete.html.erb
@@ -19,7 +19,7 @@
 
     <h2 class="govuk-heading-m">Contact support to delete this course</h2>
 
-    <p class="govuk-body">Contact the <%= bat_contact_mail_to 'Becoming a teacher team', subject: "Delete #{@course.name} (#{@course.course_code})" %> by email to delete this course.</p>
+    <p class="govuk-body">Contact the <%= bat_contact_mail_to 'Becoming a teacher team', subject: "Delete #{@course.name} (#{@provider_code}/#{@course.course_code})" %> by email to delete this course.</p>
 
     <p class="govuk-body">In your email include:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/courses/withdraw.html.erb
+++ b/app/views/courses/withdraw.html.erb
@@ -17,7 +17,7 @@
 
     <h2 class="govuk-heading-m">Contact support to withdraw this course</h2>
 
-    <p class="govuk-body">Contact the <%= bat_contact_mail_to 'Becoming a teacher team', subject: "Withdraw #{@course.name} (#{@course.course_code})" %> by email to withdraw this course.</p>
+    <p class="govuk-body">Contact the <%= bat_contact_mail_to 'Becoming a teacher team', subject: "Withdraw #{@course.name} (#{@provider_code}/#{@course.course_code})" %> by email to withdraw this course.</p>
 
     <p class="govuk-body">In your email include:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/courses/withdraw.html.erb
+++ b/app/views/courses/withdraw.html.erb
@@ -17,7 +17,7 @@
 
     <h2 class="govuk-heading-m">Contact support to withdraw this course</h2>
 
-    <p class="govuk-body">Contact the <%= mail_to 'becomingateacher@digital.education.gov.uk', 'Becoming a teacher team', subject: "Withdraw #{@course.name} (#{@course.course_code})", class: "govuk-link" %> by email to withdraw this course.</p>
+    <p class="govuk-body">Contact the <%= bat_contact_mail_to 'Becoming a teacher team', subject: "Withdraw #{@course.name} (#{@course.course_code})" %> by email to withdraw this course.</p>
 
     <p class="govuk-body">In your email include:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">You are not permitted to see this page</h1>
     <p class="govuk-body">This page is restricted to certain users only.</p>
     <p class="govuk-body">
-      <%= mail_to "becomingateacher@digital.education.gov.uk", "Contact us by email to request access to your organisation", subject: "Publish teacher training courses access request", class: "govuk-link" %>
+      <%= bat_contact_mail_to "Contact us by email to request access to your organisation", subject: "Publish teacher training courses access request" %>
     </p>
   </div>
 </div>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">You are not permitted to see this page</h1>
     <p class="govuk-body">This page is restricted to certain users only.</p>
     <p class="govuk-body">
-      <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Publish%20teacher%20training%20courses%20access%20request">Contact us by email to request access to your organisation</a>
+      <%= mail_to "becomingateacher@digital.education.gov.uk", "Contact us by email to request access to your organisation", subject: "Publish teacher training courses access request", class: "govuk-link" %>
     </p>
   </div>
 </div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">Sorry, something went wrong</h1>
     <p class="govuk-body">Sorry, we're experiencing technical difficulties.</p>
     <p class="govuk-body">
-      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">Contact the Becoming a Teacher team</a> if you continue to see this error.
+      <%= mail_to "becomingateacher@digital.education.gov.uk", "Contact the Becoming a Teacher team", class: "govuk-link" %> if you continue to see this error.
     </p>
   </div>
 </div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">Sorry, something went wrong</h1>
     <p class="govuk-body">Sorry, we're experiencing technical difficulties.</p>
     <p class="govuk-body">
-      <%= mail_to "becomingateacher@digital.education.gov.uk", "Contact the Becoming a Teacher team", class: "govuk-link" %> if you continue to see this error.
+      <%= bat_contact_mail_to "Contact the Becoming a Teacher team" %> if you continue to see this error.
     </p>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">Page not found</h1>
     <p class="govuk-body">If you entered a web address please check it was correct.</p>
     <p class="govuk-body">
-      <%= mail_to "becomingateacher@digital.education.gov.uk", "Contact the Becoming a Teacher team", class: "govuk-link" %> if you believe you are seeing this message in error.
+      <%= bat_contact_mail_to "Contact the Becoming a Teacher team" %> if you believe you are seeing this message in error.
     </p>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">Page not found</h1>
     <p class="govuk-body">If you entered a web address please check it was correct.</p>
     <p class="govuk-body">
-      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">Contact the Becoming a Teacher team</a> if you believe you are seeing this message in error.
+      <%= mail_to "becomingateacher@digital.education.gov.uk", "Contact the Becoming a Teacher team", class: "govuk-link" %> if you believe you are seeing this message in error.
     </p>
   </div>
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds govuk-footer__content-container">
         <p class="govuk-footer__content">
-          <%= mail_to "becomingateacher@digital.education.gov.uk", "Contact the Becoming a Teacher team", subject: "Publish teacher training courses support", class: "govuk-footer__link" %> for support.
+          <%= bat_contact_mail_to "Contact the Becoming a Teacher team", subject: "Publish teacher training courses support" %> for support.
         </p>
       </div>
     </div>
@@ -12,7 +12,7 @@
         <h2 class="govuk-visually-hidden">Support links</h2>
         <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
           <li class="govuk-footer__inline-list-item">
-            <%= mail_to "becomingateacher@digital.education.gov.uk", "Give feedback", subject: "Publish teacher training courses feedback", class: "govuk-footer__link" %>
+            <%= bat_contact_mail_to "Give feedback", subject: "Publish teacher training courses feedback", link_class: "govuk-footer__link" %>
           </li>
           <li class="govuk-footer__inline-list-item">
             <%= link_to "Publishing guidance", guidance_path, class: "govuk-footer__link" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
       <div class="govuk-phase-banner">
         <p class="govuk-phase-banner__content">
           <strong class="govuk-tag govuk-phase-banner__content__tag ">BETA</strong>
-          <span class="govuk-phase-banner__text">This is a new service – your <%= mail_to "becomingateacher@digital.education.gov.uk", "feedback", subject: "Publish teacher training courses feedback", class: "govuk-link" %> will help us to improve it.</span>
+          <span class="govuk-phase-banner__text">This is a new service – your <%= bat_contact_mail_to "feedback", subject: "Publish teacher training courses feedback" %> will help us to improve it.</span>
         </p>
       </div>
 

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -89,7 +89,7 @@
     <h2 class="govuk-heading-l">Contact Info</h2>
 
     <p class="govuk-body">
-      If you have any questions about how your personal information will be used, please contact us at <a href="mailto:becomingateacher@digital.education.gov.uk" class="govuk-link">becomingateacher@digital.education.gov.uk</a> and enter data privacy as a reference. For the Data Protection Officer (DPO) please contact us via gov.uk and mark it for the attention of the ‘DPO’.
+      If you have any questions about how your personal information will be used, please contact us at <%= mail_to "becomingateacher@digital.education.gov.uk", "becomingateacher@digital.education.gov.uk", class: "govuk-link" %> and enter data privacy as a reference. For the Data Protection Officer (DPO) please contact us via gov.uk and mark it for the attention of the ‘DPO’.
     </p>
 
     <h2 class="govuk-heading-l">Last updated</h2>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -89,7 +89,7 @@
     <h2 class="govuk-heading-l">Contact Info</h2>
 
     <p class="govuk-body">
-      If you have any questions about how your personal information will be used, please contact us at <%= mail_to "becomingateacher@digital.education.gov.uk", "becomingateacher@digital.education.gov.uk", class: "govuk-link" %> and enter data privacy as a reference. For the Data Protection Officer (DPO) please contact us via gov.uk and mark it for the attention of the ‘DPO’.
+      If you have any questions about how your personal information will be used, please contact us at <%= bat_contact_mail_to %> and enter data privacy as a reference. For the Data Protection Officer (DPO) please contact us via gov.uk and mark it for the attention of the ‘DPO’.
     </p>
 
     <h2 class="govuk-heading-l">Last updated</h2>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -20,7 +20,7 @@
       This Service is operated by [the Department for Education] (“we”, “our”, or “us”). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
     </p>
     <p class="govuk-body">
-      You can contact us using the following email address: <%= mail_to "becomingateacher@digital.education.gov.uk", "becomingateacher@digital.education.gov.uk", class: "govuk-link" %>
+      You can contact us using the following email address: <%= bat_contact_mail_to %>
     </p>
 
     <h3 class="govuk-heading-m">Access to the Service</h3>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -20,7 +20,7 @@
       This Service is operated by [the Department for Education] (“we”, “our”, or “us”). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
     </p>
     <p class="govuk-body">
-      You can contact us using the following email address: <a href="mailto:becomingateacher@digital.education.gov.uk" class="govuk-link">becomingateacher@digital.education.gov.uk</a>
+      You can contact us using the following email address: <%= mail_to "becomingateacher@digital.education.gov.uk", "becomingateacher@digital.education.gov.uk", class: "govuk-link" %>
     </p>
 
     <h3 class="govuk-heading-m">Access to the Service</h3>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,3 +23,5 @@ manage_ui:
 search_ui:
   # URL of the C# search ui app (search-and-compare-ui)
   base_url: https://localhost:5000
+service_support:
+  contact_email_address: becomingateacher@digital.education.gov.uk


### PR DESCRIPTION
### Context
There is a bit of duplication in how we generate the contact links in the service. Also, I've noticed that we don't include in the provider code in withdraw/delete course emails

### Changes proposed in this pull request
- Add a view helper for generating contact emails
- Add missing provider code to withdraw/delete course emails

### Guidance to review
