### PR TITLE
[1462] Add course requirements and eligibility edit page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,7 +1,7 @@
 class CoursesController < ApplicationController
   decorates_assigned :course
-  before_action :build_course, only: %i[show description about delete withdraw publish]
-  before_action :build_provider, only: %i[show description about publish]
+  before_action :build_course, only: %i[show description about requirements delete withdraw publish]
+  before_action :build_provider, only: %i[show description about requirements publish]
 
   def index
     @provider = Provider
@@ -38,6 +38,8 @@ class CoursesController < ApplicationController
   def description; end
 
   def about; end
+
+  def requirements; end
 
   def withdraw; end
 

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -1,0 +1,59 @@
+<%= content_for :page_title, "#{course.name_and_code} - Courses" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
+<% end %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+  Requirements and eligibility
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for course, url: publish_provider_course_path(course.provider.provider_code, course.course_code), method: :post do |f| %>
+      <h3 class="govuk-heading-l remove-top-margin">Qualifications needed</h3>
+
+      <p class="govuk-body">State the minimum academic qualifications needed for this course.</p>
+
+      <div class="govuk-character-count" data-module="character-count" data-maxwords="100">
+        <div class="govuk-form-group">
+          <%= f.label :required_qualifications, 'Qualifications needed', class: 'govuk-label govuk-label--s' %>
+          <%= f.text_area :required_qualifications, rows: 10, class: 'govuk-textarea js-character-count' %>
+        </div>
+      </div>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+
+      <h3 class="govuk-heading-l remove-top-margin">Personal qualities</h3>
+
+      <p class="govuk-body">Tell applicants about the skills and motivation you’re looking for (eg experience with children, a genuine passion for teaching, or a talent for public speaking).</p>
+
+      <div class="govuk-character-count" data-module="character-count" data-maxwords="100">
+        <div class="govuk-form-group">
+          <%= f.label :personal_qualities, 'Personal qualities (optional)', class: 'govuk-label govuk-label--s' %>
+          <%= f.text_area :personal_qualities, rows: 10, class: 'govuk-textarea js-character-count' %>
+        </div>
+      </div>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+
+      <h3 class="govuk-heading-l remove-top-margin">Other requirements</h3>
+
+      <p class="govuk-body">If applicants need any non-academic qualifications or documents, list them here (eg criminal record checks, or relevant work experience).</p>
+
+      <div class="govuk-character-count" data-module="character-count" data-maxwords="100">
+        <div class="govuk-form-group">
+          <%= f.label :other_requirements, 'Other requirements (optional)', class: 'govuk-label govuk-label--s' %>
+          <%= f.text_area :other_requirements, rows: 10, class: 'govuk-textarea js-character-count' %>
+        </div>
+      </div>
+
+      <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes', provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       put '/vacancies', on: :member, to: 'courses/vacancies#update'
       get '/description', on: :member, to: 'courses#description'
       get '/about', on: :member, to: 'courses#about'
+      get '/requirements', on: :member, to: 'courses#requirements'
       get '/withdraw', on: :member, to: 'courses#withdraw'
       get '/delete', on: :member, to: 'courses#delete'
       post '/publish', on: :member, to: 'courses#publish'

--- a/spec/features/courses/requirement_spec.rb
+++ b/spec/features/courses/requirement_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+feature 'Course requirements', type: :feature do
+  let(:course_jsonapi) do
+    jsonapi(
+      :course,
+      provider: jsonapi(:provider, provider_code: 'A0')
+    )
+  end
+  let(:course)          { course_jsonapi.to_resource }
+  let(:course_response) { course_jsonapi.render }
+
+  before do
+    stub_omniauth
+    stub_api_v2_request(
+      "/providers/AO/courses/#{course.course_code}?include=site_statuses.site,provider.sites,accrediting_provider",
+      course_response
+    )
+  end
+
+  let(:about_course_page) { PageObjects::Page::Organisations::CourseRequirements.new }
+
+  scenario 'viewing the courses requirements page' do
+    visit requirements_provider_course_path('AO', course.course_code)
+
+    expect(about_course_page.caption).to have_content(
+      "#{course.name} (#{course.course_code})"
+    )
+    expect(about_course_page.title).to have_content(
+      "Requirements and eligibility"
+    )
+    expect(about_course_page.required_qualifications).to have_content(
+      course.required_qualifications
+    )
+    expect(about_course_page.personal_qualities).to have_content(
+      course.personal_qualities
+    )
+    expect(about_course_page.other_requirements).to have_content(
+      course.other_requirements
+    )
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/course_requirements.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_requirements.rb
@@ -1,0 +1,15 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseRequirements < PageObjects::Base
+        set_url '/organisations/{provider_code}/courses/{course_code}/requirements'
+
+        element :title, '.govuk-heading-xl'
+        element :caption, '.govuk-caption-xl'
+        element :required_qualifications, '#course_required_qualifications'
+        element :personal_qualities, '#course_personal_qualities'
+        element :other_requirements, '#course_other_requirements'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Re-creating `/organisation/2cf/course/self/2yn6/requirements` in rails

### Changes proposed in this pull request
Add `/requirements` to a course

### Guidance to review
> This is a "dumb" read only form at present because there is some backend work todo 

c# | rails
:--:|:--:
![c#](https://user-images.githubusercontent.com/3071606/57618740-26459680-757c-11e9-85b2-48edc3d99a5b.png)|![rails](https://user-images.githubusercontent.com/3071606/57618721-1af26b00-757c-11e9-82ba-416840ccf691.png)

