### PR TITLE
[1409] Add guard

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,12 @@
 inherit_gem:
   govuk-lint: configs/rubocop/all.yml
+
+AllCops:
+  Exclude:
+    - 'bin/rails'
+    - 'bin/rake'
+    - 'bin/setup'
+    - 'bin/update'
+    - 'bin/yarn'
+    - 'db/schema.rb'
+    - 'node_modules/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -71,11 +71,17 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+  gem 'spring-commands-rspec'
   gem 'spring-watcher-listen', '~> 2.0.0'
 
   # For better errors
   gem 'better_errors'
   gem 'binding_of_caller'
+
+  # Run tests automatically
+  gem 'guard'
+  gem 'guard-rspec', require: false
+  gem 'guard-rubocop', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,12 +145,30 @@ GEM
     ffi (1.10.0)
     foreman (0.85.0)
       thor (~> 0.19.1)
+    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govuk-lint (3.11.0)
       rubocop (~> 0.64)
       rubocop-rspec (~> 1.28)
       scss_lint
+    guard (2.15.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    guard-rubocop (1.3.0)
+      guard (~> 2.0)
+      rubocop (~> 0.20)
     hashdiff (0.3.8)
     hashie (3.6.0)
     httpclient (2.8.3)
@@ -177,6 +195,7 @@ GEM
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lumberjack (1.0.13)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
@@ -188,9 +207,13 @@ GEM
     minitest (5.11.3)
     msgpack (1.2.10)
     multipart-post (2.0.0)
+    nenv (0.3.0)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    notiffany (0.1.1)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
@@ -266,6 +289,10 @@ GEM
     regexp_parser (1.4.0)
     request_store (1.4.1)
       rack (>= 1.4)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -312,6 +339,7 @@ GEM
       rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.9.0)
       faraday (>= 0.7.6, < 1.0)
+    shellany (0.0.1)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -322,6 +350,8 @@ GEM
       capybara (~> 3.2)
     spring (2.0.2)
       activesupport (>= 4.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -393,6 +423,9 @@ DEPENDENCIES
   faker
   foreman
   govuk-lint
+  guard
+  guard-rspec
+  guard-rubocop
   json_api_client
   jwt
   listen (>= 3.0.5, < 3.2)
@@ -410,6 +443,7 @@ DEPENDENCIES
   simplecov
   site_prism
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   super_diff
   tzinfo-data

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,76 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+# rubocop:disable Metrics/BlockLength
+group :red_green_refactor, halt_on_fail: true do
+  guard :rspec, cmd: 'bundle exec spring rspec', failed_mode: :keep do
+    require "guard/rspec/dsl"
+    dsl = Guard::RSpec::Dsl.new(self)
+
+    # Feel free to open issues for suggestions and improvements
+
+    # RSpec files
+    rspec = dsl.rspec
+    watch(rspec.spec_helper) { rspec.spec_dir }
+    watch(rspec.spec_support) { rspec.spec_dir }
+    watch(rspec.spec_files)
+
+    # Ruby files
+    ruby = dsl.ruby
+    dsl.watch_spec_files_for(ruby.lib_files)
+
+    # Rails files
+    rails = dsl.rails(view_extensions: %w(erb))
+    dsl.watch_spec_files_for(rails.app_files)
+    dsl.watch_spec_files_for(rails.views)
+
+    watch(rails.controllers) do |m|
+      [
+        rspec.spec.call("controllers/#{m[1]}_controller"),
+      ]
+    end
+
+    # Rails config changes
+    watch(rails.spec_helper)     { rspec.spec_dir }
+    watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+    watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+    # Capybara features specs
+    watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+    watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+  end
+
+  guard :rubocop do
+    watch(%r{.+\.rb$})
+    watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
+  end
+
+  guard :rubocop, all_on_start: false do
+    watch(%r{.+\.rb$})
+    watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/README.md
+++ b/README.md
@@ -38,8 +38,15 @@ bundle exec rake
 ```
 
 ## Running specs
+
 ```
 bundle exec rspec
+```
+
+Or through guard (`--no-interactions` allows the use of `pry` inside tests):
+
+```bash
+bundle exec guard --no-interactions
 ```
 
 ## Linting


### PR DESCRIPTION
### Context

This allows us to automatically run rspec on files that have changed. Uses spring so they run faster.

Add guard-rubocop, and ignore generated files when running rubocop.