### PR TITLE
[1286] Always show publish status

### DIFF
--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -10,9 +10,7 @@
     <%= course_ucas_status(course) %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__content-status">
-    <% if course.is_running? %>
-      <%= render partial: 'content_status_tag', locals: { course: course } %>
-    <% end %>
+    <%= render partial: 'content_status_tag', locals: { course: course } %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__findable">
     <% if course.attributes[:findable?] %>

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -10,7 +10,7 @@ feature 'Index courses', type: :feature do
       has_vacancies?: true,
       include_nulls: [:accrediting_provider]
   }
-  let(:course_3) { jsonapi :course, findable?: false, name: 'Physics', include_nulls: [:accrediting_provider] }
+  let(:course_3) { jsonapi :course, findable?: false, name: 'Physics', content_status: "empty", include_nulls: [:accrediting_provider] }
   let(:courses)  { [course_1, course_2, course_3] }
   let(:provider) do
     jsonapi(:provider, :opted_in, courses: courses, accredited_body?: true, provider_code: 'A123')
@@ -59,6 +59,7 @@ feature 'Index courses', type: :feature do
 
       within third_row do
         expect(find('[data-qa="courses-table__course"]')).to have_content(course_3.attributes[:name])
+        expect(find('[data-qa="courses-table__content-status"]')).to have_content('Empty')
         expect(find('[data-qa="courses-table__findable"]')).to have_content('No')
         expect(find('[data-qa="courses-table__applications"]')).to have_content('')
         expect(find('[data-qa="courses-table__vacancies"]')).to have_content('')


### PR DESCRIPTION
Add a test for the `empty` content_status which is the default for a course AFAICT.