### PR TITLE
[1383] Fix course.on_find decorated method

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -11,11 +11,11 @@ class CourseDecorator < ApplicationDecorator
     content.html_safe
   end
 
-  def on_find(provider_code = object.provider.provider_code)
+  def on_find(provider = object.provider)
     if object.findable?
-      h.govuk_link_to("Yes - view online", h.search_ui_course_page_url(provider_code: provider_code, course_code: object.course_code))
+      h.govuk_link_to("Yes - view online", h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code))
     else
-      not_on_find
+      not_on_find(provider)
     end
   end
 
@@ -112,9 +112,9 @@ private
     h.content_tag(:div, '*&nbsp;Unpublished&nbsp;changes', class: 'govuk-body govuk-body-s govuk-!-margin-bottom-0 govuk-!-margin-top-1')
   end
 
-  def not_on_find
+  def not_on_find(provider)
     if object.new_and_not_running?
-      'No – ' + (object.provider.opted_in? ? 'still in draft' : 'must be published on UCAS').to_s
+      'No – ' + (provider.opted_in? ? 'still in draft' : 'must be published on UCAS').to_s
     else
       'No'
     end

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -13,7 +13,7 @@
     <%= course.content_status_badge %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__findable">
-    <%= course.on_find(@provider.provider_code) %>
+    <%= course.on_find(@provider) %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__applications">
     <% if course.is_running? %>


### PR DESCRIPTION
### Context

Product review.

### Changes proposed in this pull request

Pass in the provider to `not_on_find` so that it can work in the courses index page, where courses do not have a provider attached to the `object`.

### Guidance to review

The existing tests already unit test this functionality; arguably this could do with an integration test.