### PR TITLE
[1439] set user id and sign-in user id in Raven contexts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,10 +25,14 @@ class ApplicationController < ActionController::Base
 
   def authenticate
     if current_user
+      assign_sentry_contexts
       add_token_to_connection
       set_has_multiple_providers
 
-      set_user_session if current_user['user_id'].blank?
+      if current_user['user_id'].blank?
+        set_user_session
+        Raven.user_context(id: current_user['user_id'])
+      end
     else
       session[:redirect_back_to] = request.path
       redirect_to '/signin'
@@ -55,6 +59,7 @@ class ApplicationController < ActionController::Base
 private
 
   def set_user_session
+    # TODO: we should return a session object here with a 'user' attached to id.
     user = Session.create(first_name: current_user_info[:first_name],
                           last_name: current_user_info[:last_name])
     session[:auth_user]['user_id'] = user.id
@@ -82,5 +87,10 @@ private
                        Settings.manage_backend.algorithm)
 
     Thread.current[:manage_courses_backend_token] = token
+  end
+
+  def assign_sentry_contexts
+    Raven.user_context(id: current_user['user_id'])
+    Raven.tags_context(sign_in_user_id: current_user.fetch('uid'))
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,8 +8,11 @@ class SessionsController < ApplicationController
   def create
     session[:auth_user] = auth_hash
 
+    Raven.tags_context(sign_in_user_id: current_user.fetch('uid'))
     add_token_to_connection
     user = set_user_session
+    # current_user['user_id'] won't be set until set_user_session is run
+    Raven.user_context(id: current_user['user_id'])
 
     if user.state == 'new'
       redirect_to transition_info_path

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe ApplicationController, type: :controller do
           sign_in_user_id: sign_in_user_id
         }
       end
-      let(:user_id) { nil }
 
       before do
         allow(Base).to receive(:connection)
@@ -38,8 +37,6 @@ RSpec.describe ApplicationController, type: :controller do
         allow(JWT).to receive(:encode)
           .with(payload, Settings.manage_backend.secret, Settings.manage_backend.algorithm)
           .and_return("anything")
-
-        controller.request.session = { auth_user: { "info" => user_info, 'uid' => sign_in_user_id } }
       end
 
       context 'user_id is not blank' do
@@ -50,7 +47,13 @@ RSpec.describe ApplicationController, type: :controller do
           allow(Provider).to receive(:all)
             .and_raise('Could not connect to backend')
 
-          controller.request.session = { auth_user: { "info" => user_info, 'user_id' => user_id, 'uid' => sign_in_user_id } }
+          controller.request.session = {
+            auth_user: {
+              "info"    => user_info,
+              'user_id' => user_id,
+              'uid'     => sign_in_user_id
+            }
+          }
           controller.authenticate
         end
 
@@ -69,23 +72,46 @@ RSpec.describe ApplicationController, type: :controller do
         it "has set provider_count" do
           expect(controller.request.session[:auth_user][:provider_count]).to eq nil
         end
+
+        describe 'sentry contexts' do
+          before do
+            allow(Raven).to receive(:user_context)
+            allow(Raven).to receive(:tags_context)
+          end
+
+          it 'sets the id in the user context' do
+            controller.authenticate
+
+            expect(Raven).to have_received(:user_context).with(id: user_id)
+          end
+
+          it 'sets the DFE sign-in id in the tags context' do
+            controller.authenticate
+
+            expect(Raven).to have_received(:tags_context)
+                               .with(sign_in_user_id: sign_in_user_id)
+          end
+        end
       end
 
       context 'user_id is blank' do
-        let(:user_info) {
-          {
-            "first_name" => "John",
-            "last_name" => "Smith",
-            "email" => user_email,
-          }
-        }
+        let(:user_id) { 999 }
 
         before do
           allow(Session).to receive(:create)
-            .with(first_name: user_info[:first_name], last_name: user_info[:last_name])
-            .and_return(double(id: 999))
+                              .with(first_name: user_info[:first_name],
+                                    last_name: user_info[:last_name])
+                              .and_return(double(id: user_id))
           allow(Provider).to receive(:all)
-            .and_return(%w[one two])
+                               .and_return(%w[one two])
+
+          controller.request.session = {
+            auth_user: {
+              "info"    => user_info,
+              'uid'     => sign_in_user_id
+            }
+          }
+
           controller.authenticate
         end
 
@@ -98,11 +124,33 @@ RSpec.describe ApplicationController, type: :controller do
         end
 
         it "has set user_id" do
-          expect(controller.request.session[:auth_user]['user_id']).to eq 999
+          expect(controller.request.session[:auth_user]['user_id'])
+            .to eq user_id
         end
 
         it "has set provider_count" do
-          expect(controller.request.session[:auth_user][:provider_count]).to eq 2
+          expect(controller.request.session[:auth_user][:provider_count])
+            .to eq 2
+        end
+
+        describe 'sentry contexts' do
+          before do
+            allow(Raven).to receive(:user_context)
+            allow(Raven).to receive(:tags_context)
+          end
+
+          it 'sets the id in the user context' do
+            controller.authenticate
+
+            expect(Raven).to have_received(:user_context).with(id: user_id)
+          end
+
+          it 'sets the DFE sign-in id in the tags context' do
+            controller.authenticate
+
+            expect(Raven).to have_received(:tags_context)
+                               .with(sign_in_user_id: sign_in_user_id)
+          end
         end
       end
     end


### PR DESCRIPTION
### Context

Having the user id and sign-in user id helps us better debug errors.

### Changes proposed in this pull request

Add the user id and sign-in user id to what's captured by Raven.

