### PR TITLE
Suppress study mode for vacancies on some locations

### DIFF
--- a/app/views/courses/vacancies/_site_status_checkbox.html.erb
+++ b/app/views/courses/vacancies/_site_status_checkbox.html.erb
@@ -1,4 +1,5 @@
-<div class='govuk-checkboxes__item'>
+<% show_study_mode ||= false %>
+<div class="govuk-checkboxes__item">
   <%= f.check_box(study_mode, checked: vacancy_available_for_course_site_status?(course, f.object, study_mode), class: 'govuk-checkboxes__input') %>
-  <%= f.label(study_mode, "#{f.object.site.location_name} (#{study_mode.to_s.humanize})", class: 'govuk-label govuk-checkboxes__label') %>
+  <%= f.label(study_mode, "#{f.object.site.location_name}#{show_study_mode ? " (#{study_mode.to_s.humanize})" : ""}", class: 'govuk-label govuk-checkboxes__label') %>
 </div>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -40,8 +40,8 @@
                   <div class="govuk-checkboxes">
                     <%= f.fields_for :site_status, @site_statuses do |sf| %>
                       <% if @course.study_mode == 'full_time_or_part_time' %>
-                        <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :part_time } %>
-                        <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :full_time } %>
+                        <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :part_time, show_study_mode: true } %>
+                        <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :full_time, show_study_mode: true } %>
                       <% elsif @course.study_mode == 'full_time' || @course.study_mode == 'part_time' %>
                         <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: @course.study_mode } %>
                       <% end %>

--- a/spec/requests/courses/vacancies/edit_spec.rb
+++ b/spec/requests/courses/vacancies/edit_spec.rb
@@ -61,8 +61,11 @@ describe 'Edit vacancies' do
           ).render
         end
 
-        it 'shows a full time checkbox' do
+        it 'shows a checkbox without a study mode' do
           expect(response.body).to include(
+            site.attributes[:location_name]
+          )
+          expect(response.body).to_not include(
             "#{site.attributes[:location_name]} (Full time)"
           )
           expect(response.body).not_to include(
@@ -80,11 +83,14 @@ describe 'Edit vacancies' do
           ).render
         end
 
-        it 'shows a part time checkbox' do
+        it 'shows a checkbox without a study mode' do
+          expect(response.body).to include(
+            site.attributes[:location_name]
+          )
           expect(response.body).not_to include(
             "#{site.attributes[:location_name]} (Full time)"
           )
-          expect(response.body).to include(
+          expect(response.body).to_not include(
             "#{site.attributes[:location_name]} (Part time)"
           )
         end


### PR DESCRIPTION
If a course is all part time or all full time, we don't need to add "Full time" and "Part time" to the end of the location label.

### Before
![Screen Shot 2019-04-08 at 16 53 50](https://user-images.githubusercontent.com/319055/55738378-edffe500-5a1e-11e9-82b4-cc28e811b483.png)

### After
![Screen Shot 2019-04-08 at 16 53 57](https://user-images.githubusercontent.com/319055/55738379-edffe500-5a1e-11e9-969a-906eb8d1cb4e.png)


