### PR TITLE
[1430] Only display running site locations

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -78,6 +78,10 @@ class CourseDecorator < ApplicationDecorator
     end
   end
 
+  def alphabetically_sorted_site_statuses
+    object.site_statuses.sort_by { |ss| ss.site.location_name }
+  end
+
 private
 
   def status_tag_content

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -14,4 +14,8 @@ class SiteStatus < Base
   def running?
     status == 'running'
   end
+
+  def new_or_running?
+    status.in?(%w[running new_status])
+  end
 end

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -78,8 +78,8 @@
               <% course.alphabetically_sorted_site_statuses.each do |site_status| %>
                 <li>
                   <%= site_status.site.location_name %>
-                  <% unless site_status.status == 'running' %>
-                    <span class="govuk-hint govuk-!-display-inline">(<%= site_status.status %>)</span>
+                  <% unless site_status.new_or_running? %>
+                    <span class="govuk-hint govuk-!-display-inline">(not running)</span>
                   <% end %>
                 </li>
               <% end %>

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -75,7 +75,7 @@
             <%= course.site_statuses.first.site.location_name %>
           <% else %>
             <ul class="govuk-list courses-locations-list">
-              <% @course.site_statuses.sort_by{ |ss| ss.site.location_name }.each do |site_status| %>
+              <% course.alphabetically_sorted_site_statuses.each do |site_status| %>
                 <li>
                   <%= site_status.site.location_name %>
                   <% unless site_status.status == 'running' %>

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -75,8 +75,13 @@
             <%= course.site_statuses.first.site.location_name %>
           <% else %>
             <ul class="govuk-list courses-locations-list">
-              <% course.site_statuses.map(&:site).map(&:location_name).each do |location_name| %>
-                <li><%= location_name %></li>
+              <% @course.site_statuses.sort_by{ |ss| ss.site.location_name }.each do |site_status| %>
+                <li>
+                  <%= site_status.site.location_name %>
+                  <% unless site_status.status == 'running' %>
+                    <span class="govuk-hint govuk-!-display-inline">(<%= site_status.status %>)</span>
+                  <% end %>
+                </li>
               <% end %>
             </ul>
           <% end %>

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
       vac_status { 'both_full_time_and_part_time_vacancies' }
     end
 
+    trait :full_time do
+      vac_status { 'full_time_vacancies' }
+    end
+
     trait :part_time do
       vac_status { 'part_time_vacancies' }
     end

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -68,7 +68,7 @@ feature 'Show course', type: :feature do
       site1.location_name
     )
     expect(course_page.locations).to have_content(
-      "#{site2.location_name} (suspended)"
+      "#{site2.location_name} (not running)"
     )
     expect { course_page.apprenticeship }.to raise_error(Capybara::ElementNotFound)
     expect(course_page.funding).to have_content(


### PR DESCRIPTION
### Context
The course basic details view is currently showing sites (through site statuses) that are not-running

### Changes proposed in this pull request
- Render site status "status" that are NOT running
- Sort sites by location name

### Guidance to review
# After
![localhost_3000_organisations_1J1_courses_36KQ(Laptop with MDPI screen) (2)](https://user-images.githubusercontent.com/3071606/57387700-bd8ea080-71ae-11e9-88f5-18b72aa36e65.png)
