### PR TITLE
[1302] fix authorization errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,6 @@ class ApplicationController < ActionController::Base
 
   before_action :set_has_multiple_providers,
                 :authenticate
-  after_action :nuke_token
 
   def not_found
     respond_to do |format|
@@ -82,14 +81,6 @@ private
                         Settings.authentication.secret,
                         Settings.authentication.algorithm)
 
-    Base.connection(true) do |connection|
-      connection.use FaradayMiddleware::OAuth2, token, token_type: :bearer
-    end
-  end
-
-  def nuke_token
-    Base.connection(true) do |connection|
-      connection.use FaradayMiddleware::OAuth2, nil, token_type: :bearer
-    end
+    Thread.current[:manage_courses_backend_token] = token
   end
 end

--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -4,7 +4,7 @@ class Base < JsonApiClient::Resource
   # the user was first authenticated.
   class MCBConnection < JsonApiClient::Connection
     def run(request_method, path, params: nil, headers: {}, body: nil)
-      authorization = "Bearer #{Thread.current[:manage_courses_backend_token]}"
+      authorization = "Bearer #{Thread.current.fetch(:manage_courses_backend_token)}"
       super(
         request_method,
         path,

--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -1,5 +1,22 @@
 class Base < JsonApiClient::Resource
+  # This connection class grabs the bearer token from the thread key-value
+  # store and adds it to our connection. This token was saved there for us when
+  # the user was first authenticated.
+  class MCBConnection < JsonApiClient::Connection
+    def run(request_method, path, params: nil, headers: {}, body: nil)
+      authorization = "Bearer #{Thread.current[:manage_courses_backend_token]}"
+      super(
+        request_method,
+        path,
+        params: params,
+        headers: headers.update('Authorization' => authorization),
+        body: body
+      )
+    end
+  end
+
   include Draper::Decoratable
 
   self.site = "#{Settings.manage_backend.base_url}/api/v2/"
+  self.connection_class = MCBConnection
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -58,10 +58,6 @@ RSpec.describe ApplicationController, type: :controller do
           expect(JWT).to have_received(:encode)
         end
 
-        it "has set connection" do
-          expect(Base).to have_received(:connection)
-        end
-
         it "has not called session create" do
           expect(Session).to_not have_received(:create)
         end
@@ -95,10 +91,6 @@ RSpec.describe ApplicationController, type: :controller do
 
         it "has performed jwt encoding" do
           expect(JWT).to have_received(:encode)
-        end
-
-        it "has set connection" do
-          expect(Base).to have_received(:connection)
         end
 
         it "has called session create" do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe SessionsController, type: :controller do
         expect(subject).to redirect_to("/")
         expect(@request.session[:auth_user]['user_id']).to eq user_id
         expect(@request.session[:auth_user]["info"]).to eq user.attributes
-        expect(Base).to have_received(:connection).with(true).twice
       end
     end
 

--- a/spec/features/backend_requests_spec.rb
+++ b/spec/features/backend_requests_spec.rb
@@ -6,8 +6,46 @@ describe 'requests made to mc-be' do
     let(:provider2) { jsonapi :provider }
 
     it 'is thread-safe' do
+      # The api calls in this test should be completely isolated:
+      # - request 1 + provider 1 + user 1 token
+      # should not be in any way mixed up with:
+      # - request 2 + provider 2 + user 2 token
+
+      # This test simulates a thread-based race bug we found in the wild. Two
+      # concurrent calls would result in the auth token of one user being used
+      # for the call to the backend for a different user's request, resulting
+      # in users seeing each-others' data. (This is bad).
+      #
+      # The token was being stored in Faraday's connection which it turns out
+      # is not thread-safe, resulting in there only being a single place to
+      # store the token for every request. The PR that adds this test also
+      # changes the token storage to be explicitly thread-local.
+      #
+      # See class `MCBConnection` for the fix.
+      #
+      # Sequence of events:
+      #
+      #   - Request 1: start - sets the authorisation token for user1
+      #   - Request 1: invoke the controller action which takes a little time
+      #                opening it up to a race condition error
+      #
+      #   - - Request 2: begins while Request 1 is not yet complete (in
+      #                  a separate thread)
+      #   - - Request 2: overwrite the previous token (user1) as a part of
+      #                  authentication
+      #   - - Request 2: make the provider2 api call
+      #   - - Request 2: allow the call to complete
+      #
+      #   The state is now corrupt as the user1 token has been overwritten by
+      #   user2 token
+      #
+      #   - Request 1: allow the call to complete - this will use the wrong
+      #                user token for its call to the backend api.
+
       stub_omniauth disable_completely: false
       stub_session_create
+
+      # Stub extra dependencies, these calls are not under test here.
       stub_api_v2_request(
         '/providers',
         jsonapi(:providers_response, data: [provider1, provider2]),
@@ -18,6 +56,16 @@ describe 'requests made to mc-be' do
         jsonapi(:providers_response, data: [provider1, provider2]),
         token: 'tokenUser2'
       )
+
+      # Stub the expected provider-code & token pairings.
+      # The calls to the provider1 endpoint should use the user1 token,
+      # calls to the provider2 endpoint should use the user2 token.
+      #
+      # By only stubbing these two exact combinations of provider_code and
+      # token, any calls that use the wrong token for a provider will cause a
+      # test failure (due to accessing a url+token combination that has no
+      # stub). This is the assertion in this test, hence there is no further
+      # explicit expect() in this test.
       stub_api_v2_request(
         "/providers/#{provider1.provider_code}",
         provider1.render,
@@ -29,31 +77,34 @@ describe 'requests made to mc-be' do
         token: 'tokenUser2'
       )
 
+      # Intercept a call to `find` in the middle of the flow of a provider1
+      # request so that we can introduce a concurrent api call for provider2.
       allow(Provider).to receive(:find)
                            .with(provider1.provider_code)
                            .and_wrap_original do |method, *args|
-        # This simulates a bug we found in the wild:
-        #
-        #   - Request 1: start and set the authorisation token for user2 on the
-        #                Faraday connection
-        #   - Request 1: invoke the controller action which takes a little time
-        #                opening it up to a race condition error
-        #   - Request 2: start and set the authorisation token for user2 on the
-        #                Faraday connection
-        #   - Request 1: connect to manage-courses backend with user1's token
-        thread = Thread.new do
+        thread = Thread.new do # thread2
+          # stable JWT encoding mock
           allow(JWT).to receive(:encode).and_return('tokenUser2')
+          # fire off a concurrent call to trigger the race condition:
           visit("/organisations/#{provider2.provider_code}")
         end
+        # ensure the second call has completed so that shared state will have
+        # been modified
         thread.join
+        # allow thread1 to continue
         method.call(*args)
       end
 
+      # Because we've intercepted the provider1 find call we need to still
+      # allow the provider2 find call
       allow(Provider).to receive(:find)
                            .with(provider2.provider_code)
                            .and_call_original
 
+      # stable JWT encoding mock
       allow(JWT).to receive(:encode).and_return('tokenUser1')
+
+      # Fire off the provider1 call (the first of the two concurrent threads)
       visit("/organisations/#{provider1.provider_code}")
     end
   end

--- a/spec/features/backend_requests_spec.rb
+++ b/spec/features/backend_requests_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe 'requests made to mc-be' do
+  describe 'the authorization header' do
+    let(:provider1) { jsonapi :provider }
+    let(:provider2) { jsonapi :provider }
+
+    it 'is thread-safe' do
+      stub_omniauth disable_completely: false
+      stub_session_create
+      stub_api_v2_request(
+        '/providers',
+        jsonapi(:providers_response, data: [provider1, provider2]),
+        token: 'tokenUser1'
+      )
+      stub_api_v2_request(
+        '/providers',
+        jsonapi(:providers_response, data: [provider1, provider2]),
+        token: 'tokenUser2'
+      )
+      stub_api_v2_request(
+        "/providers/#{provider1.provider_code}",
+        provider1.render,
+        token: 'tokenUser1'
+      )
+      stub_api_v2_request(
+        "/providers/#{provider2.provider_code}",
+        provider2.render,
+        token: 'tokenUser2'
+      )
+
+      allow(Provider).to receive(:find)
+                           .with(provider1.provider_code)
+                           .and_wrap_original do |method, *args|
+        # This simulates a bug we found in the wild:
+        #
+        #   - Request 1: start and set the authorisation token for user2 on the
+        #                Faraday connection
+        #   - Request 1: invoke the controller action which takes a little time
+        #                opening it up to a race condition error
+        #   - Request 2: start and set the authorisation token for user2 on the
+        #                Faraday connection
+        #   - Request 1: connect to manage-courses backend with user1's token
+        thread = Thread.new do
+          allow(JWT).to receive(:encode).and_return('tokenUser2')
+          visit("/organisations/#{provider2.provider_code}")
+        end
+        thread.join
+        method.call(*args)
+      end
+
+      allow(Provider).to receive(:find)
+                           .with(provider2.provider_code)
+                           .and_call_original
+
+      allow(JWT).to receive(:encode).and_return('tokenUser1')
+      visit("/organisations/#{provider1.provider_code}")
+    end
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -31,15 +31,28 @@ module Helpers
     allow(Session).to receive(:create).and_return(user)
   end
 
-  def stub_api_v2_request(url_path, stub, method = :get, status = 200)
+  def stub_api_v2_request(url_path, stub, method = :get, status = 200, token: nil)
     url = "#{Settings.manage_backend.base_url}/api/v2#{url_path}"
 
-    stub_request(method, url)
-      .to_return(
-        status: status,
-        body: stub.to_json,
-        headers: { 'Content-Type': 'application/vnd.api+json' }
+    stubbed_request = stub_request(method, url)
+                        .to_return(
+                          status: status,
+                          body: stub.to_json,
+                          headers: { 'Content-Type': 'application/vnd.api+json' }
+                        )
+    if token
+      stubbed_request.with(
+        headers: {
+          'Accept'          => 'application/vnd.api+json',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Authorization'   => "Bearer #{token}",
+          'Content-Type'    => 'application/vnd.api+json',
+          'User-Agent'      => 'Faraday v0.15.4'
+        }
       )
+    end
+
+    stubbed_request
   end
 end
 


### PR DESCRIPTION
https://trello.com/c/OnBKJMq6/1302-authorization-failure-when-updating-site-statuses

### Context

Apparently Faraday is not thread-safe and the way we were setting the
authorization token on the connection was opening us up to a race condition.

### Changes proposed in this pull request

This plugs that hole by using the Thread key-value context to save the user
token, and using that when we generate the connection to mcb.

### Guidance to review

This PR requires #242 and is based off of that one.
