### PR TITLE
[XXXX] Only display the 500 page in production mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, except: :not_found
-  rescue_from StandardError, with: :internal_server_error
   rescue_from JsonApiClient::Errors::NotAuthorized, with: :render_manage_ui
   rescue_from JsonApiClient::Errors::AccessDenied, with: :render_manage_ui
 
@@ -11,14 +10,6 @@ class ApplicationController < ActionController::Base
       format.html { render 'errors/not_found', status: :not_found }
       format.json { render json: { error: 'Resource not found' }, status: :not_found }
       format.all { render status: :not_found, body: nil }
-    end
-  end
-
-  def internal_server_error(exception)
-    Raven.capture_exception(exception)
-    respond_to do |format|
-      format.html { render 'errors/internal_server_error', status: :internal_server_error }
-      format.json { render json: { error: 'Internal server error' }, status: :internal_server_error }
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,8 @@ module ManageCoursesFrontend
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.exceptions_app = self.routes
+
     config.session_store :cookie_store,
                          key: '_publish_teacher_training_courses_session',
                          expire_after: 6.hours

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -39,17 +39,5 @@ describe UsersController, type: :controller do
         expect(response).to redirect_to(providers_path)
       end
     end
-
-    context "with server error" do
-      before do
-        stub_api_v2_request("/users/#{user.id}/accept_transition_screen", {}, :patch, 500)
-      end
-
-      it "redirects to providers index" do
-        get :accept_transition_info
-        expect(Raven).to have_received(:capture_exception).with(instance_of(JsonApiClient::Errors::ServerError))
-        expect(response).to have_http_status(:internal_server_error)
-      end
-    end
   end
 end

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -26,15 +26,4 @@ RSpec.feature 'View pages', type: :feature do
     visit "/guidance"
     expect(find('h1')).to have_content('Guidance for Publish teacher training courses')
   end
-
-  context "With errors" do
-    scenario "Navigate to /guidance" do
-      allow_any_instance_of(PagesController)
-        .to receive(:guidance)
-        .and_raise(StandardError)
-
-      visit "/guidance"
-      expect(find('h1')).to have_content('Sorry, something went wrong')
-    end
-  end
 end


### PR DESCRIPTION
Better solution, turn on the relevant Rails flag.

Tests removed because there's no point in testing Rails itself.