### PR TITLE
[1360] Display information for non opted in providers

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -152,7 +152,11 @@
     <div class="govuk-grid-column-one-third">
       <div class="status-box">
         <h2 class="govuk-heading-m">Changing your basic details</h2>
-        <p>To make any changes to your basic details, or to <%= @course.is_running? ? "withdraw" : "delete" %> this course, <%= bat_contact_mail_to "contact the Becoming a Teacher team", subject: "Edit #{@course.name} (#{@provider_code}/#{@course.course_code})" %>.</p>
+        <% if @provider.opted_in? %>
+          <p>To make any changes to your basic details, or to <%= @course.is_running? ? "withdraw" : "delete" %> this course, <%= bat_contact_mail_to "contact the Becoming a Teacher team", subject: "Edit #{@course.name} (#{@provider_code}/#{@course.course_code})" %>.</p>
+        <% else %>
+          <p class="govuk-body">You can only change this information using <%= link_to "UCAS web-link", "https://update.ucas.co.uk/netupdate2/Welcome.htm" %>. Changes will usually appear here within one working&nbsp;day.</p>
+        <% end %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
This has been moved from manage-courses-ui because manage-courses-frontend is now displaying the basic details.

Haven't written tests because this is all going away in a week.

### Screenshot

<img width="1058" alt="Screenshot 2019-04-24 at 14 23 49" src="https://user-images.githubusercontent.com/1650875/56662789-a8891c00-669c-11e9-92db-fb4529fdd63b.png">
