### PR TITLE
[1459] Add course about form

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,7 +1,7 @@
 class CoursesController < ApplicationController
   decorates_assigned :course
-  before_action :build_course, only: %i[show description delete withdraw publish]
-  before_action :build_provider, only: %i[show description publish]
+  before_action :build_course, only: %i[show description about delete withdraw publish]
+  before_action :build_provider, only: %i[show description about publish]
 
   def index
     @provider = Provider
@@ -36,6 +36,8 @@ class CoursesController < ApplicationController
   def show; end
 
   def description; end
+
+  def about; end
 
   def withdraw; end
 

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -1,0 +1,86 @@
+<%= content_for :page_title, "#{course.name_and_code} - Courses" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
+<% end %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+  About this course
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for course, url: publish_provider_course_path(course.provider.provider_code, course.course_code), method: :post do |f| %>
+      <p class="govuk-body">Give applicants a short description of the course.</p>
+
+      <p class="govuk-body">You could include:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>an overview of what candidates are taught</li>
+        <li>how much time they’ll spend training in school</li>
+        <li>how they’ll be assessed</li>
+        <li>the workload (eg how many essays per term?)</li>
+        <li>any other locations they’ll need to go to (eg will they also have to attend classes at an accredited body?)</li>
+        <li>information about the prestige of the course (eg league-table rankings)</li>
+      </ul>
+
+      <p class="govuk-body">If you offer different courses in the same subject, be clear about how this course differs from the others (eg amount of time spent in school, course structure). This will help the applicant decide which course best suits them.</p>
+
+      <div class="govuk-character-count" data-module="character-count" data-maxwords="400">
+        <div class="govuk-form-group">
+          <%= f.label :about_course, 'About this course', class: 'govuk-label govuk-label--s' %>
+          <%= f.text_area :about_course, rows: 15, class: 'govuk-textarea js-character-count' %>
+        </div>
+      </div>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+
+      <h3 class="govuk-heading-l remove-top-margin">Interview process</h3>
+
+      <p class="govuk-body">Give applicants a summary of the interview process.</p>
+
+      <p class="govuk-body">This could include:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>who’ll be interviewing them</li>
+        <li>how many interviews they’ll need to attend</li>
+        <li>details of any tests they’ll need to sit</li>
+      </ul>
+
+      <div class="govuk-character-count" data-module="character-count" data-maxwords="250">
+        <div class="govuk-form-group">
+          <%= f.label :interview_process, 'Interview process (optional)', class: 'govuk-label govuk-label--s' %>
+          <%= f.text_area :interview_process, rows: 10, class: 'govuk-textarea js-character-count' %>
+        </div>
+      </div>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+
+      <h3 class="govuk-heading-l remove-top-margin">How school placements work</h3>
+
+      <p class="govuk-body">Tell applicants more about the schools they’ll be teaching in.</p>
+
+      <p class="govuk-body">You could include:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>how the candidate’s schools are selected</li>
+        <li>the average distance candidates have to travel from home to school</li>
+        <li>the age ranges they’ll be teaching (eg 11 to 16 or 11 to 18)</li>
+        <li>how many schools you partner with in total</li>
+        <li>the number of placements a candidate will have</li>
+        <li>how much time candidates spend in each school</li>
+      </ul>
+
+      <div class="govuk-character-count" data-module="character-count" data-maxwords="350">
+        <div class="govuk-form-group">
+          <%= f.label :how_school_placements_work, 'How school placements work', class: 'govuk-label govuk-label--s' %>
+          <%= f.text_area :how_school_placements_work, rows: 10, class: 'govuk-textarea js-character-count' %>
+        </div>
+      </div>
+
+      <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes', provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       get '/vacancies', on: :member, to: 'courses/vacancies#edit'
       put '/vacancies', on: :member, to: 'courses/vacancies#update'
       get '/description', on: :member, to: 'courses#description'
+      get '/about', on: :member, to: 'courses#about'
       get '/withdraw', on: :member, to: 'courses#withdraw'
       get '/delete', on: :member, to: 'courses#delete'
       post '/publish', on: :member, to: 'courses#publish'

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+feature 'About course', type: :feature do
+  let(:course) do
+    jsonapi(
+      :course,
+      provider: jsonapi(:provider, provider_code: 'A0')
+    ).render
+  end
+  let(:course_attributes) { course[:data][:attributes] }
+
+  before do
+    stub_omniauth
+    stub_api_v2_request(
+      "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site,provider.sites,accrediting_provider",
+      course
+    )
+  end
+
+  scenario 'viewing the about courses page' do
+    visit about_provider_course_path('AO', course_attributes[:course_code])
+
+    expect(find('.govuk-caption-xl')).to have_content(
+      "#{course_attributes[:name]} (#{course_attributes[:course_code]})"
+    )
+    expect(find('.govuk-heading-xl')).to have_content(
+      "About this course"
+    )
+    expect(page).to have_field("About this course")
+    expect(page).to have_field("Interview process (optional)")
+    expect(page).to have_field("How school placements work")
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/course_about.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_about.rb
@@ -1,0 +1,15 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseAbout < PageObjects::Base
+        set_url '/organisations/{provider_code}/courses/{course_code}/about '
+
+        element :title, '.govuk-heading-xl'
+        element :caption, '.govuk-caption-xl'
+        element :about_textarea, '#course_about_course'
+        element :interview_process_textarea, '#course_interview_process'
+        element :how_school_placements_work_textarea, '#course_how_school_placements_work'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Re-creating `/organisation/2cf/course/self/2yn6/about` in rails

### Changes proposed in this pull request
Add `/about` to a course

### Guidance to review
> This is a "dumb" read only form at present because there is some backend work todo 

c# | rails
:--:|:--:
![c#](https://user-images.githubusercontent.com/3071606/57467539-a321f900-727a-11e9-852f-e9ca8cb01cf7.png)|![rails](https://user-images.githubusercontent.com/3071606/57468662-d36a9700-727c-11e9-93a6-a80e795f1e14.png)
