### PR TITLE
[1383] Always show content status in status panel

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -51,8 +51,6 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def content_status_badge
-    return if object.not_running?
-
     badge = h.content_tag(:div, content_tag_content.html_safe, class: "govuk-tag phase-tag--small #{content_tag_css_class}")
     badge += content_tag_unpublished if object.has_unpublished_changes?
     badge.html_safe

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -10,7 +10,9 @@
     <%= course.ucas_status %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__content-status">
-    <%= course.content_status_badge %>
+    <% unless course.not_running? %>
+      <%= course.content_status_badge %>
+    <% end %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__findable">
     <%= course.on_find(@provider) %>

--- a/app/views/courses/_status_panel.html.erb
+++ b/app/views/courses/_status_panel.html.erb
@@ -1,6 +1,6 @@
 <div class="status-box">
   <h3 class="govuk-heading-m">Status</h3>
-  <div class="govuk-!-margin-bottom-6">
+  <div class="govuk-!-margin-bottom-6" data-qa="course__content-status">
     <%= course.content_status_badge %>
   </div>
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Is it on Find?</h3>

--- a/spec/features/courses/description_spec.rb
+++ b/spec/features/courses/description_spec.rb
@@ -120,24 +120,18 @@ feature 'Course description', type: :feature do
   end
 
   describe 'shows status panel' do
-    context 'published course' do
-      scenario 'displays if the course is on find' do
-        expect(course_page.is_findable).to have_content('Yes')
-      end
-
-      scenario 'displays if the course has vacancies' do
-        expect(course_page.has_vacancies).to have_content('Yes')
-      end
-
-      scenario 'displays if the course is open for applications' do
-        expect(course_page.open_for_applications).to have_content('Open')
-      end
+    scenario 'displays status panel' do
+      expect(course_page.is_findable).to have_content('Yes')
+      expect(course_page.has_vacancies).to have_content('Yes')
+      expect(course_page.open_for_applications).to have_content('Open')
+      expect(course_page.content_status).to have_content('Published')
     end
 
     context 'unpublished course' do
       let(:course_jsonapi) {
         jsonapi(:course,
                 findable?: false,
+                content_status: 'draft',
                 site_statuses: [site_status],
                 provider: provider,
                 accrediting_provider: provider)
@@ -145,16 +139,9 @@ feature 'Course description', type: :feature do
       let(:course)          { course_jsonapi.to_resource }
       let(:course_response) { course_jsonapi.render }
 
-      scenario 'displays if the course is on find' do
+      scenario 'displays status panel' do
         expect(course_page.is_findable).to have_content('No')
-      end
-
-      scenario 'does not display if the course has vacancies' do
-        expect(course_page.has_vacancies).to_not have_content('Yes')
-      end
-
-      scenario 'does not display if the course is open for applications' do
-        expect(course_page.open_for_applications).to_not have_content('Open')
+        expect(course_page.content_status).to have_content('Draft')
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_description.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_description.rb
@@ -22,6 +22,7 @@ module PageObjects
         element :is_findable, '[data-qa=course__is_findable]'
         element :open_for_applications, '[data-qa=course__open_for_applications]'
         element :last_published_at, '[data-qa=course__last_published_date]'
+        element :content_status, '[data-qa=course__content-status]'
       end
     end
   end


### PR DESCRIPTION
### Context
Course content status after decorator change which introduced this bug

### Changes proposed in this pull request
- Continue to hide course content status "badge" in the courses table
- Always show the course content status "badge" in the status panel on /description

### Guidance to review
# Before 
<img width="1552" alt="Screenshot 2019-04-30 at 18 00 53" src="https://user-images.githubusercontent.com/3071606/56979525-eb9e3000-6b71-11e9-93c9-a025991fcd1d.png">

# After 
<img width="1552" alt="Screenshot 2019-04-30 at 17 59 14" src="https://user-images.githubusercontent.com/3071606/56979417-af6acf80-6b71-11e9-9795-f0909327e0d4.png">