### PR TITLE
Update delete link to match design

### DIFF
--- a/app/views/courses/_status_panel.html.erb
+++ b/app/views/courses/_status_panel.html.erb
@@ -21,8 +21,7 @@
     <p class="govuk-body">Remove this course from Find and close applications.</p>
     <%= link_to 'Withdraw this course', withdraw_provider_course_path(@provider.provider_code, course.course_code), class: "govuk-link--destructive" %>
   <% else %>
-    <h3 class="govuk-heading-m">Delete</h3>
-    <p class="govuk-body">Remove this course from Find and close applications.</p>
+    <h3 class="govuk-heading-m govuk-visually-hidden">Delete</h3>
     <%= link_to 'Delete this course', delete_provider_course_path(@provider.provider_code, course.course_code), class: "govuk-link--destructive" %>
   <% end %>
 </div>


### PR DESCRIPTION
Deleting doesn't remove a course from Find. If a course is on Find you can't delete it.

Keep the delete heading for screenreaders.

![Screen Shot 2019-05-13 at 12 09 14](https://user-images.githubusercontent.com/319055/57617136-f3999f00-7577-11e9-8168-de5bc09f57a9.png)
