### PR TITLE
[1444] Rescue from 500s by showing the generic 500 page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, except: :not_found
+  rescue_from StandardError, with: :internal_server_error
   rescue_from JsonApiClient::Errors::NotAuthorized, with: :render_manage_ui
   rescue_from JsonApiClient::Errors::AccessDenied, with: :render_manage_ui
 
@@ -10,6 +11,14 @@ class ApplicationController < ActionController::Base
       format.html { render 'errors/not_found', status: :not_found }
       format.json { render json: { error: 'Resource not found' }, status: :not_found }
       format.all { render status: :not_found, body: nil }
+    end
+  end
+
+  def internal_server_error(exception)
+    Raven.capture_exception(exception)
+    respond_to do |format|
+      format.html { render 'errors/internal_server_error', status: :internal_server_error }
+      format.json { render json: { error: 'Internal server error' }, status: :internal_server_error }
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,9 +5,9 @@ class UsersController < ApplicationController
   rescue JsonApiClient::Errors::ClientError, JsonApiClient::Errors::ServerError => e
     e.env.body.delete("traces")
     Raven.extra_context(e.env)
-    Raven.capture_exception(e)
 
     if e.is_a? JsonApiClient::Errors::ClientError
+      Raven.capture_exception(e)
       redirect_to providers_path
     else
       raise e

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -46,8 +46,9 @@ describe UsersController, type: :controller do
       end
 
       it "redirects to providers index" do
-        expect { get :accept_transition_info }.to raise_error JsonApiClient::Errors::ServerError
+        get :accept_transition_info
         expect(Raven).to have_received(:capture_exception).with(instance_of(JsonApiClient::Errors::ServerError))
+        expect(response).to have_http_status(:internal_server_error)
       end
     end
   end

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -26,4 +26,15 @@ RSpec.feature 'View pages', type: :feature do
     visit "/guidance"
     expect(find('h1')).to have_content('Guidance for Publish teacher training courses')
   end
+
+  context "With errors" do
+    scenario "Navigate to /guidance" do
+      allow_any_instance_of(PagesController)
+        .to receive(:guidance)
+        .and_raise(StandardError)
+
+      visit "/guidance"
+      expect(find('h1')).to have_content('Sorry, something went wrong')
+    end
+  end
 end


### PR DESCRIPTION
### Context

Currently, the users get a blank page. This is an improvement.

### Guidance to review

The test I wrote resides in `view_pages_spec.rb ` which is probably not the best place?