### PR TITLE
[1349] Show subjects in alphabetical order, one per line

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -75,7 +75,9 @@
               <%= 'Subject'.pluralize(@course.subjects.count) %>
             </dt>
             <dd class="govuk-summary-list__value" data-qa="course__subjects">
-              <%= @course.subjects.join(', ') %>
+              <% @course.subjects.sort.each do |subject| %>
+                <%= subject %><br>
+              <% end %>
             </dd>
           </div>
 

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -37,7 +37,7 @@ feature 'Show course', type: :feature do
       "#{course.attributes[:name]} (#{course.attributes[:course_code]})"
     )
     expect(course_page.subjects).to have_content(
-      course.attributes[:subjects].join(', ').to_s
+      course.attributes[:subjects].sort.join(' ').to_s
     )
     expect(course_page.qualifications).to have_content(
       'PGCE with QTS'


### PR DESCRIPTION
### Context

Subjects aren't ordered alphabetically on the course page. They also aren't shown one per line.

### Changes proposed in this pull request

Show subjects in alphabetical order, and one per line.

### Guidance to review
