### PR TITLE
[1356] Filter out sensitive user params from log

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %I[password email first_name last_name]


### PR DESCRIPTION
To prevent personally identifiable user info to be logged unnecessarily.