### PR TITLE
Move flash messages into main element

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,9 +51,8 @@
 
       <%= yield(:before_content) %>
 
-      <%= render partial: "layouts/flash" if flash.any? %>
-
       <main class="govuk-main-wrapper" id="main-content" role="main">
+        <%= render partial: "layouts/flash" if flash.any? %>
         <%= yield %>
       </main>
     </div>


### PR DESCRIPTION
Flash messages are important and should be read out when skipping to main content.
This also fixes the vertical alignment of the messages.

### Before
![Screen Shot 2019-04-08 at 16 10 24](https://user-images.githubusercontent.com/319055/55735264-e6d5d880-5a18-11e9-9d76-9604aa6fc16d.png)

### After
![Screen Shot 2019-04-08 at 16 10 00](https://user-images.githubusercontent.com/319055/55735263-e6d5d880-5a18-11e9-875d-235d41848a4f.png)


