### PR TITLE
[1253] Initial course page basic details

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,13 +1,9 @@
 class CoursesController < ApplicationController
   before_action :authenticate
   before_action :build_course, only: %i[show delete withdraw]
+  before_action :build_provider, only: %i[index show]
 
   def index
-    @provider = Provider
-      .includes(courses: [:accrediting_provider])
-      .find(params[:provider_code])
-      .first
-
     # rubocop:disable Style/MultilineBlockChain
     @courses_by_accrediting_provider = @provider
       .courses
@@ -36,6 +32,13 @@ class CoursesController < ApplicationController
   def delete; end
 
 private
+
+  def build_provider
+    @provider = Provider
+      .includes(courses: [:accrediting_provider])
+      .find(params[:provider_code])
+      .first
+  end
 
   def build_course
     @provider_code = params[:provider_code]

--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -28,4 +28,16 @@ module CourseHelper
       "not_running" => "Not running"
     }[course.attributes[:ucas_status]]
   end
+
+  def course_outcome(course)
+    course.qualifications.sort.map(&:upcase).join(' with ')
+  end
+
+  def course_study_mode(course)
+    course.study_mode.humanize
+  end
+
+  def course_start_date(course)
+    course.start_date.to_date.strftime("%B %Y")
+  end
 end

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -40,7 +40,7 @@
           Outcome
         </dt>
         <dd class="govuk-summary-list__value" data-qa="course__qualifications">
-          <%= course_qualifications(@course) %>
+          <%= course_outcome(@course) %>
         </dd>
       </div>
 
@@ -66,8 +66,22 @@
         <dt class="govuk-summary-list__key">
           Locations
         </dt>
-        <dd class="govuk-summary-list__value" style="border: 3px solid red">
-          Main Site
+        <dd class="govuk-summary-list__value" data-qa="course__locations">
+          <% if @course.site_statuses.size == 1 then %>
+            <%= @course.site_statuses.first.site.location_name %>
+          <% else %>
+            <ul class="govuk-list courses-locations-list">
+              <% @course.site_statuses.map(&:site).map(&:location_name).each do |location_name| %>
+                <li><%= location_name %></li>
+              <% end %>
+            </ul>
+          <% end %>
+          <% if @provider.sites.size == 1 then %>
+            <p class="govuk-body govuk-hint">You can’t change this because you only have 1&nbsp;location</p>
+            <p class="govuk-body">
+              <%= link_to "Manage all your locations", provider_sites_path(@provider[:provider_code]), class: "govuk-link" %>
+            </p>
+          <% end %>
         </dd>
       </div>
 

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -22,3 +22,99 @@
   <span class="govuk-caption-xl"><%= @course.description %></span>
   <%= @course.name %> (<%= @course.course_code %>)
 </h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Level
+        </dt>
+        <dd class="govuk-summary-list__value" style="border: 3px solid red">
+          Secondary
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Outcome
+        </dt>
+        <dd class="govuk-summary-list__value" data-qa="course__qualifications">
+          <%= course_qualifications(@course) %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Apprenticeship
+        </dt>
+        <dd class="govuk-summary-list__value" style="border: 3px solid red">
+          No
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Full or part time
+        </dt>
+        <dd class="govuk-summary-list__value" data-qa="course__study_mode">
+          <%= course_study_mode(@course) %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Locations
+        </dt>
+        <dd class="govuk-summary-list__value" style="border: 3px solid red">
+          Main Site
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Applications open
+        </dt>
+        <dd class="govuk-summary-list__value" style="border: 3px solid red">
+          10 October 2018
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Course starts
+        </dt>
+        <dd class="govuk-summary-list__value" data-qa="course__start_date">
+          <%= course_start_date(@course) %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Title
+        </dt>
+        <dd class="govuk-summary-list__value" data-qa="course__name">
+          <%= @course.name %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Description
+        </dt>
+        <dd class="govuk-summary-list__value" data-qa="course__description">
+          <%= @course.description %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Course code
+        </dt>
+        <dd class="govuk-summary-list__value" data-qa="course__course_code">
+          <%= @course.course_code %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,7 +1,21 @@
 <%= content_for :page_title, "#{@course.name} (#{@course.course_code}) - Courses" %>
 
 <% content_for :before_content do %>
-  <%= link_to 'Back', provider_courses_path, class: "govuk-back-link" %>
+  <nav class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <% if @has_multiple_providers then %>
+        <li class="govuk-breadcrumbs__list-item">
+          <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
+        </li>
+      <% end %>
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to @provider[:provider_name], provider_path(code: @provider[:provider_code]), class: "govuk-breadcrumbs__link" %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to "Courses", provider_courses_path(@provider[:provider_code]), class: "govuk-breadcrumbs__link" %>
+      </li>
+    </ol>
+  </nav>
 <% end %>
 
 <h1 class="govuk-heading-xl">

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -23,3 +23,7 @@ $button-colour: #00823b;
   background-color: govuk-colour("grey-4");
   padding: govuk-spacing(4);
 }
+
+.courses-locations-list li:last-child {
+  margin-bottom: 0;
+}

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -18,6 +18,8 @@ FactoryBot.define do
     content_status { "published" }
     ucas_status { 'running' }
     accrediting_provider { nil }
+    qualifications { %w[qts pcge] }
+    start_date     { Time.new(2019) }
 
     trait :with_vacancy do
       has_vacancies? { true }

--- a/spec/features/courses/delete_spec.rb
+++ b/spec/features/courses/delete_spec.rb
@@ -13,7 +13,7 @@ feature 'Delete course', type: :feature do
     stub_omniauth
     stub_session_create
     stub_api_v2_request(
-      "/providers/AO/courses/#{course_attributes[:course_code]}",
+      "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site,provider.sites",
       course
     )
   end

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -5,18 +5,20 @@ feature 'Show course', type: :feature do
     jsonapi :course,
       qualifications: %w[qts pgce],
       study_mode: 'full_time',
-      start_date: Time.new(2019)
+      start_date: Time.new(2019),
+      site_statuses: [site_status],
+      provider: jsonapi(:provider)
   }
+  let(:site) { jsonapi(:site) }
+  let(:site_status) do
+    jsonapi(:site_status, :full_time_and_part_time, site: site)
+  end
   let(:course_response) { course.render }
   before do
     stub_omniauth
     stub_session_create
     stub_api_v2_request(
-      "/providers/A0?include=courses.accrediting_provider",
-      jsonapi(:provider).render
-    )
-    stub_api_v2_request(
-      "/providers/A0/courses/#{course.attributes[:course_code]}",
+      "/providers/A0/courses/#{course.attributes[:course_code]}?include=site_statuses.site,provider.sites",
       course_response
     )
   end
@@ -47,6 +49,9 @@ feature 'Show course', type: :feature do
     )
     expect(find('[data-qa=course__course_code]')).to have_content(
       course.attributes[:course_code]
+    )
+    expect(find('[data-qa=course__locations]')).to have_content(
+      site.attributes[:location_name]
     )
   end
 end

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -1,11 +1,20 @@
 require 'rails_helper'
 
 feature 'Show course', type: :feature do
-  let(:course) { jsonapi :course }
+  let(:course) {
+    jsonapi :course,
+      qualifications: %w[qts pgce],
+      study_mode: 'full_time',
+      start_date: Time.new(2019)
+  }
   let(:course_response) { course.render }
   before do
     stub_omniauth
     stub_session_create
+    stub_api_v2_request(
+      "/providers/A0?include=courses.accrediting_provider",
+      jsonapi(:provider).render
+    )
     stub_api_v2_request(
       "/providers/A0/courses/#{course.attributes[:course_code]}",
       course_response
@@ -15,9 +24,29 @@ feature 'Show course', type: :feature do
   scenario 'viewing the show courses page' do
     visit "/organisations/A0/courses/#{course.attributes[:course_code]}"
 
-    expect(find('.govuk-caption-xl')).to have_content(course.attributes[:description])
+    expect(find('.govuk-caption-xl')).to have_content(
+      course.attributes[:description]
+    )
     expect(find('.govuk-heading-xl')).to have_content(
       "#{course.attributes[:name]} (#{course.attributes[:course_code]})"
+    )
+    expect(find('[data-qa=course__qualifications]')).to have_content(
+      'PGCE with QTS'
+    )
+    expect(find('[data-qa=course__study_mode]')).to have_content(
+      'Full time'
+    )
+    expect(find('[data-qa=course__start_date]')).to have_content(
+      'January 2019'
+    )
+    expect(find('[data-qa=course__name]')).to have_content(
+      course.attributes[:name]
+    )
+    expect(find('[data-qa=course__description]')).to have_content(
+      course.attributes[:description]
+    )
+    expect(find('[data-qa=course__course_code]')).to have_content(
+      course.attributes[:course_code]
     )
   end
 end

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -23,34 +23,36 @@ feature 'Show course', type: :feature do
     )
   end
 
+  let(:course_page) { PageObjects::Page::Organisations::Course.new }
+
   scenario 'viewing the show courses page' do
     visit "/organisations/A0/courses/#{course.attributes[:course_code]}"
 
-    expect(find('.govuk-caption-xl')).to have_content(
+    expect(course_page.caption).to have_content(
       course.attributes[:description]
     )
-    expect(find('.govuk-heading-xl')).to have_content(
+    expect(course_page.title).to have_content(
       "#{course.attributes[:name]} (#{course.attributes[:course_code]})"
     )
-    expect(find('[data-qa=course__qualifications]')).to have_content(
+    expect(course_page.qualifications).to have_content(
       'PGCE with QTS'
     )
-    expect(find('[data-qa=course__study_mode]')).to have_content(
+    expect(course_page.study_mode).to have_content(
       'Full time'
     )
-    expect(find('[data-qa=course__start_date]')).to have_content(
+    expect(course_page.start_date).to have_content(
       'January 2019'
     )
-    expect(find('[data-qa=course__name]')).to have_content(
+    expect(course_page.name).to have_content(
       course.attributes[:name]
     )
-    expect(find('[data-qa=course__description]')).to have_content(
+    expect(course_page.description).to have_content(
       course.attributes[:description]
     )
-    expect(find('[data-qa=course__course_code]')).to have_content(
+    expect(course_page.course_code).to have_content(
       course.attributes[:course_code]
     )
-    expect(find('[data-qa=course__locations]')).to have_content(
+    expect(course_page.locations).to have_content(
       site.attributes[:location_name]
     )
   end

--- a/spec/features/courses/withdraw_spec.rb
+++ b/spec/features/courses/withdraw_spec.rb
@@ -13,7 +13,7 @@ feature 'Withdraw course', type: :feature do
     stub_omniauth
     stub_session_create
     stub_api_v2_request(
-      "/providers/AO/courses/#{course_attributes[:course_code]}",
+      "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site,provider.sites",
       course
     )
   end

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -1,0 +1,19 @@
+module PageObjects
+  module Page
+    module Organisations
+      class Course < PageObjects::Base
+        set_url '/organisations/{provider_code}/course/{course_code}'
+
+        element :title, '.govuk-heading-xl'
+        element :caption, '.govuk-caption-xl'
+        element :qualifications, '[data-qa=course__qualifications]'
+        element :study_mode, '[data-qa=course__study_mode]'
+        element :start_date, '[data-qa=course__start_date]'
+        element :name, '[data-qa=course__name]'
+        element :description, '[data-qa=course__description]'
+        element :course_code, '[data-qa=course__course_code]'
+        element :locations, '[data-qa=course__locations]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We need to show further information about the course.

### Changes proposed in this pull request

Populates the course basic details page with info from the course object.

### Guidance to review

This is a first PR that does most of the work and I aim to come back with separate PRs for the rest of the fields. We should merge this sooner than later to prevent it from growing and becoming harder to review.

### Screenshot

<img width="876" alt="Screenshot 2019-04-15 at 14 21 50" src="https://user-images.githubusercontent.com/1650875/56136067-e645c080-5f89-11e9-9193-7b317735215c.png">
