### PR TITLE
[1372] Handle client / server errors on accept_transition_info

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,5 +2,15 @@ class UsersController < ApplicationController
   def accept_transition_info
     User.member(current_user['user_id']).accept_transition_screen
     redirect_to providers_path
+  rescue JsonApiClient::Errors::ClientError, JsonApiClient::Errors::ServerError => e
+    e.env.body.delete("traces")
+    Raven.extra_context(e.env)
+    Raven.capture_exception(e)
+
+    if e.is_a? JsonApiClient::Errors::ClientError
+      redirect_to providers_path
+    else
+      raise e
+    end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe UsersController, type: :controller do
+  let(:user) { jsonapi :user }
+
+  before do
+    stub_omniauth
+    stub_session_create
+    allow_any_instance_of(ApplicationController)
+      .to receive(:current_user)
+      .and_return('user_id' => user.id)
+    allow(Raven).to receive(:capture_exception)
+  end
+
+  describe 'GET #accept_transition_info' do
+    context "with working request" do
+      before do
+        stub_api_v2_request("/users/#{user.id}/accept_transition_screen", {}, :patch, 200)
+      end
+
+      it "redirects to providers index" do
+        get :accept_transition_info
+        expect(response).to redirect_to(providers_path)
+      end
+    end
+
+    context "with client error" do
+      before do
+        stub_api_v2_request("/users/#{user.id}/accept_transition_screen", {}, :patch, 400)
+      end
+
+      it "redirects to providers index" do
+        get :accept_transition_info
+        expect(Raven).to have_received(:capture_exception).with(instance_of(JsonApiClient::Errors::ClientError))
+        expect(response).to redirect_to(providers_path)
+      end
+    end
+
+    context "with server error" do
+      before do
+        stub_api_v2_request("/users/#{user.id}/accept_transition_screen", {}, :patch, 500)
+      end
+
+      it "redirects to providers index" do
+        expect { get :accept_transition_info }.to raise_error JsonApiClient::Errors::ServerError
+        expect(Raven).to have_received(:capture_exception).with(instance_of(JsonApiClient::Errors::ServerError))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

The frontend will blow up if the API returns a 400 or a 500. The API will return 4xx when the user is already transitioned, and 500 for a variety of reasons.

### Changes proposed in this pull request

Ensure users are always directed to the providers page.

### Guidance to review

The spec could be dried out, suggestions welcome!