### PR TITLE
[1424] Fix provider show

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -6,6 +6,6 @@ class ProvidersController < ApplicationController
   end
 
   def show
-    @provider = Provider.find(params[:code]).first.attributes
+    @provider = Provider.find(params[:code]).first
   end
 end

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, @provider[:provider_name] %>
+<%= content_for :page_title, @provider.provider_name %>
 
 <% if @has_multiple_providers then %>
   <% content_for :before_content do %>
@@ -8,18 +8,18 @@
           <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
         </li>
         <li class="govuk-breadcrumbs__list-item" aria-current="page">
-          <%= @provider[:provider_name] %>
+          <%= @provider.provider_name %>
         </li>
       </ol>
     </nav>
   <% end %>
 <% end %>
 
-<h1 class="govuk-heading-xl"><%= @provider[:provider_name] %></h1>
+<h1 class="govuk-heading-xl"><%= @provider.provider_name %></h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m"><%= govuk_link_to "About your organisation", manage_ui_url("/organisation/#{@provider[:provider_code]}/details") %></h2>
+    <h2 class="govuk-heading-m"><%= govuk_link_to "About your organisation", manage_ui_url("/organisation/#{@provider.provider_code}/details") %></h2>
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
       <li>write about your organisation</li>
@@ -27,14 +27,14 @@
       <li>publish this information on all course pages</li>
     </ul>
 
-    <h2 class="govuk-heading-m"><%= link_to "Locations", provider_sites_path(@provider[:provider_code]), class: "govuk-link", data: { qa: 'provider__locations' } %></h2>
+    <h2 class="govuk-heading-m"><%= link_to "Locations", provider_sites_path(@provider.provider_code), class: "govuk-link", data: { qa: 'provider__locations' } %></h2>
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
       <li>edit location names and addresses</li>
       <li>add locations</li>
     </ul>
 
-    <h2 class="govuk-heading-m"><%= link_to "Courses", provider_courses_path(@provider[:provider_code]), class: "govuk-link", data: { qa: 'provider__courses' } %></h2>
+    <h2 class="govuk-heading-m"><%= link_to "Courses", provider_courses_path(@provider.provider_code), class: "govuk-link", data: { qa: 'provider__courses' } %></h2>
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
       <li>write about each course</li>
@@ -42,7 +42,7 @@
       <li>copy content between courses</li>
     </ul>
 
-    <h2 class="govuk-heading-m"><%= govuk_link_to "Request access for someone else", manage_ui_url("/organisation/#{@provider[:provider_code]}/request-access") %></h2>
+    <h2 class="govuk-heading-m"><%= govuk_link_to "Request access for someone else", manage_ui_url("/organisation/#{@provider.provider_code}/request-access") %></h2>
     <p class="govuk-body govuk-!-margin-bottom-8">You can request a DfE Sign-in account for others who manage your courses.</p>
   </div>
   <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
### Context
If the provider is not found a server error would be raised because of `attributes` on nil class i.e. https://sentry.io/organizations/dfe-bat/issues/1007932208/?environment=qa&project=1407453&query=is%3Aunresolved

### Changes proposed in this pull request
- Remove `.attributes` from controller

### Guidance to review
Try and navigate to a made up provider show view i.e. `/organisations/1R` 
