### PR TITLE
[1342] hide content status if course is not running

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -22,4 +22,8 @@ class Course < Base
   def is_running?
     ucas_status == 'running'
   end
+
+  def not_running?
+    ucas_status == 'not_running'
+  end
 end

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -10,7 +10,7 @@
     <%= course_ucas_status(course) %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__content-status">
-    <%= render partial: 'content_status_tag', locals: { course: course } %>
+    <%= render partial: 'content_status_tag', locals: { course: course } unless course.not_running? %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__findable">
     <% if course.attributes[:findable?] %>

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -11,7 +11,8 @@ feature 'Index courses', type: :feature do
       include_nulls: [:accrediting_provider]
   }
   let(:course_3) { jsonapi :course, findable?: false, name: 'Physics', content_status: "empty", include_nulls: [:accrediting_provider] }
-  let(:courses)  { [course_1, course_2, course_3] }
+  let(:course_4) { jsonapi :course, findable?: false, name: 'Science', content_status: "published", include_nulls: [:accrediting_provider] }
+  let(:courses)  { [course_1, course_2, course_3, course_4] }
   let(:provider) do
     jsonapi(:provider, :opted_in, courses: courses, accredited_body?: true, provider_code: 'A123')
   end
@@ -63,6 +64,13 @@ feature 'Index courses', type: :feature do
       expect(third_row.is_it_on_find).to  have_content 'No'
       expect(third_row.applications).to   have_content ''
       expect(third_row.vacancies).to      have_content ''
+
+      fourth_row = organisations_courses_page.rows.fourth
+      expect(fourth_row.name).to           have_content course_4.attributes[:name]
+      expect(fourth_row.content_status).to have_content ''
+      expect(fourth_row.is_it_on_find).to  have_content 'No'
+      expect(fourth_row.applications).to   have_content ''
+      expect(fourth_row.vacancies).to      have_content ''
     end
 
     scenario "it shows 'add a new course' link" do


### PR DESCRIPTION
### Context
> In user research, publishers were confused when seeing ‘not running’ in the UCAS status and ‘Published’ in the content status column of the courses table. 

### Changes proposed in this pull request
- Don't render `content_status` if course is "Not running"

### Guidance to review
# Before
<img width="1551" alt="Screenshot 2019-04-20 at 20 59 19" src="https://user-images.githubusercontent.com/3071606/56461713-3c15d080-63af-11e9-9219-b6cd11191fb9.png">

# After
<img width="1551" alt="Screenshot 2019-04-20 at 20 59 26" src="https://user-images.githubusercontent.com/3071606/56461716-4637cf00-63af-11e9-8629-de387b9ac1c0.png">
