### PR TITLE
[1325] Redirect expired DFE sessions to signin again

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -16,7 +16,9 @@ module OmniAuth
 
       def callback_phase
         error = request.params['error_reason'] || request.params['error']
-        if error
+        if error == 'sessionexpired'
+          return redirect('/signin')
+        elsif error
           raise CallbackError.new(request.params['error'], request.params['error_description'] || request.params['error_reason'], request.params['error_uri'])
         elsif request.params['state'].to_s.empty? || request.params['state'] != stored_state
           # Monkey patch: Ensure a basic 401 rack response with no body or header isn't served

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -89,6 +89,10 @@ if Settings.dfe_signin.issuer.present?
       else
         @app.call(env)
       end
+    rescue ActionController::InvalidAuthenticityToken
+      response = Rack::Response.new
+      response.redirect('/signin')
+      response.finish
     end
   end
 


### PR DESCRIPTION
### Context

When a session expires, the Omniauth middleware throws an exception. We should redirect users to signin when this happens.

### Changes proposed in this pull request

Adds try/catch to relevant part of Omniauth initialiser.

### Guidance to review

I'm not sure if the `ActionController::InvalidAuthenticityToken` is just for CSRF issues (possibly what I was testing with locally) or for any kind of expired auth.

Have tested this locally by going to the `/transition-info` page, logging out in a separate tab, and clicking the green button.