### PR TITLE
[1384] add course preview link

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -38,4 +38,8 @@ class Course < Base
   def has_unpublished_changes?
     content_status == "published_with_unpublished_changes"
   end
+
+  def is_published?
+    content_status == 'published'
+  end
 end

--- a/app/views/courses/_status_panel.html.erb
+++ b/app/views/courses/_status_panel.html.erb
@@ -8,30 +8,10 @@
     <%= course.on_find %>
   </p>
 
-  <% if course.is_published? %>
-    <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Applications</h3>
-    <p class="govuk-body" data-qa="course__open_for_applications"><%= course.open_or_closed_for_applications %></p>
-
-    <h3 class="govuk-heading-s govuk-!-margin-0">Vacancies</h3>
-    <p class="govuk-body" data-qa="course__has_vacancies">
-      <%= course.vacancies %>
-    </p>
-
-    <% if course.last_published_at.present? %>
-      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
-      <p class="govuk-body" data-qa="course__last_published_date">
-        Last published:<br>
-        <%= l(course.last_published_at&.to_date) %>
-      </p>
-    <% end %>
+  <% if course.is_published? && course.is_running? %>
+    <%= render partial: 'courses/status_panel/published' %>
   <% else %>
-    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
-    <h3 class="govuk-heading-m">Preview</h3>
-    <p class="govuk-body">See how your unpublished changes look.</p>
-    <p class="govuk-body">Preview your course to check for mistakes before publishing.</p>
-    <p class="govuk-body">
-      <%= link_to 'Preview course', search_ui_url("/preview/#{course.provider.provider_code}/#{course.course_code}"), class: 'govuk-link' %>
-    </p>
+    <%= render partial: 'courses/status_panel/unpublished' %>
   <% end %>
 
   <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/app/views/courses/_status_panel.html.erb
+++ b/app/views/courses/_status_panel.html.erb
@@ -8,17 +8,30 @@
     <%= course.on_find %>
   </p>
 
-  <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Applications</h3>
-  <p class="govuk-body" data-qa="course__open_for_applications"><%= course.open_or_closed_for_applications %></p>
+  <% if course.is_published? %>
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Applications</h3>
+    <p class="govuk-body" data-qa="course__open_for_applications"><%= course.open_or_closed_for_applications %></p>
 
-  <h3 class="govuk-heading-s govuk-!-margin-0">Vacancies</h3>
-  <p class="govuk-body" data-qa="course__has_vacancies">
-    <%= course.vacancies %>
-  </p>
+    <h3 class="govuk-heading-s govuk-!-margin-0">Vacancies</h3>
+    <p class="govuk-body" data-qa="course__has_vacancies">
+      <%= course.vacancies %>
+    </p>
 
-  <% if course.last_published_at.present? %>
+    <% if course.last_published_at.present? %>
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+      <p class="govuk-body" data-qa="course__last_published_date">
+        Last published:<br>
+        <%= l(course.last_published_at&.to_date) %>
+      </p>
+    <% end %>
+  <% else %>
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
-    <p class="govuk-body">Last published:<br><%= l(course.last_published_at&.to_date) %></p>
+    <h3 class="govuk-heading-m">Preview</h3>
+    <p class="govuk-body">See how your unpublished changes look.</p>
+    <p class="govuk-body">Preview your course to check for mistakes before publishing.</p>
+    <p class="govuk-body">
+      <%= link_to 'Preview course', search_ui_url("/preview/#{course.provider.provider_code}/#{course.course_code}"), class: 'govuk-link' %>
+    </p>
   <% end %>
 
   <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/app/views/courses/status_panel/_published.html.erb
+++ b/app/views/courses/status_panel/_published.html.erb
@@ -1,0 +1,15 @@
+<h3 class="govuk-heading-s govuk-!-margin-bottom-0">Applications</h3>
+<p class="govuk-body" data-qa="course__open_for_applications"><%= course.open_or_closed_for_applications %></p>
+
+<h3 class="govuk-heading-s govuk-!-margin-0">Vacancies</h3>
+<p class="govuk-body" data-qa="course__has_vacancies">
+  <%= course.vacancies %>
+</p>
+
+<% if course.last_published_at.present? %>
+  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+  <p class="govuk-body" data-qa="course__last_published_date">
+    Last published:<br>
+    <%= l(course.last_published_at&.to_date) %>
+  </p>
+<% end %>

--- a/app/views/courses/status_panel/_unpublished.html.erb
+++ b/app/views/courses/status_panel/_unpublished.html.erb
@@ -1,0 +1,7 @@
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+<h3 class="govuk-heading-m">Preview</h3>
+<p class="govuk-body">See how your unpublished changes look.</p>
+<p class="govuk-body">Preview your course to check for mistakes before publishing.</p>
+<p class="govuk-body">
+  <%= link_to 'Preview course', search_ui_url("/preview/#{course.provider.provider_code}/#{course.course_code}"), class: 'govuk-link' %>
+</p>

--- a/spec/features/courses/description_spec.rb
+++ b/spec/features/courses/description_spec.rb
@@ -9,7 +9,8 @@ feature 'Course description', type: :feature do
             funding: 'fee',
             site_statuses: [site_status],
             provider: provider,
-            accrediting_provider: provider)
+            accrediting_provider: provider,
+            last_published_at: '2019-03-05T14:42:34Z')
   }
   let(:site) { jsonapi(:site) }
   let(:site_status) do
@@ -67,6 +68,9 @@ feature 'Course description', type: :feature do
       expect(course_page.other_requirements).to have_content(
         course.other_requirements
       )
+      expect(course_page.last_published_at).to have_content(
+        'Last published: 5 March 2019'
+      )
     end
   end
 
@@ -116,16 +120,42 @@ feature 'Course description', type: :feature do
   end
 
   describe 'shows status panel' do
-    scenario 'displays if the course has vacancies' do
-      expect(course_page.has_vacancies).to have_content('Yes')
+    context 'published course' do
+      scenario 'displays if the course is on find' do
+        expect(course_page.is_findable).to have_content('Yes')
+      end
+
+      scenario 'displays if the course has vacancies' do
+        expect(course_page.has_vacancies).to have_content('Yes')
+      end
+
+      scenario 'displays if the course is open for applications' do
+        expect(course_page.open_for_applications).to have_content('Open')
+      end
     end
 
-    scenario 'displays if the course is open for applications' do
-      expect(course_page.open_for_applications).to have_content('Open')
-    end
+    context 'unpublished course' do
+      let(:course_jsonapi) {
+        jsonapi(:course,
+                findable?: false,
+                site_statuses: [site_status],
+                provider: provider,
+                accrediting_provider: provider)
+      }
+      let(:course)          { course_jsonapi.to_resource }
+      let(:course_response) { course_jsonapi.render }
 
-    scenario 'displays if the course is on find' do
-      expect(course_page.is_findable).to have_content('Yes')
+      scenario 'displays if the course is on find' do
+        expect(course_page.is_findable).to have_content('No')
+      end
+
+      scenario 'does not display if the course has vacancies' do
+        expect(course_page.has_vacancies).to_not have_content('Yes')
+      end
+
+      scenario 'does not display if the course is open for applications' do
+        expect(course_page.open_for_applications).to_not have_content('Open')
+      end
     end
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/course_description.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_description.rb
@@ -21,6 +21,7 @@ module PageObjects
         element :has_vacancies, '[data-qa=course__has_vacancies]'
         element :is_findable, '[data-qa=course__is_findable]'
         element :open_for_applications, '[data-qa=course__open_for_applications]'
+        element :last_published_at, '[data-qa=course__last_published_date]'
       end
     end
   end


### PR DESCRIPTION
### Context
Preview unpublished course

### Changes proposed in this pull request
- Render preview link if course is not published
- Hide vacancies info if course is not published
- Hide applications status if course is not published

### Guidance to review
# After
![localhost_3000_organisations_2CG_courses_2YZW_description(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/56907625-8fb5a780-6a9c-11e9-8bc8-5e32dab7fbc8.png)
![localhost_3000_organisations_2AT_courses_35L7_description(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/56907623-8fb5a780-6a9c-11e9-869e-8b90bdbb67f0.png)
