### PR TITLE
[1321] Display course SEND

### DIFF
--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -59,4 +59,8 @@ module CourseHelper
   def course_applications_open(course)
     course.attributes[:applications_open_from]&.to_date&.strftime("%-d %B %Y")
   end
+
+  def course_send(course)
+    course.attributes[:is_send?] == true ? 'Yes' : 'No'
+  end
 end

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -37,6 +37,15 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
+          SEND
+        </dt>
+        <dd class="govuk-summary-list__value" data-qa="course__is_send">
+          <%= course_send(@course) %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
           Outcome
         </dt>
         <dd class="govuk-summary-list__value" data-qa="course__qualifications">

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     start_date     { Time.new(2019) }
     funding        { 'fee' }
     applications_open_from { DateTime.new(2019).utc.iso8601 }
+    is_send? { false }
 
     trait :with_vacancy do
       has_vacancies? { true }

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -67,5 +67,8 @@ feature 'Show course', type: :feature do
     expect(course_page.applications_open).to have_content(
       '1 January 2019'
     )
+    expect(course_page.is_send).to have_content(
+      'No'
+    )
   end
 end

--- a/spec/helpers/course_helper_spec.rb
+++ b/spec/helpers/course_helper_spec.rb
@@ -57,4 +57,11 @@ RSpec.feature 'View helpers', type: :helper do
       expect(helper.course_applications_open(build(:course, applications_open_from: '2019-01-01T00:00:00Z'))).to eq('1 January 2019')
     end
   end
+
+  describe "#course_send" do
+    it "returns correct content" do
+      expect(helper.course_send(build(:course, is_send?: true))).to eq('Yes')
+      expect(helper.course_send(build(:course, is_send?: false))).to eq('No')
+    end
+  end
 end

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -17,6 +17,7 @@ module PageObjects
         element :funding, '[data-qa=course__funding]'
         element :accredited_body, '[data-qa=course__accredited_body]'
         element :applications_open, '[data-qa=course__applications_open]'
+        element :is_send, '[data-qa=course__is_send]'
       end
     end
   end


### PR DESCRIPTION
### Context

We need to surface all course information to the user.

### Changes proposed in this pull request

- Presents `SEND` status in the courses show page

### Guidance to review

Thanks @dankmitchell for writing this up, I'm just opening the PR. :)
