### PR TITLE
[1419] Remove return URL hack from specs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,7 @@ class ApplicationController < ActionController::Base
   rescue_from JsonApiClient::Errors::NotAuthorized, with: :render_manage_ui
   rescue_from JsonApiClient::Errors::AccessDenied, with: :render_manage_ui
 
-  before_action :set_has_multiple_providers,
-                :authenticate
+  before_action :authenticate
 
   def not_found
     respond_to do |format|
@@ -27,6 +26,7 @@ class ApplicationController < ActionController::Base
   def authenticate
     if current_user
       add_token_to_connection
+      set_has_multiple_providers
 
       set_user_session if current_user['user_id'].blank?
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,7 @@ class ApplicationController < ActionController::Base
   end
 
   def has_multiple_providers?
-    provider_count = session.to_hash.dig("auth_user", "provider_count")
+    provider_count = session.to_hash.dig('auth_user', 'provider_count')
     provider_count.nil? || provider_count > 1
   end
 

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -6,6 +6,6 @@ class ProvidersController < ApplicationController
   end
 
   def show
-    @provider = Provider.find(params[:code]).first.attributes
+    @provider = Provider.find(params[:code]).first
   end
 end

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, @provider[:provider_name] %>
+<%= content_for :page_title, @provider.provider_name %>
 
 <% if @has_multiple_providers then %>
   <% content_for :before_content do %>
@@ -8,18 +8,18 @@
           <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
         </li>
         <li class="govuk-breadcrumbs__list-item" aria-current="page">
-          <%= @provider[:provider_name] %>
+          <%= @provider.provider_name %>
         </li>
       </ol>
     </nav>
   <% end %>
 <% end %>
 
-<h1 class="govuk-heading-xl"><%= @provider[:provider_name] %></h1>
+<h1 class="govuk-heading-xl"><%= @provider.provider_name %></h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m"><%= govuk_link_to "About your organisation", manage_ui_url("/organisation/#{@provider[:provider_code]}/details") %></h2>
+    <h2 class="govuk-heading-m"><%= govuk_link_to "About your organisation", manage_ui_url("/organisation/#{@provider.provider_code}/details") %></h2>
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
       <li>write about your organisation</li>
@@ -27,14 +27,14 @@
       <li>publish this information on all course pages</li>
     </ul>
 
-    <h2 class="govuk-heading-m"><%= link_to "Locations", provider_sites_path(@provider[:provider_code]), class: "govuk-link", data: { qa: 'provider__locations' } %></h2>
+    <h2 class="govuk-heading-m"><%= link_to "Locations", provider_sites_path(@provider.provider_code), class: "govuk-link", data: { qa: 'provider__locations' } %></h2>
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
       <li>edit location names and addresses</li>
       <li>add locations</li>
     </ul>
 
-    <h2 class="govuk-heading-m"><%= link_to "Courses", provider_courses_path(@provider[:provider_code]), class: "govuk-link", data: { qa: 'provider__courses' } %></h2>
+    <h2 class="govuk-heading-m"><%= link_to "Courses", provider_courses_path(@provider.provider_code), class: "govuk-link", data: { qa: 'provider__courses' } %></h2>
     <p class="govuk-body">Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
       <li>write about each course</li>
@@ -42,7 +42,7 @@
       <li>copy content between courses</li>
     </ul>
 
-    <h2 class="govuk-heading-m"><%= govuk_link_to "Request access for someone else", manage_ui_url("/organisation/#{@provider[:provider_code]}/request-access") %></h2>
+    <h2 class="govuk-heading-m"><%= govuk_link_to "Request access for someone else", manage_ui_url("/organisation/#{@provider.provider_code}/request-access") %></h2>
     <p class="govuk-body govuk-!-margin-bottom-8">You can request a DfE Sign-in account for others who manage your courses.</p>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe ProvidersController, type: :controller do
     before do
       stub_omniauth
       stub_session_create
+
+      # TODO: This is ugly, but will be removed when controller specs are axed.
+      old_controller = @controller
+      @controller = SessionsController.new
+      request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:dfe]
+      get :create
+      @controller = old_controller
     end
 
     describe 'GET #index' do

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ProvidersController, type: :controller do
   context "with authenticated user" do
     before do
       stub_omniauth
-      stub_session_create
 
       # TODO: This is ugly, but will be removed when controller specs are axed.
       old_controller = @controller

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -5,7 +5,6 @@ describe UsersController, type: :controller do
 
   before do
     stub_omniauth(user: user)
-    stub_session_create
 
     # TODO: This is ugly, but will be removed when controller specs are axed.
     old_controller = @controller

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -4,11 +4,16 @@ describe UsersController, type: :controller do
   let(:user) { jsonapi :user }
 
   before do
-    stub_omniauth
+    stub_omniauth(user: user)
     stub_session_create
-    allow_any_instance_of(ApplicationController)
-      .to receive(:current_user)
-      .and_return('user_id' => user.id)
+
+    # TODO: This is ugly, but will be removed when controller specs are axed.
+    old_controller = @controller
+    @controller = SessionsController.new
+    request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:dfe]
+    get :create
+    @controller = old_controller
+
     allow(Raven).to receive(:capture_exception)
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,16 +1,11 @@
 FactoryBot.define do
-  factory :user, parent: :jsonapi_mock_serializable do
-    transient do
-      jsonapi_type           { 'user' }
-      jsonapi_relationships  { [] }
-      jsonapi_include_counts { [] }
-    end
-
+  factory :user, class: Hash do
     sequence(:id)
     first_name { Faker::Name.first_name }
     last_name  { Faker::Name.last_name }
     email      { Faker::Internet.safe_email("#{first_name} #{last_name}") }
     state      { 'transitioned' }
+    accept_terms_date_utc { Time.current }
     opted_in?  { false }
 
     trait :new do
@@ -19,6 +14,16 @@ FactoryBot.define do
 
     trait :opted_in do
       opted_in? { true }
+    end
+
+    initialize_with do |_evaluator|
+      data_attributes = attributes.except(:id)
+
+      JSONAPIMockSerializable.new(
+        id,
+        'users',
+        attributes: data_attributes
+      )
     end
   end
 end

--- a/spec/features/backend_requests_spec.rb
+++ b/spec/features/backend_requests_spec.rb
@@ -43,7 +43,6 @@ describe 'requests made to mc-be' do
       #                user token for its call to the backend api.
 
       stub_omniauth disable_completely: false
-      stub_session_create
 
       # Stub extra dependencies, these calls are not under test here.
       stub_api_v2_request(

--- a/spec/features/backend_requests_spec.rb
+++ b/spec/features/backend_requests_spec.rb
@@ -42,7 +42,7 @@ describe 'requests made to mc-be' do
       #   - Request 1: allow the call to complete - this will use the wrong
       #                user token for its call to the backend api.
 
-      stub_omniauth disable_completely: false
+      stub_omniauth
 
       # Stub extra dependencies, these calls are not under test here.
       stub_api_v2_request(

--- a/spec/features/courses/delete_spec.rb
+++ b/spec/features/courses/delete_spec.rb
@@ -11,7 +11,6 @@ feature 'Delete course', type: :feature do
 
   before do
     stub_omniauth
-    stub_session_create
     stub_api_v2_request(
       "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site,provider.sites,accrediting_provider",
       course

--- a/spec/features/courses/description_spec.rb
+++ b/spec/features/courses/description_spec.rb
@@ -20,7 +20,6 @@ feature 'Course description', type: :feature do
   let(:course_response) { course_jsonapi.render }
   before do
     stub_omniauth
-    stub_session_create
     stub_api_v2_request(
       "/providers/A0/courses/#{course.course_code}?include=site_statuses.site,provider.sites,accrediting_provider",
       course_response

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -24,7 +24,7 @@ feature 'Index courses', type: :feature do
   describe "without accrediting providers" do
     before do
       user = jsonapi :user, :opted_in
-      stub_omniauth(disable_completely: false, user: user)
+      stub_omniauth(user: user)
       stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
       stub_api_v2_request("/providers/A123", provider_response)
       stub_api_v2_request(
@@ -97,7 +97,7 @@ feature 'Index courses', type: :feature do
 
     before do
       user = jsonapi :user, :opted_in
-      stub_omniauth(disable_completely: false, user: user)
+      stub_omniauth(user: user)
       stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
       stub_api_v2_request("/providers/A123", provider_response)
       stub_api_v2_request(

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -25,7 +25,6 @@ feature 'Index courses', type: :feature do
     before do
       user = jsonapi :user, :opted_in
       stub_omniauth(disable_completely: false, user: user)
-      stub_session_create(user: User.new(JSON.parse(user.to_json)))
       stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
       stub_api_v2_request("/providers/A123", provider_response)
       stub_api_v2_request(
@@ -99,7 +98,6 @@ feature 'Index courses', type: :feature do
     before do
       user = jsonapi :user, :opted_in
       stub_omniauth(disable_completely: false, user: user)
-      stub_session_create(user: User.new(JSON.parse(user.to_json)))
       stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
       stub_api_v2_request("/providers/A123", provider_response)
       stub_api_v2_request(
@@ -133,7 +131,6 @@ feature 'Index courses', type: :feature do
 
     before do
       stub_omniauth
-      stub_session_create
       stub_api_v2_request(
         "/providers/A321?include=courses.accrediting_provider",
         provider_response

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -19,7 +19,6 @@ feature 'Show course', type: :feature do
   let(:course_response) { course.render }
   before do
     stub_omniauth
-    stub_session_create
     stub_api_v2_request(
       "/providers/A0/courses/#{course.course_code}?include=site_statuses.site,provider.sites,accrediting_provider",
       course_response

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -37,7 +37,6 @@ feature 'Edit course vacancies', type: :feature do
 
   before do
     stub_omniauth
-    stub_session_create
     stub_api_v2_request(
       "/providers/AO?include=courses.accrediting_provider",
       jsonapi(:provider).render

--- a/spec/features/courses/withdraw_spec.rb
+++ b/spec/features/courses/withdraw_spec.rb
@@ -11,7 +11,6 @@ feature 'Withdraw course', type: :feature do
 
   before do
     stub_omniauth
-    stub_session_create
     stub_api_v2_request(
       "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site,provider.sites,accrediting_provider",
       course

--- a/spec/features/locations/edit_spec.rb
+++ b/spec/features/locations/edit_spec.rb
@@ -15,7 +15,6 @@ feature 'Edit locations', type: :feature do
   describe "without errors" do
     before do
       stub_omniauth
-      stub_session_create
       stub_api_v2_request("/providers/#{provider_code}?include=sites", provider)
       stub_api_v2_request("/providers/#{provider_code}/sites/#{site.id}", site, :patch, 200)
     end
@@ -36,7 +35,6 @@ feature 'Edit locations', type: :feature do
   describe "with validations errors" do
     before do
       stub_omniauth
-      stub_session_create
       stub_api_v2_request("/providers/#{provider_code}?include=sites", provider)
       stub_api_v2_request("/providers/#{provider_code}/sites/#{site.id}", build(:error), :patch, 422)
     end

--- a/spec/features/locations/index_spec.rb
+++ b/spec/features/locations/index_spec.rb
@@ -22,7 +22,7 @@ feature 'View locations', type: :feature do
 
   before do
     user = jsonapi :user, :opted_in
-    stub_omniauth(disable_completely: false, user: user)
+    stub_omniauth(user: user)
     stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider[:data]]))
     stub_api_v2_request("/providers/#{provider_code}", provider)
     stub_api_v2_request("/providers/#{provider_code}?include=sites", provider)

--- a/spec/features/locations/index_spec.rb
+++ b/spec/features/locations/index_spec.rb
@@ -23,7 +23,6 @@ feature 'View locations', type: :feature do
   before do
     user = jsonapi :user, :opted_in
     stub_omniauth(disable_completely: false, user: user)
-    stub_session_create(user: User.new(JSON.parse(user.to_json)))
     stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider[:data]]))
     stub_api_v2_request("/providers/#{provider_code}", provider)
     stub_api_v2_request("/providers/#{provider_code}?include=sites", provider)

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -14,8 +14,8 @@ RSpec.feature 'View providers', type: :feature do
   scenario 'Navigate to /organisations/AO' do
     stub_omniauth
     stub_session_create
-    stub_api_v2_request('/providers', jsonapi(:providers_response, data: [jsonapi(:provider, provider_code: "A0")]))
-    stub_api_v2_request('/providers/A0', jsonapi(:providers_response, data: [jsonapi(:provider, provider_code: "A0")]))
+    stub_api_v2_request('/providers', jsonapi(:providers_response))
+    stub_api_v2_request('/providers/A0', jsonapi(:provider, provider_code: 'A0'))
 
     visit('/organisations/A0')
     expect(find('h1')).to have_content('ACME SCITT A0')

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.feature 'View providers', type: :feature do
   scenario 'Navigate to /organisations' do
     stub_omniauth
-    stub_session_create
     stub_api_v2_request('/providers', jsonapi(:providers_response))
 
     visit('/organisations')
@@ -13,9 +12,8 @@ RSpec.feature 'View providers', type: :feature do
 
   scenario 'Navigate to /organisations/AO' do
     stub_omniauth
-    stub_session_create
     stub_api_v2_request('/providers', jsonapi(:providers_response))
-    stub_api_v2_request('/providers/A0', jsonapi(:provider, provider_code: 'A0'))
+    stub_api_v2_request('/providers/A0', jsonapi(:provider, provider_code: "A0"))
 
     visit('/organisations/A0')
     expect(find('h1')).to have_content('ACME SCITT A0')

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -1,23 +1,30 @@
 require 'rails_helper'
 
 RSpec.feature 'View providers', type: :feature do
+  let(:provider1) { jsonapi :provider, provider_code: 'A0', include_counts: [:courses] }
+  let(:provider2) { jsonapi :provider, provider_code: 'A1', include_counts: [:courses] }
+  let(:provider_response) { provider1.render }
+  let(:providers_response) {
+    jsonapi(:providers_response, data: [provider1.render[:data], provider2.render[:data]])
+  }
+
   scenario 'Navigate to /organisations' do
     stub_omniauth
-    stub_api_v2_request('/providers', jsonapi(:providers_response))
+    stub_api_v2_request('/providers', providers_response)
 
     visit('/organisations')
     expect(find('h1')).to have_content('Organisations')
-    expect(first('.govuk-list li')).to have_content('ACME SCITT A0')
+    expect(first('.govuk-list li')).to have_content(provider1.provider_name.to_s)
   end
+
 
   scenario 'Navigate to /organisations/AO' do
     stub_omniauth
-    stub_api_v2_request('/providers', jsonapi(:providers_response))
-    stub_api_v2_request('/providers/A0', jsonapi(:provider, provider_code: "A0"))
+    stub_api_v2_request('/providers/A0', provider_response)
 
     visit('/organisations/A0')
-    expect(find('h1')).to have_content('ACME SCITT A0')
-    expect(page).to have_selector(".govuk-breadcrumbs")
+    expect(find('h1')).to have_content(provider1.provider_name.to_s)
+    expect(page).to_not have_selector(".govuk-breadcrumbs")
     expect(page).to have_link('Locations', href: '/organisations/A0/locations')
     expect(page).to have_link('Courses', href: '/organisations/A0/courses')
   end

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -6,7 +6,7 @@ describe 'sessions' do
   let(:root_page) { PageObjects::Page::RootPage.new }
 
   it 'redirects users back to where they were going on sign-in' do
-    stub_omniauth disable_completely: false
+    stub_omniauth
     stub_api_v2_request('/providers', jsonapi(:providers_response))
     stub_api_v2_request("/providers/#{provider.provider_code}", provider.render)
 
@@ -16,7 +16,7 @@ describe 'sessions' do
   end
 
   it 'redirects users to root when they go straight to the signin page' do
-    stub_omniauth disable_completely: false
+    stub_omniauth
     stub_api_v2_request('/providers', jsonapi(:providers_response))
 
     visit '/signin'

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -7,7 +7,6 @@ describe 'sessions' do
 
   it 'redirects users back to where they were going on sign-in' do
     stub_omniauth disable_completely: false
-    stub_session_create
     stub_api_v2_request('/providers', jsonapi(:providers_response))
     stub_api_v2_request("/providers/#{provider.provider_code}", provider.render)
 
@@ -18,7 +17,6 @@ describe 'sessions' do
 
   it 'redirects users to root when they go straight to the signin page' do
     stub_omniauth disable_completely: false
-    stub_session_create
     stub_api_v2_request('/providers', jsonapi(:providers_response))
 
     visit '/signin'

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -10,7 +10,6 @@ feature 'Sign in', type: :feature do
 
     stub_omniauth disable_completely: false,
                   user: user
-    stub_session_create user: user.to_resource
     stub_api_v2_request('/providers', jsonapi(:providers_response))
 
     visit root_path
@@ -24,7 +23,6 @@ feature 'Sign in', type: :feature do
     user = jsonapi :user, :new, :opted_in
 
     stub_omniauth(user: user)
-    stub_session_create(user: user)
     stub_api_v2_request('/providers', jsonapi(:providers_response))
     request = stub_api_v2_request "/users/#{user.id}/accept_transition_screen", user, :patch
 
@@ -43,7 +41,6 @@ feature 'Sign in', type: :feature do
     user = jsonapi :user, :new
 
     stub_omniauth(user: user)
-    stub_session_create(user: user)
     stub_api_v2_request('/providers', jsonapi(:providers_response))
 
     visit '/signin'

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -26,7 +26,6 @@ feature 'Sign in', type: :feature do
     stub_omniauth(user: user)
     stub_session_create(user: user)
     stub_api_v2_request('/providers', jsonapi(:providers_response))
-    stub_api_v2_request '/sessions', user, :post
     request = stub_api_v2_request "/users/#{user.id}/accept_transition_screen", user, :patch
 
     visit '/signin'
@@ -46,7 +45,6 @@ feature 'Sign in', type: :feature do
     stub_omniauth(user: user)
     stub_session_create(user: user)
     stub_api_v2_request('/providers', jsonapi(:providers_response))
-    stub_api_v2_request '/sessions', user, :post
 
     visit '/signin'
 

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -8,8 +8,7 @@ feature 'Sign in', type: :feature do
   scenario 'using DfE Sign-in' do
     user = jsonapi :user
 
-    stub_omniauth disable_completely: false,
-                  user: user
+    stub_omniauth(user: user)
     stub_api_v2_request('/providers', jsonapi(:providers_response))
 
     visit root_path

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.feature 'View pages', type: :feature do
   scenario "Navigate to /cookies" do
     stub_omniauth
-    stub_session_create
 
     visit "/cookies"
     expect(find('h1')).to have_content('Cookies')
@@ -11,7 +10,6 @@ RSpec.feature 'View pages', type: :feature do
 
   scenario "Navigate to /terms-conditions" do
     stub_omniauth
-    stub_session_create
 
     visit "/terms-conditions"
     expect(find('h1')).to have_content('Terms and Conditions')
@@ -19,7 +17,6 @@ RSpec.feature 'View pages', type: :feature do
 
   scenario "Navigate to /privacy-policy" do
     stub_omniauth
-    stub_session_create
 
     visit "/privacy-policy"
     expect(find('h1')).to have_content('Privacy policy')

--- a/spec/requests/courses/vacancies/edit_spec.rb
+++ b/spec/requests/courses/vacancies/edit_spec.rb
@@ -25,6 +25,7 @@ describe 'Edit vacancies' do
         "/providers/AO/courses/#{course_code}?include=site_statuses.site",
         course
       )
+      get(auth_dfe_callback_path)
       get(edit_vacancies_path)
     end
 

--- a/spec/requests/courses/vacancies/edit_spec.rb
+++ b/spec/requests/courses/vacancies/edit_spec.rb
@@ -20,7 +20,6 @@ describe 'Edit vacancies' do
 
     before do
       stub_omniauth
-      stub_session_create
       stub_api_v2_request(
         "/providers/AO/courses/#{course_code}?include=site_statuses.site",
         course

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -20,11 +20,6 @@ module Helpers
 
     Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:dfe]
     stub_api_v2_request('/sessions', user_resource.render, :post)
-
-    # Temp solution until we implement `return_url` for DfE sign-in
-    if disable_completely
-      allow_any_instance_of(ApplicationController).to receive(:authenticate)
-    end
   end
 
   def stub_session_create(user: double(id: 1, 'opted_in?': false))

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,7 +1,7 @@
 module Helpers
   def stub_omniauth(disable_completely: true, user: nil)
-    user_resource = jsonapi(:user)
-    user ||= user_resource.to_resource
+    user_resource = user || jsonapi(:user)
+    user = user_resource.to_resource
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:dfe] = {
       'provider' => 'dfe',

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,5 +1,5 @@
 module Helpers
-  def stub_omniauth(disable_completely: true, user: nil)
+  def stub_omniauth(user: nil)
     user_resource = user || jsonapi(:user)
     user = user_resource.to_resource
     OmniAuth.config.test_mode = true

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -4,17 +4,17 @@ module Helpers
     user ||= user_resource.to_resource
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:dfe] = {
-      provider: "dfe",
-      uid: "123456789",
-      "info" => {
-        "first_name" => user.first_name,
-        "last_name"  => user.last_name,
-        "email"      => user.email,
+      'provider' => 'dfe',
+      'uid'      => SecureRandom.uuid,
+      'info'     => {
+        'first_name' => user.first_name,
+        'last_name'  => user.last_name,
+        'email'      => user.email,
         'id'         => user.id,
         'state'      => user.state
       },
-      credentials: {
-        token_id: "123"
+      'credentials' => {
+        'token_id' => '123'
       }
     }
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -25,9 +25,6 @@ module Helpers
     stub_api_v2_request('/sessions', user_resource.render, :post)
   end
 
-  def stub_session_create(user: double(id: 1, 'opted_in?': false))
-  end
-
   def stub_api_v2_request(url_path, stub, method = :get, status = 200, token: nil)
     url = "#{Settings.manage_backend.base_url}/api/v2#{url_path}"
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -18,6 +18,9 @@ module Helpers
       }
     }
 
+    # This is needed because we check the provider count on all pages
+    # TODO: Move this to be returned with the user.
+    stub_api_v2_request('/providers', jsonapi(:provider).render)
     Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:dfe]
     stub_api_v2_request('/sessions', user_resource.render, :post)
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -19,6 +19,7 @@ module Helpers
     }
 
     Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:dfe]
+    stub_api_v2_request('/sessions', user_resource.render, :post)
 
     # Temp solution until we implement `return_url` for DfE sign-in
     if disable_completely

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -18,6 +18,8 @@ module Helpers
       }
     }
 
+    Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:dfe]
+
     # Temp solution until we implement `return_url` for DfE sign-in
     if disable_completely
       allow_any_instance_of(ApplicationController).to receive(:authenticate)
@@ -25,7 +27,6 @@ module Helpers
   end
 
   def stub_session_create(user: double(id: 1, 'opted_in?': false))
-    allow(Session).to receive(:create).and_return(user)
   end
 
   def stub_api_v2_request(url_path, stub, method = :get, status = 200, token: nil)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,10 +1,7 @@
 module Helpers
   def stub_omniauth(disable_completely: true, user: nil)
-    user ||= double first_name: 'John',
-                    last_name: 'Smith',
-                    email: 'email@example.com',
-                    id: 1,
-                    state: 'new'
+    user_resource = jsonapi(:user)
+    user ||= user_resource.to_resource
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:dfe] = {
       provider: "dfe",


### PR DESCRIPTION
### Context

The tests mock out too much of the auth flow, they were too far from reality.

### Changes proposed in this pull request

Change the tests to perform auth, only mocking out the data we get back from DfE-SignIn via OmniAuth.

### Guidance to review