### PR TITLE
[1326] Display course level in courses show page

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -56,8 +56,8 @@
             <dt class="govuk-summary-list__key">
               Level
             </dt>
-            <dd class="govuk-summary-list__value" style="border: 3px solid red">
-              Secondary
+            <dd class="govuk-summary-list__value" data-qa="course__level">
+              <%= @course.attributes[:level]&.humanize %>
             </dd>
           </div>
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -23,6 +23,7 @@ FactoryBot.define do
     funding        { 'fee' }
     applications_open_from { DateTime.new(2019).utc.iso8601 }
     is_send? { false }
+    level { "secondary" }
 
     trait :with_vacancy do
       has_vacancies? { true }

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -70,5 +70,8 @@ feature 'Show course', type: :feature do
     expect(course_page.is_send).to have_content(
       'No'
     )
+    expect(course_page.level).to have_content(
+      'Secondary'
+    )
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -18,6 +18,7 @@ module PageObjects
         element :accredited_body, '[data-qa=course__accredited_body]'
         element :applications_open, '[data-qa=course__applications_open]'
         element :is_send, '[data-qa=course__is_send]'
+        element :level, '[data-qa=course__level]'
       end
     end
   end


### PR DESCRIPTION
### Context

We need to display all the fields in the courses show page.

### Changes proposed in this pull request

Use the `level` from the API.

### Guidance to review

🚢 