### PR TITLE
[1328] Wrap courses table with tabs component

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -23,143 +23,171 @@
   <%= @course.name %> (<%= @course.course_code %>)
 </h1>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Level
-        </dt>
-        <dd class="govuk-summary-list__value" style="border: 3px solid red">
-          Secondary
-        </dd>
-      </div>
+<div class="course-tabs govuk-tabs">
+  <h2 class="govuk-tabs__title">Contents</h2>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          SEND
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__is_send">
-          <%= course_send(@course) %>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Outcome
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__qualifications">
-          <%= course_outcome(@course) %>
-        </dd>
-      </div>
-
-      <% if @provider.accredited_body? then %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Apprenticeship
-          </dt>
-          <dd class="govuk-summary-list__value" data-qa="course__apprenticeship">
-            <%= course_apprenticeship(@course) %>
-          </dd>
-        </div>
-      <% else %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Fee or salary
-          </dt>
-          <dd class="govuk-summary-list__value" data-qa="course__funding">
-            <%= course_funding(@course) %>
-          </dd>
-        </div>
+  <ul class="govuk-tabs__list" role="tablist">
+    <li class="govuk-tabs__list-item" role="presentation">
+      <%=
+        link_to manage_ui_course_page_url( provider_code: @provider[:provider_code], course_code: @course.attributes[:course_code]),
+        class: "govuk-tabs__tab", role: 'tab', tabindex: '0', aria: { selected: false } do
+      %>
+        Description<br>
+        <span class="govuk-body-s govuk-!-font-weight-regular pointer-events-none">Content, fees and eligibility</span>
       <% end %>
+    </li>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Full or part time
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__study_mode">
-          <%= course_study_mode(@course) %>
-        </dd>
-      </div>
+    <li class="govuk-tabs__list-item" role="presentation">
+      <%=
+        link_to "#information",
+        class: "govuk-tabs__tab govuk-tabs__tab--selected", id: "tab_information", role: 'tab', tabindex: '-1', aria: { selected: true } do
+      %>
+        Basic details<br>
+        <span class="govuk-body-s govuk-!-font-weight-regular pointer-events-none">Locations, outcome, subject</span>
+      <% end %>
+    </li>
+  </ul>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Locations
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__locations">
-          <% if @course.site_statuses.size == 1 then %>
-            <%= @course.site_statuses.first.site.location_name %>
+  <section class="govuk-tabs__panel" id="information" role="tabpanel" aria-labelledby="tab_information">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Level
+            </dt>
+            <dd class="govuk-summary-list__value" style="border: 3px solid red">
+              Secondary
+            </dd>
+          </div>
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              SEND
+            </dt>
+            <dd class="govuk-summary-list__value" data-qa="course__is_send">
+              <%= course_send(@course) %>
+            </dd>
+          </div>
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Outcome
+            </dt>
+            <dd class="govuk-summary-list__value" data-qa="course__qualifications">
+              <%= course_outcome(@course) %>
+            </dd>
+          </div>
+
+          <% if @provider.accredited_body? then %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Apprenticeship
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__apprenticeship">
+                <%= course_apprenticeship(@course) %>
+              </dd>
+            </div>
           <% else %>
-            <ul class="govuk-list courses-locations-list">
-              <% @course.site_statuses.map(&:site).map(&:location_name).each do |location_name| %>
-                <li><%= location_name %></li>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Fee or salary
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__funding">
+                <%= course_funding(@course) %>
+              </dd>
+            </div>
+          <% end %>
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Full or part time
+            </dt>
+            <dd class="govuk-summary-list__value" data-qa="course__study_mode">
+              <%= course_study_mode(@course) %>
+            </dd>
+          </div>
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Locations
+            </dt>
+            <dd class="govuk-summary-list__value" data-qa="course__locations">
+              <% if @course.site_statuses.size == 1 then %>
+                <%= @course.site_statuses.first.site.location_name %>
+              <% else %>
+                <ul class="govuk-list courses-locations-list">
+                  <% @course.site_statuses.map(&:site).map(&:location_name).each do |location_name| %>
+                    <li><%= location_name %></li>
+                  <% end %>
+                </ul>
               <% end %>
-            </ul>
+              <% if @provider.sites.size == 1 then %>
+                <p class="govuk-body govuk-hint">You can’t change this because you only have 1&nbsp;location</p>
+                <p class="govuk-body">
+                  <%= link_to "Manage all your locations", provider_sites_path(@provider[:provider_code]), class: "govuk-link" %>
+                </p>
+              <% end %>
+            </dd>
+          </div>
+
+          <% unless @provider.accredited_body? then %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Accredited body
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__accredited_body">
+                <%= @course.accrediting_provider&.provider_name %>
+              </dd>
+            </div>
           <% end %>
-          <% if @provider.sites.size == 1 then %>
-            <p class="govuk-body govuk-hint">You can’t change this because you only have 1&nbsp;location</p>
-            <p class="govuk-body">
-              <%= link_to "Manage all your locations", provider_sites_path(@provider[:provider_code]), class: "govuk-link" %>
-            </p>
-          <% end %>
-        </dd>
-      </div>
 
-      <% unless @provider.accredited_body? then %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Accredited body
-          </dt>
-          <dd class="govuk-summary-list__value" data-qa="course__accredited_body">
-            <%= @course.accrediting_provider&.provider_name %>
-          </dd>
-        </div>
-      <% end %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Applications open
+            </dt>
+            <dd class="govuk-summary-list__value" data-qa="course__applications_open">
+              <%= course_applications_open(@course) %>
+            </dd>
+          </div>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Applications open
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__applications_open">
-          <%= course_applications_open(@course) %>
-        </dd>
-      </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Course starts
+            </dt>
+            <dd class="govuk-summary-list__value" data-qa="course__start_date">
+              <%= course_start_date(@course) %>
+            </dd>
+          </div>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Course starts
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__start_date">
-          <%= course_start_date(@course) %>
-        </dd>
-      </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Title
+            </dt>
+            <dd class="govuk-summary-list__value" data-qa="course__name">
+              <%= @course.name %>
+            </dd>
+          </div>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Title
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__name">
-          <%= @course.name %>
-        </dd>
-      </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Description
+            </dt>
+            <dd class="govuk-summary-list__value" data-qa="course__description">
+              <%= @course.description %>
+            </dd>
+          </div>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Description
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__description">
-          <%= @course.description %>
-        </dd>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Course code
+            </dt>
+            <dd class="govuk-summary-list__value" data-qa="course__course_code">
+              <%= @course.course_code %>
+            </dd>
+          </div>
+        </dl>
       </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Course code
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__course_code">
-          <%= @course.course_code %>
-        </dd>
-      </div>
-    </dl>
-  </div>
+    </div>
+  </section>
 </div>

--- a/app/webpacker/stylesheets/_course-tabs.scss
+++ b/app/webpacker/stylesheets/_course-tabs.scss
@@ -1,0 +1,20 @@
+.course-tabs {
+  .govuk-tabs__panel {
+    border: none;
+    padding: govuk-spacing(6) 0 0;
+  }
+
+  .govuk-tabs__tab {
+    font-weight: bold;
+    color: $govuk-link-colour;
+    text-align: left;
+
+    &--selected {
+      color: $govuk-text-colour;
+      background-color: govuk-colour("white");
+      border-top: govuk-spacing(1) solid $govuk-link-colour;
+      padding-top: govuk-spacing(2);
+      text-decoration: none;
+    }
+  }
+}

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -7,6 +7,7 @@ $button-colour: #00823b;
 @import "cookie-banner";
 @import "flash";
 @import "phase-tag";
+@import "course-tabs";
 
 .text-decoration-underline-dotted {
   text-decoration: underline dotted;


### PR DESCRIPTION
### Context

We need to present the basic details on the frontend, and the enrichment information on the ui.

### Changes proposed in this pull request

- Wrap courses table with tabs component
- "Description" tab directs to manage-courses-ui.

### Guidance to review

Review without whitespace changes.

### After

<img width="1031" alt="Screenshot 2019-04-17 at 18 49 42" src="https://user-images.githubusercontent.com/1650875/56309615-cc4ede00-6141-11e9-96a8-4e3de916a8a6.png">
