### PR TITLE
[1369] Clean up feature specs with page objects

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -30,15 +30,21 @@
   <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your course details.</p>
 <% end %>
 
-<%= render partial: 'course_table', locals: { courses: @self_accredited_courses } if @self_accredited_courses %>
+<% if @self_accredited_courses %>
+  <section data-qa="courses__table-section">
+    <%= render partial: 'course_table', locals: { courses: @self_accredited_courses } %>
+  </section>
+<% end %>
 
 <% @courses_by_accrediting_provider.each do |accrediting_provider, courses| %>
-  <h2 class="govuk-heading-m">
-    <span class="govuk-caption-m">Accredited body</span>
-    <%= accrediting_provider %>
-  </h2>
+  <section data-qa="courses__table-section">
+    <h2 class="govuk-heading-m">
+      <span class="govuk-caption-m">Accredited body</span>
+      <%= accrediting_provider %>
+    </h2>
 
-  <%= render partial: 'course_table', locals: { courses: courses } %>
+    <%= render partial: 'course_table', locals: { courses: courses } %>
+  </section>
 <% end %>
 
 <% if @provider.opted_in? %>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -34,7 +34,7 @@
       <li>add locations</li>
     </ul>
 
-    <h2 class="govuk-heading-m"><%= link_to "Courses", provider_courses_path(@provider[:provider_code]), class: "govuk-link" %></h2>
+    <h2 class="govuk-heading-m"><%= link_to "Courses", provider_courses_path(@provider[:provider_code]), class: "govuk-link", data: { qa: 'provider__courses' } %></h2>
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
       <li>write about each course</li>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -27,7 +27,7 @@
       <li>publish this information on all course pages</li>
     </ul>
 
-    <h2 class="govuk-heading-m"><%= link_to "Locations", provider_sites_path(@provider[:provider_code]), class: "govuk-link" %></h2>
+    <h2 class="govuk-heading-m"><%= link_to "Locations", provider_sites_path(@provider[:provider_code]), class: "govuk-link", data: { qa: 'provider__locations' } %></h2>
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
       <li>edit location names and addresses</li>

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -1,5 +1,5 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell">
+  <td class="govuk-table__cell" data-qa="provider__location-name">
     <%= link_to_if @provider.opted_in?, site.attributes[:location_name], edit_provider_site_path(@provider.provider_code, site.attributes[:id]), class: "govuk-link govuk-!-font-weight-bold" %>
   </td>
   <td class="govuk-table__cell">

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -50,7 +50,7 @@
             <span class="govuk-visually-hidden">Error:</span> <%= @errors[:location_name]&.first %>
           </span>
         <% end %>
-        <%= f.text_field :location_name, class: "govuk-input govuk-!-width-full", aria: { describedby: @errors[:location_name] ? "location_name-error" : '' } %>
+        <%= f.text_field :location_name, class: "govuk-input govuk-!-width-full", aria: { describedby: @errors[:location_name] ? "location_name-error" : '' }, data: { qa: 'location__name' } %>
       </div>
 
       <h2 class="govuk-heading-m govuk-!-margin-top-8">Address</h2>
@@ -110,7 +110,7 @@
         <%= f.select :region_code, Site::REGIONS, {}, class: "govuk-select", aria: { describedby: @errors[:region_code] ? "region_code-error": '' } %>
       </div>
 
-      <%= f.submit "Publish changes", class: "govuk-button" %>
+      <%= f.submit "Publish changes", class: "govuk-button", data: { qa: 'location__publish-changes' } %>
     <% end %>
     <p class="govuk-body">
       <%= link_to "Cancel changes", provider_sites_path(@provider[:provider_code]), class: "govuk-link" %>

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -17,10 +17,9 @@ feature 'Index courses', type: :feature do
     jsonapi(:provider, :opted_in, courses: courses, accredited_body?: true, provider_code: 'A123')
   end
   let(:provider_response) { provider.render }
+  let(:courses_page) { PageObjects::Page::Organisations::Courses.new }
 
   describe "without accrediting providers" do
-    let(:organisations_courses_page) { PageObjects::Page::Organisations::Courses.new }
-
     before do
       user = jsonapi :user, :opted_in
       stub_omniauth(disable_completely: false, user: user)
@@ -39,7 +38,7 @@ feature 'Index courses', type: :feature do
       expect(find('h1')).to have_content('Courses')
       expect(page).to have_selector('tbody tr', count: provider.relationships[:courses].size)
 
-      first_row = organisations_courses_page.rows.first
+      first_row = courses_page.rows.first
       expect(first_row.name).to           have_content course_1.attributes[:name]
       expect(first_row.ucas_status).to    have_content 'Running'
       expect(first_row.content_status).to have_content 'Published'
@@ -53,7 +52,7 @@ feature 'Index courses', type: :feature do
         "https://localhost:44364/organisation/A123/course/self/#{course_1.attributes[:course_code]}"
       )
 
-      second_row = organisations_courses_page.rows.second
+      second_row = courses_page.rows.second
       expect(second_row.name).to          have_content course_2.attributes[:name]
       expect(second_row.is_it_on_find).to have_content('Yes - view online')
       expect(second_row.applications).to  have_content 'Open'
@@ -62,14 +61,14 @@ feature 'Index courses', type: :feature do
         "https://localhost:5000/course/A123/#{course_2.attributes[:course_code]}"
       )
 
-      third_row = organisations_courses_page.rows.third
+      third_row = courses_page.rows.third
       expect(third_row.name).to           have_content course_3.attributes[:name]
       expect(third_row.content_status).to have_content 'Empty'
       expect(third_row.is_it_on_find).to  have_content 'No'
       expect(third_row.applications).to   have_content ''
       expect(third_row.vacancies).to      have_content ''
 
-      fourth_row = organisations_courses_page.rows.fourth
+      fourth_row = courses_page.rows.fourth
       expect(fourth_row.name).to           have_content course_4.attributes[:name]
       expect(fourth_row.content_status).to have_content ''
       expect(fourth_row.is_it_on_find).to  have_content 'No'
@@ -78,7 +77,7 @@ feature 'Index courses', type: :feature do
     end
 
     scenario "it shows 'add a new course' link" do
-      expect(page).to have_link('Add a new course', href: /#{Settings.google_forms.new_course_for_accredited_bodies.url.gsub('?', '\?')}/)
+      expect(courses_page).to have_link_to_add_a_course_for_accredited_bodies
     end
   end
 
@@ -110,14 +109,13 @@ feature 'Index courses', type: :feature do
     scenario "it shows a list of courses" do
       expect(find('h1')).to have_content('Courses')
       expect(page).to have_selector('table', count: 3)
-      expect(page).to have_link('Add a new course', href: /#{Settings.google_forms.new_course_for_unaccredited_bodies.url.gsub('?', '\?')}/)
 
       expect(page.all('h2')[0]).to have_content('Accredited body Aacme Scitt')
       expect(page.all('h2')[1]).to have_content('Accredited body Zacme Scitt')
     end
 
     scenario "it shows 'add a new course' link" do
-      expect(page).to have_link('Add a new course', href: /#{Settings.google_forms.new_course_for_unaccredited_bodies.url.gsub('?', '\?')}/)
+      expect(courses_page).to have_link_to_add_a_course_for_unaccredited_bodies
     end
   end
 

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -39,9 +39,10 @@ feature 'Index courses', type: :feature do
 
     scenario 'it shows a list of courses' do
       expect(courses_page.title).to have_content('Courses')
-      expect(courses_page.rows.size).to eq(4)
+      courses_table = courses_page.courses_tables.first
+      expect(courses_table.rows.size).to eq(4)
 
-      first_row = courses_page.rows.first
+      first_row = courses_table.rows.first
       expect(first_row.name).to           have_content course_1.attributes[:name]
       expect(first_row.ucas_status).to    have_content 'Running'
       expect(first_row.content_status).to have_content 'Published'
@@ -55,7 +56,7 @@ feature 'Index courses', type: :feature do
         "https://localhost:44364/organisation/A123/course/self/#{course_1.attributes[:course_code]}"
       )
 
-      second_row = courses_page.rows.second
+      second_row = courses_table.rows.second
       expect(second_row.name).to          have_content course_2.attributes[:name]
       expect(second_row.is_it_on_find).to have_content('Yes - view online')
       expect(second_row.applications).to  have_content 'Open'
@@ -64,14 +65,14 @@ feature 'Index courses', type: :feature do
         "https://localhost:5000/course/A123/#{course_2.attributes[:course_code]}"
       )
 
-      third_row = courses_page.rows.third
+      third_row = courses_table.rows.third
       expect(third_row.name).to           have_content course_3.attributes[:name]
       expect(third_row.content_status).to have_content 'Empty'
       expect(third_row.is_it_on_find).to  have_content 'No'
       expect(third_row.applications).to   have_content ''
       expect(third_row.vacancies).to      have_content ''
 
-      fourth_row = courses_page.rows.fourth
+      fourth_row = courses_table.rows.fourth
       expect(fourth_row.name).to           have_content course_4.attributes[:name]
       expect(fourth_row.content_status).to have_content ''
       expect(fourth_row.is_it_on_find).to  have_content 'No'
@@ -105,16 +106,18 @@ feature 'Index courses', type: :feature do
         "/providers/A123?include=courses.accrediting_provider",
         provider_response
       )
-      visit "/"
-      click_on "Courses"
+      root_page.load
+      expect(organisation_page).to be_displayed(provider_code: 'A123')
+      organisation_page.courses.click
     end
 
     scenario "it shows a list of courses" do
-      expect(find('h1')).to have_content('Courses')
-      expect(page).to have_selector('table', count: 3)
+      expect(courses_page.title).to have_content('Courses')
+      expect(courses_page.courses_tables.size).to eq(3)
 
-      expect(page.all('h2')[0]).to have_content('Accredited body Aacme Scitt')
-      expect(page.all('h2')[1]).to have_content('Accredited body Zacme Scitt')
+      expect(courses_page.courses_tables.first).to_not have_subheading
+      expect(courses_page.courses_tables.second.subheading).to have_content('Accredited body Aacme Scitt')
+      expect(courses_page.courses_tables.third.subheading).to have_content('Accredited body Zacme Scitt')
     end
 
     scenario "it shows 'add a new course' link" do

--- a/spec/features/locations/edit_spec.rb
+++ b/spec/features/locations/edit_spec.rb
@@ -8,24 +8,28 @@ feature 'Edit locations', type: :feature do
   end
 
   let(:provider_attributes) { provider[:data][:attributes] }
+  let(:provider_code) { provider_attributes[:provider_code] }
+  let(:locations_page) { PageObjects::Page::LocationsPage.new }
+  let(:location_page) { PageObjects::Page::LocationPage.new }
 
   describe "without errors" do
     before do
       stub_omniauth
       stub_session_create
-      stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}?include=sites", provider)
-      stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}/sites/#{site.id}", site, :patch, 200)
+      stub_api_v2_request("/providers/#{provider_code}?include=sites", provider)
+      stub_api_v2_request("/providers/#{provider_code}/sites/#{site.id}", site, :patch, 200)
     end
 
     scenario 'it shows a location' do
-      visit edit_provider_site_path(provider_attributes[:provider_code], site.id)
+      visit edit_provider_site_path(provider_code, site.id)
 
-      expect(find('h1')).to have_content('Main site 1')
+      expect(location_page).to be_displayed(provider_code: provider_code, site_id: site.id)
+      expect(location_page.title).to have_content('Main site 1')
 
-      click_on('Publish changes')
+      location_page.publish_changes.click
 
-      expect(find('h1')).to have_content('Locations')
-      expect(find('.govuk-success-summary')).to have_content('Your changes have been published')
+      expect(locations_page).to be_displayed
+      expect(locations_page.success_summary).to have_content('Your changes have been published')
     end
   end
 
@@ -33,30 +37,30 @@ feature 'Edit locations', type: :feature do
     before do
       stub_omniauth
       stub_session_create
-      stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}?include=sites", provider)
-      stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}/sites/#{site.id}", build(:error), :patch, 422)
+      stub_api_v2_request("/providers/#{provider_code}?include=sites", provider)
+      stub_api_v2_request("/providers/#{provider_code}/sites/#{site.id}", build(:error), :patch, 422)
     end
 
     scenario 'displays validation errors' do
-      visit edit_provider_site_path(provider_attributes[:provider_code], site.id)
+      visit edit_provider_site_path(provider_code, site.id)
 
-      expect(find('h1')).to have_content('Main site 1')
+      expect(location_page).to be_displayed(provider_code: provider_code, site_id: site.id)
 
-      click_on('Publish changes')
+      location_page.publish_changes.click
 
-      expect(find('h1')).to have_content('Main site 1')
-      expect(find('.govuk-error-summary')).to have_content('Name is missing')
+      expect(location_page).to be_displayed(provider_code: provider_code, site_id: site.id)
+      expect(location_page.error_summary).to have_content('Name is missing')
     end
 
     scenario 'displays the old location name when the change fails' do
-      visit edit_provider_site_path(provider_attributes[:provider_code], site.id)
+      visit edit_provider_site_path(provider_code, site.id)
 
-      expect(find('h1')).to have_content('Main site 1')
+      expect(location_page.title).to have_content('Main site 1')
 
-      fill_in("Name", with: "Main site 2")
-      click_on('Publish changes')
+      location_page.name_field.set "Main site 2"
+      location_page.publish_changes.click
 
-      expect(find('h1')).to have_content('Main site 1')
+      expect(location_page.title).to have_content('Main site 1')
     end
   end
 end

--- a/spec/features/locations/index_spec.rb
+++ b/spec/features/locations/index_spec.rb
@@ -13,26 +13,33 @@ feature 'View locations', type: :feature do
     jsonapi(:provider, sites: sites).render
   end
   let(:provider_attributes) { provider[:data][:attributes] }
+  let(:provider_code) { provider_attributes[:provider_code] }
   let(:site_response) { sites[0].render }
+  let(:root_page) { PageObjects::Page::RootPage.new }
+  let(:organisation_page) { PageObjects::Page::Organisations::OrganisationPage.new }
+  let(:locations_page) { PageObjects::Page::LocationsPage.new }
+  let(:location_page) { PageObjects::Page::LocationPage.new }
 
   before do
     user = jsonapi :user, :opted_in
     stub_omniauth(disable_completely: false, user: user)
     stub_session_create(user: User.new(JSON.parse(user.to_json)))
     stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider[:data]]))
-    stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}", provider)
-    stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}?include=sites", provider)
+    stub_api_v2_request("/providers/#{provider_code}", provider)
+    stub_api_v2_request("/providers/#{provider_code}?include=sites", provider)
 
-    visit "/"
-    click_on "Locations"
+    root_page.load
+    expect(organisation_page).to be_displayed(provider_code: provider_code)
+    organisation_page.locations.click
   end
 
   scenario 'it shows a list of locations' do
-    expect(find('h1')).to have_content('Locations')
-    expect(page).to have_selector('tbody tr', count: 3)
-    expect(first('.govuk-table__cell')).to_not have_link('Main site 1')
-    expect(first('.govuk-table__cell')).to have_content('Main site 1')
-    expect(page).to_not have_link('Add a location')
+    expect(locations_page).to be_displayed(provider_code: provider_code)
+    expect(locations_page.title).to have_content('Locations')
+    expect(locations_page.locations.size).to eq(3)
+    expect(locations_page.locations.first).to_not have_link
+    expect(locations_page.locations.first.cell.text).to eq('Main site 1')
+    expect(locations_page).to_not have_add_a_location_link
   end
 
   context 'when the provider is opted_in' do
@@ -41,16 +48,17 @@ feature 'View locations', type: :feature do
     end
 
     scenario 'it shows one location' do
-      stub_api_v2_request("/providers/#{provider_attributes[:provider_code]}/sites/#{sites.first.id}", site_response)
+      stub_api_v2_request("/providers/#{provider_code}/sites/#{sites.first.id}", site_response)
 
-      click_on "Main site 1"
+      expect(locations_page.locations.first).to have_link
+      locations_page.locations.first.link.click
 
-      expect(find('h1')).to have_content('Main site 1')
+      expect(location_page).to be_displayed(provider_code: provider_code, site_id: sites[0].id)
+      expect(location_page.title).to have_content('Main site 1')
     end
 
-    scenario 'should show Add Location CTA' do
-      expect(first('.govuk-table__cell')).to have_link('Main site 1')
-      expect(page).to have_link('Add a location', href: /#{Settings.google_forms.add_location.url.gsub('?', '\?')}/)
+    scenario 'prompts users to add new locations' do
+      expect(locations_page).to have_add_a_location_link
     end
   end
 end

--- a/spec/site_prism/page_objects/page/location_page.rb
+++ b/spec/site_prism/page_objects/page/location_page.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module Page
+    class LocationPage < PageObjects::Base
+      set_url '/organisations/{provider_code}/locations/{site_id}/edit'
+
+      element :title, 'h1'
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/location_page.rb
+++ b/spec/site_prism/page_objects/page/location_page.rb
@@ -2,8 +2,12 @@ module PageObjects
   module Page
     class LocationPage < PageObjects::Base
       set_url '/organisations/{provider_code}/locations/{site_id}/edit'
+      set_url_matcher(%r{/organisations/.*?/locations/\d+(/edit)?$})
 
       element :title, 'h1'
+      element :name_field, 'input[data-qa="location__name"]'
+      element :publish_changes, '[data-qa="location__publish-changes"]'
+      element :error_summary, '.govuk-error-summary'
     end
   end
 end

--- a/spec/site_prism/page_objects/page/locations_page.rb
+++ b/spec/site_prism/page_objects/page/locations_page.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module Page
+    class LocationsPage < PageObjects::Base
+      set_url '/organisations/{provider_code}/locations'
+
+      element :title, 'h1'
+      sections :locations, 'tbody tr' do
+        element :link, 'a'
+        element :cell, '[data-qa=provider__location-name]'
+      end
+      element :add_a_location_link, "a[href^=\"#{Settings.google_forms.add_location.url.gsub('?', '\?')}\"]"
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/locations_page.rb
+++ b/spec/site_prism/page_objects/page/locations_page.rb
@@ -3,6 +3,7 @@ module PageObjects
     class LocationsPage < PageObjects::Base
       set_url '/organisations/{provider_code}/locations'
 
+      element :success_summary, '.govuk-success-summary'
       element :title, 'h1'
       sections :locations, 'tbody tr' do
         element :link, 'a'

--- a/spec/site_prism/page_objects/page/organisations/courses.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses.rb
@@ -15,6 +15,12 @@ module PageObjects
           element :applications, '[data-qa="courses-table__applications"]'
           element :vacancies, '[data-qa="courses-table__vacancies"]'
         end
+
+        element :link_to_add_a_course_for_unaccredited_bodies, "a[href^=\"#{Settings.google_forms.new_course_for_unaccredited_bodies.url.gsub('?', '\?')}\"]",
+          text: "Add a new course"
+
+        element :link_to_add_a_course_for_accredited_bodies, "a[href^=\"#{Settings.google_forms.new_course_for_accredited_bodies.url.gsub('?', '\?')}\"]",
+            text: "Add a new course"
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/courses.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses.rb
@@ -5,15 +5,18 @@ module PageObjects
         set_url '/organisations/{provider_code}/courses'
 
         element :title, '.govuk-heading-xl'
-        sections :rows, 'tbody .govuk-table__row' do
-          element :name, '[data-qa="courses-table__course"]'
-          element :link, 'td.course-table__course-name a'
-          element :ucas_status, '[data-qa="courses-table__ucas-status"]'
-          element :content_status, '[data-qa="courses-table__content-status"]'
-          element :is_it_on_find, '[data-qa="courses-table__findable"]'
-          element :find_link, '[data-qa="courses-table__findable"] a'
-          element :applications, '[data-qa="courses-table__applications"]'
-          element :vacancies, '[data-qa="courses-table__vacancies"]'
+        sections :courses_tables, '[data-qa="courses__table-section"]' do
+          element :subheading, 'h2'
+          sections :rows, 'tbody tr' do
+            element :name, '[data-qa="courses-table__course"]'
+            element :link, 'td.course-table__course-name a'
+            element :ucas_status, '[data-qa="courses-table__ucas-status"]'
+            element :content_status, '[data-qa="courses-table__content-status"]'
+            element :is_it_on_find, '[data-qa="courses-table__findable"]'
+            element :find_link, '[data-qa="courses-table__findable"] a'
+            element :applications, '[data-qa="courses-table__applications"]'
+            element :vacancies, '[data-qa="courses-table__vacancies"]'
+          end
         end
 
         element :link_to_add_a_course_for_unaccredited_bodies, "a[href^=\"#{Settings.google_forms.new_course_for_unaccredited_bodies.url.gsub('?', '\?')}\"]",

--- a/spec/site_prism/page_objects/page/organisations/organisation_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_page.rb
@@ -4,7 +4,8 @@ module PageObjects
       class OrganisationPage < PageObjects::Base
         set_url '/organisations/{provider_code}'
 
-        element :locations, '[data-qa=provider__locations]'
+        element :locations, '[data-qa=provider__locations]', text: 'Locations'
+        element :courses, '[data-qa=provider__courses]', text: 'Courses'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/organisation_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_page.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Organisations
+      class OrganisationPage < PageObjects::Base
+        set_url '/organisations/{provider_code}'
+
+        element :locations, '[data-qa=provider__locations]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
#228 was merged without using page objects in any of the changed code. This PR is cleaning this up.

### Changes proposed in this pull request
- add some extra structure into the templates to make testing easier/more robust
- push selectors out of the feature specs and into page objects
