### PR TITLE
[1353] only show transition_info page if user is opted in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
     add_token_to_connection
     user = set_user_session
 
-    if user.state == 'new'
+    if user.opted_in? && user.state == 'new'
       redirect_to transition_info_path
     else
       redirect_to root_path

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,9 +11,14 @@ FactoryBot.define do
     last_name  { Faker::Name.last_name }
     email      { Faker::Internet.safe_email("#{first_name} #{last_name}") }
     state      { 'transitioned' }
+    opted_in?  { false }
 
     trait :new do
       state { 'new' }
+    end
+
+    trait :opted_in do
+      opted_in? { true }
     end
   end
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -20,8 +20,8 @@ feature 'Sign in', type: :feature do
     expect(root_page).to be_displayed
   end
 
-  scenario 'new user accepts the transition info page' do
-    user = jsonapi :user, :new
+  scenario 'new opted-in user accepts the transition info page' do
+    user = jsonapi :user, :new, :opted_in
 
     stub_omniauth(user: user)
     stub_session_create(user: user)
@@ -38,5 +38,19 @@ feature 'Sign in', type: :feature do
 
     expect(organisations_page).to be_displayed
     expect(request).to have_been_made
+  end
+
+  scenario 'new non-opted-in user accepts the transition info page' do
+    user = jsonapi :user, :new
+
+    stub_omniauth(user: user)
+    stub_session_create(user: user)
+    stub_api_v2_request('/providers', jsonapi(:providers_response))
+    stub_api_v2_request '/sessions', user, :post
+
+    visit '/signin'
+
+    expect(transition_info_page).not_to be_displayed
+    expect(root_page).to be_displayed
   end
 end


### PR DESCRIPTION
https://trello.com/c/6AtQ386u/1353-only-redirect-users-to-the-transition-info-screen-if-they-have-any-optedin-providers

### Context

Only opted-in users should see the transition page.

### Changes proposed in this pull request

Check that a user is opted-in before redirecting them to the transition page.

### Guidance to review

Example - `http://localhost:3001/api/v2/users/10345`
See https://github.com/DFE-Digital/manage-courses-backend/pull/294
