### PR TITLE
[1442] return 404 when a course does not exist

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -58,6 +58,8 @@ private
       .where(provider_code: @provider_code)
       .find(params[:code])
       .first
+  rescue JsonApiClient::Errors::NotFound
+    render file: 'errors/not_found', status: :not_found
   end
 
   def build_provider

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -30,6 +30,9 @@ feature 'Show course', type: :feature do
   scenario 'viewing the show courses page' do
     visit "/organisations/A0/courses/#{course.course_code}"
 
+    expect(course_page)
+      .to be_displayed(provider_code: 'A0', course_code: course.course_code)
+
     expect(course_page.caption).to have_content(
       course.description
     )
@@ -76,5 +79,21 @@ feature 'Show course', type: :feature do
     expect(course_page.level).to have_content(
       'Secondary'
     )
+  end
+
+  scenario 'viewing the show page for a course that does not exist' do
+    stub_api_v2_request(
+      "/providers/ZZ/courses/ZZZ?include=site_statuses.site,provider.sites,accrediting_provider",
+      '',
+      :get,
+      404
+    )
+
+    course
+    visit "/organisations/ZZ/courses/ZZZ"
+
+    expect(course_page)
+      .to be_displayed(provider_code: 'ZZ', course_code: 'ZZZ')
+    expect(course_page.title.text).to eq 'Page not found'
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -2,7 +2,7 @@ module PageObjects
   module Page
     module Organisations
       class Course < PageObjects::Base
-        set_url '/organisations/{provider_code}/course/{course_code}'
+        set_url '/organisations/{provider_code}/courses/{course_code}'
 
         element :title, '.govuk-heading-xl'
         element :caption, '.govuk-caption-xl'


### PR DESCRIPTION
### Context

Users are getting 500 errors when a course does not exist.

### Changes proposed in this pull request

Give the users a 404 biscuit instead of 500s.
