### PR TITLE
[1250] add new course cta

### DIFF
--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -28,16 +28,4 @@ module CourseHelper
       "not_running" => "Not running"
     }[course.attributes[:ucas_status]]
   end
-
-  def new_course_google_form(provider)
-    if provider.accredited_body?
-      Settings.google_forms.new_course_for_accredited_bodies_url
-    else
-      Settings.google_forms.new_course_for_unaccredited_bodies_url
-    end
-  end
-
-  def add_course_link(provider)
-    link_to "Add a new course", new_course_google_form(provider), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: :blank
-  end
 end

--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -31,9 +31,9 @@ module CourseHelper
 
   def new_course_google_form(provider)
     if provider.accredited_body?
-      "https://forms.gle/ktbyArGW5EyiMppf9"
+      Settings.google_forms.new_course_for_accredited_bodies_url
     else
-      "https://forms.gle/WEokN2S4qPcPAZcr5"
+      Settings.google_forms.new_course_for_unaccredited_bodies_url
     end
   end
 

--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -28,4 +28,16 @@ module CourseHelper
       "not_running" => "Not running"
     }[course.attributes[:ucas_status]]
   end
+
+  def new_course_google_form(provider)
+    if provider.accredited_body?
+      "https://forms.gle/ktbyArGW5EyiMppf9"
+    else
+      "https://forms.gle/WEokN2S4qPcPAZcr5"
+    end
+  end
+
+  def add_course_link(provider)
+    link_to "Add a new course", new_course_google_form(provider), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: :blank
+  end
 end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -1,0 +1,11 @@
+module ProviderHelper
+  def add_course_link(provider)
+    google_form_url = if provider.accredited_body?
+                        Settings.google_forms.new_course_for_accredited_bodies_url
+                      else
+                        Settings.google_forms.new_course_for_unaccredited_bodies_url
+                      end
+
+    link_to "Add a new course", google_form_url, class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank"
+  end
+end

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -21,7 +21,7 @@
 </ul>
 
 <% if @provider.courses.count > 10 && @provider.opted_in? %>
-  <%= link_to "Add a new course", "https://goo.gl/forms/kdNksCuwcz7TVtNF2", class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: :blank %>
+  <%= add_course_link(@provider) %>
   <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your course details.</p>
 <% end %>
 
@@ -37,6 +37,6 @@
 <% end %>
 
 <% if @provider.opted_in? %>
-  <%= link_to "Add a new course", "https://goo.gl/forms/kdNksCuwcz7TVtNF2", class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: :blank %>
+  <%= add_course_link(@provider) %>
   <p class="govuk-body-s">You’ll be taken to a Google Form to fill in your course details.</p>
 <% end %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -14,11 +14,16 @@
 
 <p class="govuk-body">Use this section to:</p>
 
-<ul class="govuk-list govuk-list--bullet">
+<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
   <li>write about each course</li>
   <li>preview and publish courses</li>
   <li>copy content between courses</li>
 </ul>
+
+<% if @provider.courses.count > 10 && @provider.opted_in? %>
+  <%= link_to "Add a new course", "https://goo.gl/forms/kdNksCuwcz7TVtNF2", class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: :blank %>
+  <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your course details.</p>
+<% end %>
 
 <%= render partial: 'course_table', locals: { courses: @self_accredited_courses } if @self_accredited_courses %>
 
@@ -29,4 +34,9 @@
   </h2>
 
   <%= render partial: 'course_table', locals: { courses: courses } %>
+<% end %>
+
+<% if @provider.opted_in? %>
+  <%= link_to "Add a new course", "https://goo.gl/forms/kdNksCuwcz7TVtNF2", class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: :blank %>
+  <p class="govuk-body-s">You’ll be taken to a Google Form to fill in your course details.</p>
 <% end %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -41,7 +41,7 @@
       </tbody>
     </table>
     <% if @provider.opted_in? %>
-      <%= link_to "Add a location", "https://forms.gle/Bvkuf6JMY8kPVHPNA", rel: "noopener noreferrer", class: "govuk-button govuk-!-margin-bottom-2", target: :blank %>
+      <%= link_to "Add a location", Settings.google_forms.add_location_url, rel: "noopener noreferrer", class: "govuk-button govuk-!-margin-bottom-2", target: :blank %>
       <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your location details.</p>
     <% end %>
   </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,5 +23,9 @@ manage_ui:
 search_ui:
   # URL of the C# search ui app (search-and-compare-ui)
   base_url: https://localhost:5000
+google_forms:
+  new_course_for_accredited_bodies_url: https://forms.gle/ktbyArGW5EyiMppf9
+  new_course_for_unaccredited_bodies_url: https://forms.gle/WEokN2S4qPcPAZcr5
+  add_location_url: https://forms.gle/Bvkuf6JMY8kPVHPNA
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     sequence(:provider_code) { |n| "A#{n}" }
     provider_name { "ACME SCITT #{provider_code}" }
     opted_in { false }
+    accredited_body? { false }
     courses { [] }
     sites { [] }
 

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -63,7 +63,7 @@ feature 'Index courses', type: :feature do
     end
 
     scenario "it shows 'add a new course' link" do
-      expect(page).to have_link('Add a new course', href: 'https://forms.gle/ktbyArGW5EyiMppf9')
+      expect(page).to have_link('Add a new course', href: Settings.google_forms.new_course_for_accredited_bodies_url)
     end
   end
 
@@ -91,14 +91,14 @@ feature 'Index courses', type: :feature do
     scenario "it shows a list of courses" do
       expect(find('h1')).to have_content('Courses')
       expect(page).to have_selector('table', count: 3)
-      expect(page).to have_link('Add a new course', href: 'https://forms.gle/WEokN2S4qPcPAZcr5')
+      expect(page).to have_link('Add a new course', href: Settings.google_forms.new_course_for_unaccredited_bodies_url)
 
       expect(page.all('h2')[0]).to have_content('Accredited body Aacme Scitt')
       expect(page.all('h2')[1]).to have_content('Accredited body Zacme Scitt')
     end
 
     scenario "it shows 'add a new course' link" do
-      expect(page).to have_link('Add a new course', href: 'https://forms.gle/WEokN2S4qPcPAZcr5')
+      expect(page).to have_link('Add a new course', href: Settings.google_forms.new_course_for_unaccredited_bodies_url)
     end
   end
 

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -85,6 +85,7 @@ feature 'Index courses', type: :feature do
 
       expect(find('h1')).to have_content('Courses')
       expect(page).to have_selector('table', count: 3)
+      expect(page).to_not have_link('Add a new course')
 
       expect(page.all('h2')[0]).to have_content('Accredited body Aacme Scitt')
       expect(page.all('h2')[1]).to have_content('Accredited body Zacme Scitt')

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+feature 'View helpers', type: :helper do
+  describe "#add_course_link" do
+    it "returns correct google form for accrediting providers" do
+      provider = jsonapi(:provider, accredited_body?: true).to_resource
+      expect(helper.add_course_link(provider)).to eq("<a class=\"govuk-button govuk-!-margin-bottom-2\" rel=\"noopener noreferrer\" target=\"_blank\" href=\"https://forms.gle/ktbyArGW5EyiMppf9\">Add a new course</a>")
+    end
+
+    it "returns correct google form for non-accrediting providers" do
+      provider = jsonapi(:provider, accredited_body?: false).to_resource
+      expect(helper.add_course_link(provider)).to eq("<a class=\"govuk-button govuk-!-margin-bottom-2\" rel=\"noopener noreferrer\" target=\"_blank\" href=\"https://forms.gle/WEokN2S4qPcPAZcr5\">Add a new course</a>")
+    end
+  end
+end

--- a/spec/support/mock_jsonapi_serializable.rb
+++ b/spec/support/mock_jsonapi_serializable.rb
@@ -80,4 +80,8 @@ class JSONAPIMockSerializable
       type: type
     }
   end
+
+  def to_resource
+    type.classify.constantize.new(to_jsonapi_data)
+  end
 end


### PR DESCRIPTION
### Context
Add new course

### Changes proposed in this pull request
"Add new course" CTA to `courses#index`

### Guidance to review
# After
![localhost_3000_organisations_2AT_courses](https://user-images.githubusercontent.com/3071606/55797239-d0388b80-5ac3-11e9-8ad3-f6f5e4ff2dee.png)
