### PR TITLE
[1337] Send DfE-SignIn ID to backend

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,18 +69,13 @@ private
   end
 
   def add_token_to_connection
-    if Settings.authentication.algorithm == 'plain-text'
-      # This method can be used in development mode to simplify querying
-      # the API with curl. It should allow us to do:
-      #
-      #    curl -H 'Authorization: Bearer user@education.gov.uk' http://localhost:3001/api/v2/providers
-      token = current_user_info['email'].to_s
-    else
-      payload = { email: current_user_info['email'].to_s }
-      token = JWT.encode(payload,
-                          Settings.authentication.secret,
-                          Settings.authentication.algorithm)
-    end
+    payload = {
+      email:           current_user_info['email'].to_s,
+      sign_in_user_id: current_user_dfe_signin_id
+    }
+    token = JWT.encode(payload,
+                        Settings.authentication.secret,
+                        Settings.authentication.algorithm)
 
     Base.connection(true) do |connection|
       connection.use FaradayMiddleware::OAuth2, token, token_type: :bearer

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,6 +39,10 @@ class ApplicationController < ActionController::Base
     current_user['info']
   end
 
+  def current_user_dfe_signin_id
+    current_user['uid']
+  end
+
   def set_has_multiple_providers
     @has_multiple_providers = has_multiple_providers?
   end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -9,5 +9,4 @@ manage_ui:
 search_ui:
   base_url: https://localhost:5000
 authentication:
-  algorithm: plain-text
-  secret: nil
+  secret: secret

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ApplicationController, type: :controller do
 
     context 'user is authenticated' do
       let(:user_email) { "email@example.com" }
+      let(:sign_in_user_id) { SecureRandom.uuid }
 
       let(:user_info) do
         {
@@ -23,8 +24,12 @@ RSpec.describe ApplicationController, type: :controller do
         }
       end
 
-      let(:payload) { { email: user_email.to_s } }
-
+      let(:payload) do
+        {
+          email:           user_email.to_s,
+          sign_in_user_id: sign_in_user_id
+        }
+      end
       let(:user_id) { nil }
 
       before do
@@ -34,7 +39,7 @@ RSpec.describe ApplicationController, type: :controller do
           .with(payload, Settings.authentication.secret, Settings.authentication.algorithm)
           .and_return("anything")
 
-        controller.request.session = { auth_user: { "info" => user_info } }
+        controller.request.session = { auth_user: { "info" => user_info, 'uid' => sign_in_user_id } }
       end
 
       context 'user_id is not blank' do
@@ -45,7 +50,7 @@ RSpec.describe ApplicationController, type: :controller do
           allow(Provider).to receive(:all)
             .and_raise('Could not connect to backend')
 
-          controller.request.session = { auth_user: { "info" => user_info, 'user_id' => user_id } }
+          controller.request.session = { auth_user: { "info" => user_info, 'user_id' => user_id, 'uid' => sign_in_user_id } }
           controller.authenticate
         end
 


### PR DESCRIPTION
### Context

We need to send the DfE-SignIn ID to the backend so we're not relying on only email for user lookup.

### Changes proposed in this pull request

- Send DfE-SignIn ID to the backend in the JWT payload
- Remove special token handling in development to match backend changes

### Guidance to review

Tested on MacOS Mojave 10.14.4. (For real this time, it works!)
