### PR TITLE
[1210] Courses table applications fix

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -18,8 +18,4 @@ class Course < Base
   def full_time_or_part_time?
     study_mode == 'full_time_or_part_time'
   end
-
-  def has_vacancies?
-    attributes[:has_vacancies?]
-  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -19,10 +19,6 @@ class Course < Base
     study_mode == 'full_time_or_part_time'
   end
 
-  def applications_being_accepted_now?
-    attributes[:applications_being_accepted_now?]
-  end
-
   def has_vacancies?
     attributes[:has_vacancies?]
   end

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -22,7 +22,7 @@
     <% end %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__applications">
-    <%= course.applications_being_accepted_now? ? "Open" : "Closed" %>
+    <%= course.open_for_applications? ? "Open" : "Closed" %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__vacancies">
     <%= course.has_vacancies? ? "Yes" : "No" %>

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -6,7 +6,7 @@ feature 'Index courses', type: :feature do
   let(:course_3) { jsonapi :course, name: 'Physics', include_nulls: [:accrediting_provider] }
   let(:courses)  { [course_1, course_2, course_3] }
   let(:provider) do
-    jsonapi(:provider, courses: courses)
+    jsonapi(:provider, courses: courses, provider_code: 'A123')
   end
   let(:provider_response) { provider.render }
 
@@ -15,13 +15,13 @@ feature 'Index courses', type: :feature do
       stub_omniauth
       stub_session_create
       stub_api_v2_request(
-        "/providers/#{provider.attributes[:provider_code]}?include=courses.accrediting_provider",
+        "/providers/A123?include=courses.accrediting_provider",
         provider_response
       )
     end
 
     scenario 'it shows a list of courses' do
-      visit "/organisations/#{provider.attributes[:provider_code]}/courses"
+      visit "/organisations/A123/courses"
 
       expect(find('h1')).to have_content('Courses')
       expect(page).to have_selector('tbody tr', count: provider.relationships[:courses].size)
@@ -29,14 +29,14 @@ feature 'Index courses', type: :feature do
       first_row, second_row, third_row = find_all('tbody .govuk-table__row').to_a
       within first_row do
         expect(find('[data-qa="courses-table__course"]')).to have_content(course_1.attributes[:name])
-        expect(first_row).to have_selector("a[href=\"https://localhost:44364/organisation/#{provider.attributes[:provider_code]}/course/self/#{course_1.attributes[:course_code]}\"]")
+        expect(first_row).to have_selector("a[href=\"https://localhost:44364/organisation/A123/course/self/#{course_1.attributes[:course_code]}\"]")
 
         expect(find('[data-qa="courses-table__ucas-status"]')).to have_content('Running')
 
         expect(find('[data-qa="courses-table__content-status"]')).to have_content('Published')
 
         expect(find('[data-qa="courses-table__findable"]')).to have_content('Yes - view online')
-        expect(first_row).to have_selector("a[href=\"https://localhost:5000/course/#{provider.attributes[:provider_code]}/#{course_1.attributes[:course_code]}\"]")
+        expect(first_row).to have_selector("a[href=\"https://localhost:5000/course/A123/#{course_1.attributes[:course_code]}\"]")
 
         expect(find('[data-qa="courses-table__applications"]')).to have_content('Closed')
         expect(find('[data-qa="courses-table__vacancies"]')).to have_content('No (Edit)')
@@ -63,13 +63,13 @@ feature 'Index courses', type: :feature do
       stub_omniauth
       stub_session_create
       stub_api_v2_request(
-        "/providers/#{provider.attributes[:provider_code]}?include=courses.accrediting_provider",
+        "/providers/A123?include=courses.accrediting_provider",
         provider_response
       )
     end
 
     scenario "it shows a list of courses" do
-      visit "/organisations/#{provider.attributes[:provider_code]}/courses"
+      visit "/organisations/A123/courses"
 
       expect(find('h1')).to have_content('Courses')
       expect(page).to have_selector('table', count: 3)

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -2,7 +2,14 @@ require 'rails_helper'
 
 feature 'Index courses', type: :feature do
   let(:course_1) { jsonapi :course, name: 'English', include_nulls: [:accrediting_provider] }
-  let(:course_2) { jsonapi :course, name: 'Mathematics', include_nulls: [:accrediting_provider] }
+  let(:course_2) {
+    jsonapi :course,
+      name: 'Mathematics',
+      findable?: true,
+      open_for_applications?: true,
+      has_vacancies?: true,
+      include_nulls: [:accrediting_provider]
+  }
   let(:course_3) { jsonapi :course, name: 'Physics', include_nulls: [:accrediting_provider] }
   let(:courses)  { [course_1, course_2, course_3] }
   let(:provider) do
@@ -44,6 +51,11 @@ feature 'Index courses', type: :feature do
 
       within second_row do
         expect(find('[data-qa="courses-table__course"]')).to have_content(course_2.attributes[:name])
+        expect(find('[data-qa="courses-table__findable"]')).to have_content('Yes - view online')
+        expect(second_row).to have_selector("a[href=\"https://localhost:5000/course/A123/#{course_2.attributes[:course_code]}\"]")
+
+        expect(find('[data-qa="courses-table__applications"]')).to have_content('Open')
+        expect(find('[data-qa="courses-table__vacancies"]')).to have_content('Yes (Edit)')
       end
 
       within third_row do

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 feature 'Index courses', type: :feature do
-  let(:course_1) { jsonapi :course, include_nulls: [:accrediting_provider] }
-  let(:course_2) { jsonapi :course, include_nulls: [:accrediting_provider] }
-  let(:course_3) { jsonapi :course, include_nulls: [:accrediting_provider] }
+  let(:course_1) { jsonapi :course, name: 'English', include_nulls: [:accrediting_provider] }
+  let(:course_2) { jsonapi :course, name: 'Mathematics', include_nulls: [:accrediting_provider] }
+  let(:course_3) { jsonapi :course, name: 'Physics', include_nulls: [:accrediting_provider] }
   let(:courses)  { [course_1, course_2, course_3] }
   let(:provider) do
     jsonapi(:provider, courses: courses)
@@ -26,20 +26,29 @@ feature 'Index courses', type: :feature do
       expect(find('h1')).to have_content('Courses')
       expect(page).to have_selector('tbody tr', count: provider.relationships[:courses].size)
 
-      expect(first('[data-qa="courses-table__course"]')).to have_content(course_1.attributes[:name])
-      expect(first('[data-qa="courses-table__course"]')).to have_content(course_2.attributes[:name])
-      expect(first('[data-qa="courses-table__course"]')).to have_content(course_3.attributes[:name])
-      expect(page).to have_selector("a[href=\"https://localhost:44364/organisation/#{provider.attributes[:provider_code]}/course/self/#{course_1.attributes[:course_code]}\"]")
+      first_row, second_row, third_row = find_all('tbody .govuk-table__row').to_a
+      within first_row do
+        expect(find('[data-qa="courses-table__course"]')).to have_content(course_1.attributes[:name])
+        expect(first_row).to have_selector("a[href=\"https://localhost:44364/organisation/#{provider.attributes[:provider_code]}/course/self/#{course_1.attributes[:course_code]}\"]")
 
-      expect(first('[data-qa="courses-table__ucas-status"]')).to have_content('Running')
+        expect(find('[data-qa="courses-table__ucas-status"]')).to have_content('Running')
 
-      expect(first('[data-qa="courses-table__content-status"]')).to have_content('Published')
+        expect(find('[data-qa="courses-table__content-status"]')).to have_content('Published')
 
-      expect(first('[data-qa="courses-table__findable"]')).to have_content('Yes - view online')
-      expect(page).to have_selector("a[href=\"https://localhost:5000/course/#{provider.attributes[:provider_code]}/#{course_1.attributes[:course_code]}\"]")
+        expect(find('[data-qa="courses-table__findable"]')).to have_content('Yes - view online')
+        expect(first_row).to have_selector("a[href=\"https://localhost:5000/course/#{provider.attributes[:provider_code]}/#{course_1.attributes[:course_code]}\"]")
 
-      expect(first('[data-qa="courses-table__applications"]')).to have_content('Closed')
-      expect(first('[data-qa="courses-table__vacancies"]')).to have_content('No (Edit)')
+        expect(find('[data-qa="courses-table__applications"]')).to have_content('Closed')
+        expect(find('[data-qa="courses-table__vacancies"]')).to have_content('No (Edit)')
+      end
+
+      within second_row do
+        expect(find('[data-qa="courses-table__course"]')).to have_content(course_2.attributes[:name])
+      end
+
+      within third_row do
+        expect(find('[data-qa="courses-table__course"]')).to have_content(course_3.attributes[:name])
+      end
     end
   end
 


### PR DESCRIPTION
### Context
The course table 'Applications' column was showing the wrong information.

### Changes proposed in this pull request
Bolster spec coverage and fix the issue.
