### PR TITLE
[1369] Pre-populate Google forms

### DIFF
--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -1,11 +1,9 @@
 module ProviderHelper
   def add_course_url(email, provider)
     if provider.accredited_body?
-      Settings.google_forms.new_course_for_accredited_bodies_url + "?" +
-        {usp: 'pp_url', "entry.957076544" => email, "entry.1735563938" => provider.provider_code}.to_query
+      google_form_url_for(Settings.google_forms.new_course_for_accredited_bodies, email, provider)
     else
-      Settings.google_forms.new_course_for_unaccredited_bodies_url + "?" +
-        {usp: 'pp_url', "entry.1033530353" => email, "entry.158771972" => provider.provider_code}.to_query
+      google_form_url_for(Settings.google_forms.new_course_for_unaccredited_bodies, email, provider)
     end
   end
 
@@ -14,10 +12,15 @@ module ProviderHelper
   end
 
   def add_location_url(email, provider)
-    Settings.google_forms.add_location_url + "?" + {usp: 'pp_url', "entry.1913622198" => email, "entry.1075663095" => provider.provider_code}.to_query
+    google_form_url_for(Settings.google_forms.add_location, email, provider)
   end
 
   def add_location_link(email, provider)
     link_to "Add a location", add_location_url(email, provider), rel: "noopener noreferrer", class: "govuk-button govuk-!-margin-bottom-2", target: :blank
+  end
+
+  def google_form_url_for(settings, email, provider)
+    settings.url + "&" +
+      { settings.email_entry => email, settings.provider_code_entry => provider.provider_code }.to_query
   end
 end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -1,11 +1,15 @@
 module ProviderHelper
-  def add_course_link(provider)
-    google_form_url = if provider.accredited_body?
-                        Settings.google_forms.new_course_for_accredited_bodies_url
-                      else
-                        Settings.google_forms.new_course_for_unaccredited_bodies_url
-                      end
+  def add_course_url(email, provider)
+    if provider.accredited_body?
+      Settings.google_forms.new_course_for_accredited_bodies_url + "?" +
+        {usp: 'pp_url', "entry.957076544" => email, "entry.1735563938" => provider.provider_code}.to_query
+    else
+      Settings.google_forms.new_course_for_unaccredited_bodies_url + "?" +
+        {usp: 'pp_url', "entry.1033530353" => email, "entry.158771972" => provider.provider_code}.to_query
+    end
+  end
 
-    link_to "Add a new course", google_form_url, class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank"
+  def add_course_link(email, provider)
+    link_to "Add a new course", add_course_url(email, provider), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank"
   end
 end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -12,4 +12,12 @@ module ProviderHelper
   def add_course_link(email, provider)
     link_to "Add a new course", add_course_url(email, provider), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank"
   end
+
+  def add_location_url(email, provider)
+    Settings.google_forms.add_location_url + "?" + {usp: 'pp_url', "entry.1913622198" => email, "entry.1075663095" => provider.provider_code}.to_query
+  end
+
+  def add_location_link(email, provider)
+    link_to "Add a location", add_location_url(email, provider), rel: "noopener noreferrer", class: "govuk-button govuk-!-margin-bottom-2", target: :blank
+  end
 end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -16,7 +16,7 @@ module ProviderHelper
   end
 
   def add_location_link(email, provider)
-    link_to "Add a location", add_location_url(email, provider), rel: "noopener noreferrer", class: "govuk-button govuk-!-margin-bottom-2", target: :blank
+    link_to "Add a location", add_location_url(email, provider), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank"
   end
 
   def google_form_url_for(settings, email, provider)

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -26,7 +26,7 @@
 </ul>
 
 <% if @provider.courses.count > 10 && @provider.opted_in? %>
-  <%= add_course_link(@provider) %>
+  <%= add_course_link(current_user['info']['email'], @provider) %>
   <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your course details.</p>
 <% end %>
 
@@ -42,6 +42,6 @@
 <% end %>
 
 <% if @provider.opted_in? %>
-  <%= add_course_link(@provider) %>
+  <%= add_course_link(current_user['info']['email'], @provider) %>
   <p class="govuk-body-s">You’ll be taken to a Google Form to fill in your course details.</p>
 <% end %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -50,7 +50,7 @@
       </tbody>
     </table>
     <% if @provider.opted_in? %>
-      <%= link_to "Add a location", Settings.google_forms.add_location_url, rel: "noopener noreferrer", class: "govuk-button govuk-!-margin-bottom-2", target: :blank %>
+      <%= add_location_link(current_user['info']['email'], @provider) %>
       <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your location details.</p>
     <% end %>
   </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,8 +24,17 @@ search_ui:
   # URL of the C# search ui app (search-and-compare-ui)
   base_url: https://localhost:5000
 google_forms:
-  new_course_for_accredited_bodies_url: https://docs.google.com/forms/d/e/1FAIpQLSd4k5wSjrVyFu-FW4ZaSsrbK0AwTpjmzfyTdfa_qdXLZ313HQ/viewform
-  new_course_for_unaccredited_bodies_url: https://docs.google.com/forms/d/e/1FAIpQLSeatJO2ZuqM-fnRJxEo6IIF0hZIU63JGnx0sDXO6Ulax7U_bA/viewform
-  add_location_url: https://docs.google.com/forms/d/e/1FAIpQLSeW14NPB081ZwayBStlZsmCoKycFuhwtktozbu8MF7CWpm5Og/viewform
+  new_course_for_accredited_bodies:
+    url: https://docs.google.com/forms/d/e/1FAIpQLSd4k5wSjrVyFu-FW4ZaSsrbK0AwTpjmzfyTdfa_qdXLZ313HQ/viewform?usp=pp_url
+    email_entry: entry.957076544
+    provider_code_entry: entry.1735563938
+  new_course_for_unaccredited_bodies:
+    url: https://docs.google.com/forms/d/e/1FAIpQLSeatJO2ZuqM-fnRJxEo6IIF0hZIU63JGnx0sDXO6Ulax7U_bA/viewform?usp=pp_url
+    email_entry: entry.1033530353
+    provider_code_entry: entry.158771972
+  add_location:
+    url: https://docs.google.com/forms/d/e/1FAIpQLSeW14NPB081ZwayBStlZsmCoKycFuhwtktozbu8MF7CWpm5Og/viewform?usp=pp_url
+    email_entry: entry.1913622198
+    provider_code_entry: entry.1075663095
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,8 +24,8 @@ search_ui:
   # URL of the C# search ui app (search-and-compare-ui)
   base_url: https://localhost:5000
 google_forms:
-  new_course_for_accredited_bodies_url: https://forms.gle/ktbyArGW5EyiMppf9
-  new_course_for_unaccredited_bodies_url: https://forms.gle/WEokN2S4qPcPAZcr5
+  new_course_for_accredited_bodies_url: https://docs.google.com/forms/d/e/1FAIpQLSd4k5wSjrVyFu-FW4ZaSsrbK0AwTpjmzfyTdfa_qdXLZ313HQ/viewform
+  new_course_for_unaccredited_bodies_url: https://docs.google.com/forms/d/e/1FAIpQLSeatJO2ZuqM-fnRJxEo6IIF0hZIU63JGnx0sDXO6Ulax7U_bA/viewform
   add_location_url: https://forms.gle/Bvkuf6JMY8kPVHPNA
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,6 @@ search_ui:
 google_forms:
   new_course_for_accredited_bodies_url: https://docs.google.com/forms/d/e/1FAIpQLSd4k5wSjrVyFu-FW4ZaSsrbK0AwTpjmzfyTdfa_qdXLZ313HQ/viewform
   new_course_for_unaccredited_bodies_url: https://docs.google.com/forms/d/e/1FAIpQLSeatJO2ZuqM-fnRJxEo6IIF0hZIU63JGnx0sDXO6Ulax7U_bA/viewform
-  add_location_url: https://forms.gle/Bvkuf6JMY8kPVHPNA
+  add_location_url: https://docs.google.com/forms/d/e/1FAIpQLSeW14NPB081ZwayBStlZsmCoKycFuhwtktozbu8MF7CWpm5Og/viewform
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -22,13 +22,17 @@ feature 'Index courses', type: :feature do
     let(:organisations_courses_page) { PageObjects::Page::Organisations::Courses.new }
 
     before do
-      stub_omniauth
-      stub_session_create
+      user = jsonapi :user, :opted_in
+      stub_omniauth(disable_completely: false, user: user)
+      stub_session_create(user: User.new(JSON.parse(user.to_json)))
+      stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
+      stub_api_v2_request("/providers/A123", provider_response)
       stub_api_v2_request(
         "/providers/A123?include=courses.accrediting_provider",
         provider_response
       )
-      visit "/organisations/A123/courses"
+      visit "/"
+      click_on "Courses"
     end
 
     scenario 'it shows a list of courses' do
@@ -74,7 +78,7 @@ feature 'Index courses', type: :feature do
     end
 
     scenario "it shows 'add a new course' link" do
-      expect(page).to have_link('Add a new course', href: Settings.google_forms.new_course_for_accredited_bodies_url)
+      expect(page).to have_link('Add a new course', href: /#{Settings.google_forms.new_course_for_accredited_bodies.url.gsub('?', '\?')}/)
     end
   end
 
@@ -90,26 +94,30 @@ feature 'Index courses', type: :feature do
     let(:course_3) { jsonapi :course, accrediting_provider: provider_2 }
 
     before do
-      stub_omniauth
-      stub_session_create
+      user = jsonapi :user, :opted_in
+      stub_omniauth(disable_completely: false, user: user)
+      stub_session_create(user: User.new(JSON.parse(user.to_json)))
+      stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
+      stub_api_v2_request("/providers/A123", provider_response)
       stub_api_v2_request(
         "/providers/A123?include=courses.accrediting_provider",
         provider_response
       )
-      visit "/organisations/A123/courses"
+      visit "/"
+      click_on "Courses"
     end
 
     scenario "it shows a list of courses" do
       expect(find('h1')).to have_content('Courses')
       expect(page).to have_selector('table', count: 3)
-      expect(page).to have_link('Add a new course', href: Settings.google_forms.new_course_for_unaccredited_bodies_url)
+      expect(page).to have_link('Add a new course', href: /#{Settings.google_forms.new_course_for_unaccredited_bodies.url.gsub('?', '\?')}/)
 
       expect(page.all('h2')[0]).to have_content('Accredited body Aacme Scitt')
       expect(page.all('h2')[1]).to have_content('Accredited body Zacme Scitt')
     end
 
     scenario "it shows 'add a new course' link" do
-      expect(page).to have_link('Add a new course', href: Settings.google_forms.new_course_for_unaccredited_bodies_url)
+      expect(page).to have_link('Add a new course', href: /#{Settings.google_forms.new_course_for_unaccredited_bodies.url.gsub('?', '\?')}/)
     end
   end
 

--- a/spec/features/locations/index_spec.rb
+++ b/spec/features/locations/index_spec.rb
@@ -12,19 +12,22 @@ feature 'View locations', type: :feature do
   let(:provider) do
     jsonapi(:provider, sites: sites).render
   end
-
   let(:provider_attributes) { provider[:data][:attributes] }
   let(:site_response) { sites[0].render }
 
   before do
-    stub_omniauth
-    stub_session_create
+    user = jsonapi :user, :opted_in
+    stub_omniauth(disable_completely: false, user: user)
+    stub_session_create(user: User.new(JSON.parse(user.to_json)))
+    stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider[:data]]))
+    stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}", provider)
     stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}?include=sites", provider)
+
+    visit "/"
+    click_on "Locations"
   end
 
   scenario 'it shows a list of locations' do
-    visit provider_sites_path(provider_attributes[:provider_code])
-
     expect(find('h1')).to have_content('Locations')
     expect(page).to have_selector('tbody tr', count: 3)
     expect(first('.govuk-table__cell')).to_not have_link('Main site 1')
@@ -32,24 +35,22 @@ feature 'View locations', type: :feature do
     expect(page).to_not have_link('Add a location')
   end
 
-  scenario 'it shows one location' do
-    stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}/sites/#{sites[0].id}", site_response)
-
-    visit("/organisations/#{provider_attributes[:provider_code]}/locations/#{sites[0].id}/edit")
-
-    expect(find('h1')).to have_content('Main site 1')
-  end
-
   context 'when the provider is opted_in' do
     let(:provider) do
       jsonapi(:provider, :opted_in, sites: sites).render
     end
 
-    scenario 'should show Add Location CTA' do
-      visit provider_sites_path(provider_attributes[:provider_code])
+    scenario 'it shows one location' do
+      stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}/sites/#{sites.first.id}", site_response)
 
+      click_on "Main site 1"
+
+      expect(find('h1')).to have_content('Main site 1')
+    end
+
+    scenario 'should show Add Location CTA' do
       expect(first('.govuk-table__cell')).to have_link('Main site 1')
-      expect(page).to have_link('Add a location')
+      expect(page).to have_link('Add a location', href: /#{Settings.google_forms.add_location.url.gsub('?', '\?')}/)
     end
   end
 end

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -1,15 +1,43 @@
 require 'rails_helper'
 
 feature 'View helpers', type: :helper do
+  let(:email) { 'ab+test@c.com' }
+  let(:html_escaped_version_of_email) { 'ab%2Btest%40c.com' }
+  let(:provider) { jsonapi(:provider).to_resource }
+
   describe "#add_course_link" do
-    it "returns correct google form for accrediting providers" do
-      provider = jsonapi(:provider, accredited_body?: true).to_resource
-      expect(helper.add_course_link(provider)).to eq("<a class=\"govuk-button govuk-!-margin-bottom-2\" rel=\"noopener noreferrer\" target=\"_blank\" href=\"https://forms.gle/ktbyArGW5EyiMppf9\">Add a new course</a>")
+    it "builds a link" do
+      expect(helper.add_course_link(email, provider)).to eq("<a class=\"govuk-button govuk-!-margin-bottom-2\" rel=\"noopener noreferrer\" target=\"_blank\" href=\"#{CGI::escapeHTML(helper.add_course_url(email, provider))}\">Add a new course</a>")
+    end
+  end
+
+  describe "#add_course_url" do
+    describe "for accredited bodies" do
+      let(:provider) { jsonapi(:provider, accredited_body?: true).to_resource }
+
+      it "returns correct google form" do
+        expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.new_course_for_accredited_bodies.url)
+        expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
+        expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
+      end
     end
 
-    it "returns correct google form for non-accrediting providers" do
-      provider = jsonapi(:provider, accredited_body?: false).to_resource
-      expect(helper.add_course_link(provider)).to eq("<a class=\"govuk-button govuk-!-margin-bottom-2\" rel=\"noopener noreferrer\" target=\"_blank\" href=\"https://forms.gle/WEokN2S4qPcPAZcr5\">Add a new course</a>")
+    describe "for non-accredited bodies" do
+      let(:provider) { jsonapi(:provider, accredited_body?: false).to_resource }
+
+      it "returns correct google form" do
+        expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.new_course_for_unaccredited_bodies.url)
+        expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
+        expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
+      end
+    end
+  end
+
+  describe "#add_location_url" do
+    it "returns a pre-populated google form URL" do
+      expect(helper.add_location_url(email, provider)).to start_with(Settings.google_forms.add_location.url)
+      expect(helper.add_location_url(email, provider)).to include(html_escaped_version_of_email)
+      expect(helper.add_location_url(email, provider)).to include(provider.attributes[:provider_code])
     end
   end
 end

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -11,6 +11,12 @@ feature 'View helpers', type: :helper do
     end
   end
 
+  describe "#add_location_link" do
+    it "builds a link" do
+      expect(helper.add_location_link(email, provider)).to eq("<a class=\"govuk-button govuk-!-margin-bottom-2\" rel=\"noopener noreferrer\" target=\"_blank\" href=\"#{CGI::escapeHTML(helper.add_location_url(email, provider))}\">Add a location</a>")
+    end
+  end
+
   describe "#add_course_url" do
     describe "for accredited bodies" do
       let(:provider) { jsonapi(:provider, accredited_body?: true).to_resource }


### PR DESCRIPTION
### Context
We use Google forms to allow publishers to submit certain information to us. Google permits pre-populating the forms which reduces the data entry burden on the publisher, and improves the quality of the data submitted to us.

### Changes proposed in this pull request

- Add code for constructing Google form links which pre-populate provider code and publisher email on:
  - the 'add new course' form
  - the 'add new location' form
- Introduce extra settings which are used to construct the pre-population URLs
- Stub some of the feature specs at a lower level, so that the user email is available in the templates

### Guidance to review
This makes the Google form link building a bit more complex, but hopefully that's all encapsulated in the helper.