### PR TITLE
[1415] redirect users back to where they were going on signin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,7 @@ class ApplicationController < ActionController::Base
 
       set_user_session if current_user['user_id'].blank?
     else
+      session[:redirect_back_to] = request.path
       redirect_to '/signin'
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,7 +14,7 @@ class SessionsController < ApplicationController
     if user.opted_in? && user.state == 'new'
       redirect_to transition_info_path
     else
-      redirect_to root_path
+      redirect_to session[:redirect_back_to] || root_path
     end
   end
 

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe 'sessions' do
+  let(:provider) { jsonapi :provider }
+  let(:provider_page) { PageObjects::Page::Organisations::OrganisationPage.new }
+  let(:root_page) { PageObjects::Page::RootPage.new }
+
+  it 'redirects users back to where they were going on sign-in' do
+    stub_omniauth disable_completely: false
+    stub_session_create
+    stub_api_v2_request('/providers', jsonapi(:providers_response))
+    stub_api_v2_request("/providers/#{provider.provider_code}", provider.render)
+
+    visit "/organisations/#{provider.provider_code}"
+
+    expect(provider_page).to be_displayed(provider_code: provider.provider_code)
+  end
+
+  it 'redirects users to root when they go straight to the signin page' do
+    stub_omniauth disable_completely: false
+    stub_session_create
+    stub_api_v2_request('/providers', jsonapi(:providers_response))
+
+    visit '/signin'
+
+    expect(root_page).to be_displayed
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -27,7 +27,7 @@ module Helpers
     end
   end
 
-  def stub_session_create(user: double(id: 1))
+  def stub_session_create(user: double(id: 1, 'opted_in?': false))
     allow(Session).to receive(:create).and_return(user)
   end
 


### PR DESCRIPTION
https://trello.com/c/s3cyWAso/1415-dont-always-redirect-to-root-on-sign-in

### Context

On sign-in users would be redirected to `/` no matter where they were originally going.

### Changes proposed in this pull request

Save where users were going before the sign-in and send them there after they are signed in. If not saved for any reason, they will still go to `/`.

### Guidance to review
