### PR TITLE
[1315] Display applications_open in courses show

### DIFF
--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -55,4 +55,8 @@ module CourseHelper
       'Fee paying (no salary)'
     end
   end
+
+  def course_applications_open(course)
+    course.attributes[:applications_open_from]&.to_date&.strftime("%-d %B %Y")
+  end
 end

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -111,8 +111,8 @@
         <dt class="govuk-summary-list__key">
           Applications open
         </dt>
-        <dd class="govuk-summary-list__value" style="border: 3px solid red">
-          10 October 2018
+        <dd class="govuk-summary-list__value" data-qa="course__applications_open">
+          <%= course_applications_open(@course) %>
         </dd>
       </div>
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     qualifications { %w[qts pcge] }
     start_date     { Time.new(2019) }
     funding        { 'fee' }
+    applications_open_from { DateTime.new(2019).utc.iso8601 }
 
     trait :with_vacancy do
       has_vacancies? { true }

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -64,5 +64,8 @@ feature 'Show course', type: :feature do
     expect(course_page.accredited_body).to have_content(
       provider.attributes[:provider_name]
     )
+    expect(course_page.applications_open).to have_content(
+      '1 January 2019'
+    )
   end
 end

--- a/spec/helpers/course_helper_spec.rb
+++ b/spec/helpers/course_helper_spec.rb
@@ -51,4 +51,10 @@ RSpec.feature 'View helpers', type: :helper do
       expect(helper.course_funding(build(:course, funding: 'fee'))).to eq('Fee paying (no salary)')
     end
   end
+
+  describe "#course_applications_open" do
+    it "returns correct content" do
+      expect(helper.course_applications_open(build(:course, applications_open_from: '2019-01-01T00:00:00Z'))).to eq('1 January 2019')
+    end
+  end
 end

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -16,6 +16,7 @@ module PageObjects
         element :apprenticeship, '[data-qa=course__apprenticeship]'
         element :funding, '[data-qa=course__funding]'
         element :accredited_body, '[data-qa=course__accredited_body]'
+        element :applications_open, '[data-qa=course__applications_open]'
       end
     end
   end


### PR DESCRIPTION
### Context

We need to expose all the course information on the courses show page.

### Changes proposed in this pull request

- Present applications_open in courses show view

### Guidance to review

When `applications_open_from` is set to null on the API, for example for courses that don't have any findable site statuses, the frontend will display the `Applications open` info but there will be an empty
string.

### Screenshot

Almost there!

<img width="731" alt="Screenshot 2019-04-17 at 16 51 54" src="https://user-images.githubusercontent.com/1650875/56302175-22675580-6131-11e9-9fda-c9b63a52f0e7.png">