### PR TITLE
[1262] Add link to edit training location

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds govuk-footer__content-container">
         <p class="govuk-footer__content">
-          <%= bat_contact_mail_to "Contact the Becoming a Teacher team", subject: "Publish teacher training courses support" %> for support.
+          <%= bat_contact_mail_to "Contact the Becoming a Teacher team", subject: "Publish teacher training courses support", link_class: "govuk-footer__link" %> for support.
         </p>
       </div>
     </div>

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
-    <%= site.attributes[:location_name] %>
+    <%= link_to_if @provider.opted_in?, site.attributes[:location_name], provider_sites_path(site.attributes[:id]), class: "govuk-link govuk-!-font-weight-bold" %>
   </td>
   <td class="govuk-table__cell">
     <%= site.attributes[:code] %> <%= site.attributes[:code] == '-' ? '(dash)' : '' %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -3,6 +3,11 @@
 <% content_for :before_content do %>
   <nav class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
+      <% if @has_multiple_providers then %>
+        <li class="govuk-breadcrumbs__list-item">
+          <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
+        </li>
+      <% end %>
       <li class="govuk-breadcrumbs__list-item">
         <%= link_to @provider.attributes[:provider_name], provider_path(code: @provider.attributes[:provider_code]), class: "govuk-breadcrumbs__link" %>
       </li>

--- a/spec/features/locations/index_spec.rb
+++ b/spec/features/locations/index_spec.rb
@@ -22,11 +22,12 @@ feature 'View locations', type: :feature do
     stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}?include=sites", provider)
   end
 
-  scenario 'it shows a list of location' do
+  scenario 'it shows a list of locations' do
     visit provider_sites_path(provider_attributes[:provider_code])
 
     expect(find('h1')).to have_content('Locations')
     expect(page).to have_selector('tbody tr', count: 3)
+    expect(first('.govuk-table__cell')).to_not have_link('Main site 1')
     expect(first('.govuk-table__cell')).to have_content('Main site 1')
     expect(page).to_not have_link('Add a location')
   end
@@ -46,6 +47,8 @@ feature 'View locations', type: :feature do
 
     scenario 'should show Add Location CTA' do
       visit provider_sites_path(provider_attributes[:provider_code])
+
+      expect(first('.govuk-table__cell')).to have_link('Main site 1')
       expect(page).to have_link('Add a location')
     end
   end


### PR DESCRIPTION
### Context
Edit training locations

### Changes proposed in this pull request
Add link to edit training locations

### Guidance to review
# After
![localhost_3000_organisations_2AT_locations](https://user-images.githubusercontent.com/3071606/55798032-d16ab800-5ac5-11e9-998a-be4a28015885.png)

!DO NOT MERGE!