### PR TITLE
1422 redirect to root if timed out user attempts to signout

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,7 +19,11 @@ class SessionsController < ApplicationController
   end
 
   def signout
-    redirect_to "#{Settings.dfe_signin.issuer}/session/end?id_token_hint=#{current_user['credentials']['id_token']}&post_logout_redirect_uri=#{Settings.dfe_signin.base_url}/auth/dfe/signout"
+    if current_user.present?
+      redirect_to "#{Settings.dfe_signin.issuer}/session/end?id_token_hint=#{current_user['credentials']['id_token']}&post_logout_redirect_uri=#{Settings.dfe_signin.base_url}/auth/dfe/signout"
+    else
+      redirect_to root_path
+    end
   end
 
   def failure

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'Sessions', type: :request do
+  describe 'GET signout' do
+    it 'redirects to DfE Sign-In session end' do
+      stub_omniauth
+      get(auth_dfe_callback_path)
+
+      get(signout_path)
+      expect(response).to redirect_to("#{Settings.dfe_signin.issuer}/session/end?id_token_hint=&post_logout_redirect_uri=https://localhost:3000/auth/dfe/signout")
+    end
+
+    context 'user session is not present' do
+      it 'redirects to root path' do
+        get(signout_path)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
If a user session has expired making `current_user` is nil then a user attempts to signout from DfE-Signin a server error is thrown because DfE-Signin requires the users `id_token` which is stored in the `current_user` object

### Changes proposed in this pull request
Check for the presence of `current_user` and redirect to root as their session has already expired

Do we need to think about a more robust strategy for this i.e. persist the `id_token` on the user when the signin?

### Guidance to review
Delete the session in your browser and hit `signout`
