### PR TITLE
[1431] Render the 404 page when provider not found

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -1,4 +1,6 @@
 class ProvidersController < ApplicationController
+  rescue_from JsonApiClient::Errors::NotFound, with: :not_found
+
   def index
     @providers = Provider.all
     render_manage_ui if @providers.empty?

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'Providers', type: :request do
+  before do
+    stub_omniauth
+    stub_session_create
+  end
+
+  describe 'GET show' do
+    it 'render providers show' do
+      provider = jsonapi(:provider)
+      stub_api_v2_request("/providers/#{provider.provider_code}", provider.render)
+      get(provider_path(provider.provider_code))
+      expect(response.body).to include(provider.provider_name)
+    end
+
+    context 'provider does not exist' do
+      it 'renders not found' do
+        stub_api_v2_request("/providers/foo", {}, :get, 404)
+        get(provider_path('foo'))
+        expect(response.body).to include('Page not found')
+      end
+    end
+  end
+end

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -3,7 +3,38 @@ require 'rails_helper'
 describe 'Providers', type: :request do
   before do
     stub_omniauth
-    stub_session_create
+    get(auth_dfe_callback_path)
+  end
+
+  describe 'GET index' do
+    context 'with 1 provider' do
+      it 'redirects to providers show' do
+        provider = jsonapi(:provider)
+        stub_api_v2_request('/providers', provider.render)
+        get(providers_path)
+        expect(response).to redirect_to provider_path(provider.provider_code)
+      end
+    end
+
+    context 'with 2 or more providers' do
+      it 'renders providers index' do
+        provider1 = jsonapi(:provider, include_counts: [:courses])
+        provider2 = jsonapi(:provider, include_counts: [:courses])
+        providers = jsonapi(:providers_response, data: [provider1.render[:data], provider2.render[:data]])
+        stub_api_v2_request('/providers', providers)
+        get(providers_path)
+        expect(response.body).to include('Organisations')
+        expect(response.body).to include(provider1.provider_name)
+      end
+    end
+
+    context 'user has no providers' do
+      it 'redirects to manage-courses-ui' do
+        stub_api_v2_request('/providers', jsonapi(:providers_response, data: []))
+        get(providers_path)
+        expect(response).to redirect_to(Settings.manage_ui.base_url)
+      end
+    end
   end
 
   describe 'GET show' do


### PR DESCRIPTION
### Context
Showing the user nice a 404 page when record not found - https://github.com/DFE-Digital/manage-courses-backend/pull/332

### Changes proposed in this pull request
- Rescue `JsonApiClient::Errors::NotFound` and render our nice 404 page

### Guidance to review
Example `https://localhost:3000/organisations/T9`