### PR TITLE
[1358] Authenticate in ApplicationController by default

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   rescue_from JsonApiClient::Errors::NotAuthorized, with: :render_manage_ui
   rescue_from JsonApiClient::Errors::AccessDenied, with: :render_manage_ui
 
-  before_action :set_has_multiple_providers
+  before_action :authenticate, :set_has_multiple_providers
 
   def not_found
     respond_to do |format|

--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -1,7 +1,6 @@
 module Courses
   class VacanciesController < ApplicationController
     before_action(
-      :authenticate,
       :build_course,
       :build_site_statuses
     )

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,4 @@
 class CoursesController < ApplicationController
-  before_action :authenticate
   before_action :build_course, only: %i[show description delete withdraw]
   before_action :build_provider, only: %i[show description]
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,7 @@
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token,
                     only: %i[not_found internal_server_error forbidden unauthorised]
+  skip_before_action :authenticate
 
   def not_found
     respond_to do |format|

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  before_action :authenticate, except: :guidance
+  skip_before_action :authenticate, only: :guidance
 
   def cookies; end
 

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -1,6 +1,4 @@
 class ProvidersController < ApplicationController
-  before_action :authenticate
-
   def index
     @providers = Provider.all
     render_manage_ui if @providers.empty?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :authenticate
+
   def new
     redirect_to "/auth/dfe"
   end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,5 +1,5 @@
 class SitesController < ApplicationController
-  before_action :authenticate, :build_provider, :initialise_errors
+  before_action :build_provider, :initialise_errors
   before_action :build_site, only: %i[edit update]
 
   def index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,4 @@
 class UsersController < ApplicationController
-  before_action :authenticate
-
   def accept_transition_info
     User.member(current_user['user_id']).accept_transition_screen
     redirect_to providers_path


### PR DESCRIPTION
This reduces the error of 'authenticate' being forgotten in a new controller.
