### PR TITLE
[1320] Add DfE subjects to show details

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -72,7 +72,7 @@
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-              Subject
+              <%= 'Subject'.pluralize(@course.subjects.count) %>
             </dt>
             <dd class="govuk-summary-list__value" data-qa="course__subjects">
               <%= @course.subjects.join(', ') %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -72,6 +72,15 @@
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
+              Subject
+            </dt>
+            <dd class="govuk-summary-list__value" data-qa="course__subjects">
+              <%= @course.subjects.join(', ') %>
+            </dd>
+          </div>
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
               Outcome
             </dt>
             <dd class="govuk-summary-list__value" data-qa="course__qualifications">

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -24,6 +24,7 @@ FactoryBot.define do
     applications_open_from { DateTime.new(2019).utc.iso8601 }
     is_send? { false }
     level { "secondary" }
+    subjects { ["English", "English with Primary"] }
 
     trait :with_vacancy do
       has_vacancies? { true }

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -36,6 +36,9 @@ feature 'Show course', type: :feature do
     expect(course_page.title).to have_content(
       "#{course.attributes[:name]} (#{course.attributes[:course_code]})"
     )
+    expect(course_page.subjects).to have_content(
+      course.attributes[:subjects].join(', ').to_s
+    )
     expect(course_page.qualifications).to have_content(
       'PGCE with QTS'
     )

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -18,6 +18,7 @@ module PageObjects
         element :accredited_body, '[data-qa=course__accredited_body]'
         element :applications_open, '[data-qa=course__applications_open]'
         element :is_send, '[data-qa=course__is_send]'
+        element :subjects, '[data-qa=course__subjects]'
         element :level, '[data-qa=course__level]'
       end
     end


### PR DESCRIPTION
### Context
Course Subjects

### Changes proposed in this pull request
Show course subjects on the basic details tab. These courses are generated from the Subjects Mapper.

### Guidance to review
## After - 1 subject
![localhost_3000_organisations_2AT_courses_35L7(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/56555134-d468ac80-658b-11e9-853f-30dcfede6de9.png)

## After - more than one subject
![localhost_3000_organisations_2AT_courses_2T89(Laptop with MDPI screen) (1)](https://user-images.githubusercontent.com/3071606/56555136-d5014300-658b-11e9-805e-e91ea8e576cd.png)
