### PR TITLE
[1384] Fix preview link and test presence

### DIFF
--- a/app/views/courses/status_panel/_unpublished.html.erb
+++ b/app/views/courses/status_panel/_unpublished.html.erb
@@ -3,5 +3,5 @@
 <p class="govuk-body">See how your unpublished changes look.</p>
 <p class="govuk-body">Preview your course to check for mistakes before publishing.</p>
 <p class="govuk-body">
-  <%= link_to 'Preview course', search_ui_url("/preview/#{course.provider.provider_code}/#{course.course_code}"), class: 'govuk-link' %>
+  <%= link_to 'Preview course', manage_ui_url("/organisation/#{course.provider.provider_code}/course/self/#{course.course_code}/preview"), class: 'govuk-link', "data-qa": "course__preview-link" %>
 </p>

--- a/spec/features/courses/description_spec.rb
+++ b/spec/features/courses/description_spec.rb
@@ -71,6 +71,7 @@ feature 'Course description', type: :feature do
       expect(course_page.last_published_at).to have_content(
         'Last published: 5 March 2019'
       )
+      expect(course_page).to_not have_preview_link
     end
   end
 
@@ -116,6 +117,7 @@ feature 'Course description', type: :feature do
       expect(course_page.other_requirements).to have_content(
         course.other_requirements
       )
+      expect(course_page).to_not have_preview_link
     end
   end
 
@@ -142,6 +144,7 @@ feature 'Course description', type: :feature do
       scenario 'displays status panel' do
         expect(course_page.is_findable).to have_content('No')
         expect(course_page.status_tag).to have_content('Draft')
+        expect(course_page).to have_preview_link
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_description.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_description.rb
@@ -23,6 +23,7 @@ module PageObjects
         element :open_for_applications, '[data-qa=course__open_for_applications]'
         element :last_published_at, '[data-qa=course__last_published_date]'
         element :status_tag, '[data-qa=course__content-status]'
+        element :preview_link, '[data-qa=course__preview-link]'
       end
     end
   end


### PR DESCRIPTION
### Context
Follow up to https://github.com/DFE-Digital/manage-courses-frontend/pull/233

### Changes proposed in this pull request
- Fix URL of course preview
- Add spec to check when it should and shouldn't be shown

### Guidance to review
A course /description page
