### PR TITLE
[1210] Update courses table

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -18,4 +18,8 @@ class Course < Base
   def full_time_or_part_time?
     study_mode == 'full_time_or_part_time'
   end
+
+  def is_running?
+    ucas_status == 'running'
+  end
 end

--- a/app/views/courses/_course_table.html.erb
+++ b/app/views/courses/_course_table.html.erb
@@ -1,4 +1,4 @@
-<table class="govuk-table ucas-info-table">
+<table class="govuk-table course-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Course</th>

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -1,5 +1,5 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell" data-qa="courses-table__course">
+  <td class="govuk-table__cell course-table__course-name" data-qa="courses-table__course">
     <%= govuk_link_to "#{ course.attributes[:name] } (#{ course.attributes[:course_code] })",
       manage_ui_course_page_url(provider_code: @provider[:provider_code], course_code: course.attributes[:course_code]),
       class: "govuk-link govuk-heading-s govuk-!-margin-bottom-0"
@@ -10,7 +10,9 @@
     <%= course_ucas_status(course) %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__content-status">
-    <%= render partial: 'content_status_tag', locals: { course: course } %>
+    <% if course.is_running? %>
+      <%= render partial: 'content_status_tag', locals: { course: course } %>
+    <% end %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__findable">
     <% if course.attributes[:findable?] %>
@@ -22,10 +24,16 @@
     <% end %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__applications">
-    <%= course.open_for_applications? ? "Open" : "Closed" %>
+    <% if course.is_running? %>
+      <%= course.open_for_applications? ? "Open" : "Closed" %>
+    <% end %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__vacancies">
-    <%= course.has_vacancies? ? "Yes" : "No" %>
-    (<%= link_to 'Edit', vacancies_provider_course_path(code: course.attributes[:course_code]), class: 'govuk-link' %>)
+    <% if course.is_running? %>
+      <%= course.has_vacancies? ? "Yes" : "No" %>
+      <% if @provider.opted_in? %>
+        (<%= link_to 'Edit', vacancies_provider_course_path(code: course.attributes[:course_code]), class: 'govuk-link' %>)
+      <% end %>
+    <% end %>
   </td>
 </tr>

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -11,3 +11,9 @@ $button-colour: #00823b;
 .text-decoration-underline-dotted {
   text-decoration: underline dotted;
 }
+
+.course-table {
+  &__course-name {
+    width: 33%;
+  }
+}


### PR DESCRIPTION
### Context
Courses table

### Changes proposed in this pull request
- Add dark bottom border to header row
- Don't render `open_for_applications`, `has_vacancies` or `content_status` if the course is not running

# After
![localhost_3000_organisations_2CF_courses](https://user-images.githubusercontent.com/3071606/55856803-49d38680-5b63-11e9-853d-21d971936b65.png)

# c# comparison
![bat-dev-manage-courses-ui-app azurewebsites net_organisation_2CF_courses](https://user-images.githubusercontent.com/3071606/55859300-b05ba300-5b69-11e9-8a1a-1b7317a872cf.png)
