### PR TITLE
[1383] rename content status tag

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -50,10 +50,10 @@ class CourseDecorator < ApplicationDecorator
     object.subjects.sort.join("<br>").html_safe
   end
 
-  def content_status_badge
-    badge = h.content_tag(:div, content_tag_content.html_safe, class: "govuk-tag phase-tag--small #{content_tag_css_class}")
-    badge += content_tag_unpublished if object.has_unpublished_changes?
-    badge.html_safe
+  def status_tag
+    tag = h.content_tag(:div, status_tag_content.html_safe, class: "govuk-tag phase-tag--small #{status_tag_css_class}")
+    tag += unpublished_status_hint if object.has_unpublished_changes?
+    tag.html_safe
   end
 
   def length
@@ -80,7 +80,7 @@ class CourseDecorator < ApplicationDecorator
 
 private
 
-  def content_tag_content
+  def status_tag_content
     case object.content_status
     when 'published'
       'Published'
@@ -93,7 +93,7 @@ private
     end
   end
 
-  def content_tag_css_class
+  def status_tag_css_class
     case course.content_status
     when 'published'
       'phase-tag--published'
@@ -106,7 +106,7 @@ private
     end
   end
 
-  def content_tag_unpublished
+  def unpublished_status_hint
     h.content_tag(:div, '*&nbsp;Unpublished&nbsp;changes'.html_safe, class: 'govuk-body govuk-body-s govuk-!-margin-bottom-0 govuk-!-margin-top-1')
   end
 

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -11,7 +11,7 @@
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__content-status">
     <% unless course.not_running? %>
-      <%= course.content_status_badge %>
+      <%= course.status_tag %>
     <% end %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__findable">

--- a/app/views/courses/_status_panel.html.erb
+++ b/app/views/courses/_status_panel.html.erb
@@ -1,7 +1,7 @@
 <div class="status-box">
   <h3 class="govuk-heading-m">Status</h3>
   <div class="govuk-!-margin-bottom-6" data-qa="course__content-status">
-    <%= course.content_status_badge %>
+    <%= course.status_tag %>
   </div>
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Is it on Find?</h3>
   <p class="govuk-body" data-qa="course__is_findable">

--- a/spec/features/courses/description_spec.rb
+++ b/spec/features/courses/description_spec.rb
@@ -124,7 +124,7 @@ feature 'Course description', type: :feature do
       expect(course_page.is_findable).to have_content('Yes')
       expect(course_page.has_vacancies).to have_content('Yes')
       expect(course_page.open_for_applications).to have_content('Open')
-      expect(course_page.content_status).to have_content('Published')
+      expect(course_page.status_tag).to have_content('Published')
     end
 
     context 'unpublished course' do
@@ -141,7 +141,7 @@ feature 'Course description', type: :feature do
 
       scenario 'displays status panel' do
         expect(course_page.is_findable).to have_content('No')
-        expect(course_page.content_status).to have_content('Draft')
+        expect(course_page.status_tag).to have_content('Draft')
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_description.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_description.rb
@@ -22,7 +22,7 @@ module PageObjects
         element :is_findable, '[data-qa=course__is_findable]'
         element :open_for_applications, '[data-qa=course__open_for_applications]'
         element :last_published_at, '[data-qa=course__last_published_date]'
-        element :content_status, '[data-qa=course__content-status]'
+        element :status_tag, '[data-qa=course__content-status]'
       end
     end
   end


### PR DESCRIPTION
### Context
Naming is hard

`content_tag` is a helper in rails so this code is confusing to read

### Changes proposed in this pull request
Rename to `status_tag`
