### PR TITLE
Add an after action that removes bearer token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   rescue_from JsonApiClient::Errors::AccessDenied, with: :render_manage_ui
 
   before_action :set_has_multiple_providers
+  after_action :nuke_token
 
   def not_found
     respond_to do |format|
@@ -82,6 +83,12 @@ private
 
     Base.connection(true) do |connection|
       connection.use FaradayMiddleware::OAuth2, token, token_type: :bearer
+    end
+  end
+
+  def nuke_token
+    Base.connection(true) do |connection|
+      connection.use FaradayMiddleware::OAuth2, nil, token_type: :bearer
     end
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SessionsController, type: :controller do
         expect(subject).to redirect_to("/")
         expect(@request.session[:auth_user]['user_id']).to eq user_id
         expect(@request.session[:auth_user]["info"]).to eq user.attributes
-        expect(Base).to have_received(:connection).with(true)
+        expect(Base).to have_received(:connection).with(true).twice
       end
     end
 


### PR DESCRIPTION
### Context

These seem to persist across connections. Needs confirming though.

### Changes proposed in this pull request

This makes sure that we never leave bearer tokens in after a request.

### Guidance to review