### PR TITLE
[1317] Display course apprenticeships and funding

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -44,6 +44,7 @@ private
     @course = Course
       .includes(site_statuses: [:site])
       .includes(provider: [:sites])
+      .includes(:accrediting_provider)
       .where(provider_code: @provider_code)
       .find(params[:code])
       .first

--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -40,4 +40,19 @@ module CourseHelper
   def course_start_date(course)
     course.start_date.to_date.strftime("%B %Y")
   end
+
+  def course_apprenticeship(course)
+    course.attributes[:funding] == 'apprenticeship' ? 'Yes' : 'No'
+  end
+
+  def course_funding(course)
+    case course.attributes[:funding]
+    when 'salary'
+      'Salaried'
+    when 'apprenticeship'
+      'Teaching apprenticeship (with salary)'
+    when 'fee'
+      'Fee paying (no salary)'
+    end
+  end
 end

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -44,14 +44,25 @@
         </dd>
       </div>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Apprenticeship
-        </dt>
-        <dd class="govuk-summary-list__value" style="border: 3px solid red">
-          No
-        </dd>
-      </div>
+      <% if @provider.accredited_body? then %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Apprenticeship
+          </dt>
+          <dd class="govuk-summary-list__value" data-qa="course__apprenticeship">
+            <%= course_apprenticeship(@course) %>
+          </dd>
+        </div>
+      <% else %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Fee or salary
+          </dt>
+          <dd class="govuk-summary-list__value" data-qa="course__funding">
+            <%= course_funding(@course) %>
+          </dd>
+        </div>
+      <% end %>
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
@@ -84,6 +95,17 @@
           <% end %>
         </dd>
       </div>
+
+      <% unless @provider.accredited_body? then %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Accredited body
+          </dt>
+          <dd class="govuk-summary-list__value" data-qa="course__accredited_body">
+            <%= @course.accrediting_provider&.provider_name %>
+          </dd>
+        </div>
+      <% end %>
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     accrediting_provider { nil }
     qualifications { %w[qts pcge] }
     start_date     { Time.new(2019) }
+    funding        { 'fee' }
 
     trait :with_vacancy do
       has_vacancies? { true }

--- a/spec/features/courses/delete_spec.rb
+++ b/spec/features/courses/delete_spec.rb
@@ -13,7 +13,7 @@ feature 'Delete course', type: :feature do
     stub_omniauth
     stub_session_create
     stub_api_v2_request(
-      "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site,provider.sites",
+      "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site,provider.sites,accrediting_provider",
       course
     )
   end

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 
 feature 'Show course', type: :feature do
+  let(:provider) { jsonapi(:provider, accredited_body?: false) }
   let(:course) {
     jsonapi :course,
       qualifications: %w[qts pgce],
       study_mode: 'full_time',
       start_date: Time.new(2019),
       site_statuses: [site_status],
-      provider: jsonapi(:provider)
+      provider: provider,
+      accrediting_provider: provider
   }
   let(:site) { jsonapi(:site) }
   let(:site_status) do
@@ -18,7 +20,7 @@ feature 'Show course', type: :feature do
     stub_omniauth
     stub_session_create
     stub_api_v2_request(
-      "/providers/A0/courses/#{course.attributes[:course_code]}?include=site_statuses.site,provider.sites",
+      "/providers/A0/courses/#{course.attributes[:course_code]}?include=site_statuses.site,provider.sites,accrediting_provider",
       course_response
     )
   end
@@ -54,6 +56,13 @@ feature 'Show course', type: :feature do
     )
     expect(course_page.locations).to have_content(
       site.attributes[:location_name]
+    )
+    expect { course_page.apprenticeship }.to raise_error(Capybara::ElementNotFound)
+    expect(course_page.funding).to have_content(
+      'Fee paying (no salary)'
+    )
+    expect(course_page.accredited_body).to have_content(
+      provider.attributes[:provider_name]
     )
   end
 end

--- a/spec/features/courses/withdraw_spec.rb
+++ b/spec/features/courses/withdraw_spec.rb
@@ -13,7 +13,7 @@ feature 'Withdraw course', type: :feature do
     stub_omniauth
     stub_session_create
     stub_api_v2_request(
-      "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site,provider.sites",
+      "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site,provider.sites,accrediting_provider",
       course
     )
   end

--- a/spec/helpers/course_helper_spec.rb
+++ b/spec/helpers/course_helper_spec.rb
@@ -36,4 +36,19 @@ RSpec.feature 'View helpers', type: :helper do
       expect(helper.course_ucas_status(build(:course, ucas_status: 'not_running'))).to eq('Not running')
     end
   end
+
+  describe "#course_apprenticeship" do
+    it "returns correct content" do
+      expect(helper.course_apprenticeship(build(:course, funding: 'apprenticeship'))).to eq('Yes')
+      expect(helper.course_apprenticeship(build(:course, funding: 'fee'))).to eq('No')
+    end
+  end
+
+  describe "#course_funding" do
+    it "returns correct content" do
+      expect(helper.course_funding(build(:course, funding: 'salary'))).to eq('Salaried')
+      expect(helper.course_funding(build(:course, funding: 'apprenticeship'))).to eq('Teaching apprenticeship (with salary)')
+      expect(helper.course_funding(build(:course, funding: 'fee'))).to eq('Fee paying (no salary)')
+    end
+  end
 end

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -13,6 +13,9 @@ module PageObjects
         element :description, '[data-qa=course__description]'
         element :course_code, '[data-qa=course__course_code]'
         element :locations, '[data-qa=course__locations]'
+        element :apprenticeship, '[data-qa=course__apprenticeship]'
+        element :funding, '[data-qa=course__funding]'
+        element :accredited_body, '[data-qa=course__accredited_body]'
       end
     end
   end


### PR DESCRIPTION
### Context

We need to expose all the things.

### Changes proposed in this pull request

Use the `funding` field which is now being passed in from the backend.

### Guidance to review

We don't have a request spec for the presence of the `apprenticeship` in the frontend and the hiding of the other two but ehhhh.

### Screenshot

<img width="642" alt="Screenshot 2019-04-16 at 17 23 13" src="https://user-images.githubusercontent.com/1650875/56227018-71978280-606c-11e9-863e-5a1584029a26.png">
