### PR TITLE
[1461] Add course salary edit page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -43,6 +43,8 @@ class CoursesController < ApplicationController
 
   def fees; end
 
+  def salary; end
+
   def withdraw; end
 
   def delete; end

--- a/app/views/courses/_course_length.html.erb
+++ b/app/views/courses/_course_length.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h2 class="govuk-fieldset__heading">Course length</h2>
+    </legend>
+    <div class="govuk-radios" data-module="radios">
+      <div class="govuk-radios__item">
+        <%= f.radio_button :course_length, 'OneYear', class: 'govuk-radios__input' %>
+        <%= f.label :course_length, '1 year', class: 'govuk-label govuk-radios__label', for: 'course_course_length_oneyear' %>
+      </div>
+      <div class="govuk-radios__item">
+        <%= f.radio_button :course_length, 'TwoYears', class: 'govuk-radios__input' %>
+        <%= f.label :course_length, 'Up to 2 years', class: 'govuk-label govuk-radios__label', for: 'course_course_length_twoyears' %>
+      </div>
+      <div class="govuk-radios__item">
+        <%= f.radio_button :course_length, 'Other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" } %>
+        <%= f.label :course_length, 'Other', class: 'govuk-label govuk-radios__label', for: 'course_course_length_other' %>
+      </div>
+      <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="other-container">
+        <div class="form-group">
+          <%= f.label :course_length, 'Course Length', class: 'govuk-label govuk-label--s', for: 'course_course_length_other_length' %>
+          <%= f.text_field :course_length, class: 'govuk-input' %>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{course.name_and_code} - Courses" %>
+<%= content_for :page_title, "Course length and fees - #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
@@ -12,33 +12,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for course, url: publish_provider_course_path(course.provider.provider_code, course.course_code), method: :post do |f| %>
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h2 class="govuk-fieldset__heading">Course length</h2>
-          </legend>
-            <div class="govuk-radios" data-module="radios">
-              <div class="govuk-radios__item">
-                <%= f.radio_button :course_length, 'OneYear', class: 'govuk-radios__input' %>
-                <%= f.label :course_length, '1 year', class: 'govuk-label govuk-radios__label', for: 'course_course_length_oneyear' %>
-              </div>
-              <div class="govuk-radios__item">
-                <%= f.radio_button :course_length, 'TwoYears', class: 'govuk-radios__input' %>
-                <%= f.label :course_length, 'Up to 2 years', class: 'govuk-label govuk-radios__label', for: 'course_course_length_twoyears' %>
-              </div>
-              <div class="govuk-radios__item">
-                <%= f.radio_button :course_length, 'Other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" } %>
-                <%= f.label :course_length, 'Other', class: 'govuk-label govuk-radios__label', for: 'course_course_length_other' %>
-              </div>
-              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="other-container">
-                <div class="form-group">
-                  <%= f.label :course_length, 'Course Length', class: 'govuk-label govuk-label--s', for: 'course_course_length_other_length' %>
-                  <%= f.text_field :course_length, class: 'govuk-input' %>
-                </div>
-              </div>
-            </div>
-        </fieldset>
-      </div>
+      <%= render partial: 'courses/course_length', locals: { f: f } %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{course.name_and_code} - Course length and salary" %>
+<%= content_for :page_title, "Course length and salary - #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
@@ -12,33 +12,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for course, url: publish_provider_course_path(course.provider.provider_code, course.course_code), method: :post do |f| %>
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h2 class="govuk-fieldset__heading">Course length</h2>
-          </legend>
-            <div class="govuk-radios" data-module="radios">
-              <div class="govuk-radios__item">
-                <%= f.radio_button :course_length, 'OneYear', class: 'govuk-radios__input' %>
-                <%= f.label :course_length, '1 year', class: 'govuk-label govuk-radios__label', for: 'course_course_length_oneyear' %>
-              </div>
-              <div class="govuk-radios__item">
-                <%= f.radio_button :course_length, 'TwoYears', class: 'govuk-radios__input' %>
-                <%= f.label :course_length, 'Up to 2 years', class: 'govuk-label govuk-radios__label', for: 'course_course_length_twoyears' %>
-              </div>
-              <div class="govuk-radios__item">
-                <%= f.radio_button :course_length, 'Other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" } %>
-                <%= f.label :course_length, 'Other', class: 'govuk-label govuk-radios__label', for: 'course_course_length_other' %>
-              </div>
-              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="other-container">
-                <div class="form-group">
-                  <%= f.label :course_length, 'Course Length', class: 'govuk-label govuk-label--s', for: 'course_course_length_other_length' %>
-                  <%= f.text_field :course_length, class: 'govuk-input' %>
-                </div>
-              </div>
-            </div>
-        </fieldset>
-      </div>
+      <%= render partial: 'courses/course_length', locals: { f: f } %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -1,0 +1,68 @@
+<%= content_for :page_title, "#{course.name_and_code} - Course length and salary" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
+<% end %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+  Course length and salary
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for course, url: publish_provider_course_path(course.provider.provider_code, course.course_code), method: :post do |f| %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h2 class="govuk-fieldset__heading">Course length</h2>
+          </legend>
+            <div class="govuk-radios" data-module="radios">
+              <div class="govuk-radios__item">
+                <%= f.radio_button :course_length, 'OneYear', class: 'govuk-radios__input' %>
+                <%= f.label :course_length, '1 year', class: 'govuk-label govuk-radios__label', for: 'course_course_length_oneyear' %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= f.radio_button :course_length, 'TwoYears', class: 'govuk-radios__input' %>
+                <%= f.label :course_length, 'Up to 2 years', class: 'govuk-label govuk-radios__label', for: 'course_course_length_twoyears' %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= f.radio_button :course_length, 'Other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" } %>
+                <%= f.label :course_length, 'Other', class: 'govuk-label govuk-radios__label', for: 'course_course_length_other' %>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="other-container">
+                <div class="form-group">
+                  <%= f.label :course_length, 'Course Length', class: 'govuk-label govuk-label--s', for: 'course_course_length_other_length' %>
+                  <%= f.text_field :course_length, class: 'govuk-input' %>
+                </div>
+              </div>
+            </div>
+        </fieldset>
+      </div>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+
+      <h3 class="govuk-heading-l remove-top-margin">Salary</h3>
+
+      <p class="govuk-body">Give details about the salary for this course.</p>
+      <p class="govuk-body">You should:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>give an indication of the salary – if you don’t have the figure, say how it will be calculated (eg using the unqualified teachers’ pay scales)</li>
+        <li>say whether there are any fees or others costs – if there are no fees for this course, you should also say so</li>
+      </ul>
+
+      <div class="govuk-character-count" data-module="character-count" data-maxwords="250">
+        <div class="govuk-form-group">
+          <%= f.label :salary_details, 'Salary', class: 'govuk-label govuk-label--s' %>
+          <%= f.text_area :salary_details, rows: 15, class: 'govuk-textarea js-character-count' %>
+        </div>
+      </div>
+
+      <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes', provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       get '/about', on: :member, to: 'courses#about'
       get '/requirements', on: :member, to: 'courses#requirements'
       get '/fees', on: :member, to: 'courses#fees'
+      get '/salary', on: :member, to: 'courses#salary'
       get '/withdraw', on: :member, to: 'courses#withdraw'
       get '/delete', on: :member, to: 'courses#delete'
       post '/publish', on: :member, to: 'courses#publish'

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+feature 'Course salary', type: :feature do
+  let(:course_jsonapi) do
+    jsonapi(
+      :course,
+      provider: jsonapi(:provider, provider_code: 'A0'),
+      course_length: 'OneYear'
+    )
+  end
+  let(:course)          { course_jsonapi.to_resource }
+  let(:course_response) { course_jsonapi.render }
+
+  before do
+    stub_omniauth
+    stub_api_v2_request(
+      "/providers/AO/courses/#{course.course_code}?include=site_statuses.site,provider.sites,accrediting_provider",
+      course_response
+    )
+  end
+
+  let(:course_salary_page) { PageObjects::Page::Organisations::CourseSalary.new }
+
+  scenario 'viewing the courses salary page' do
+    visit salary_provider_course_path('AO', course.course_code)
+
+    expect(course_salary_page.caption).to have_content(
+      "#{course.name} (#{course.course_code})"
+    )
+    expect(course_salary_page.title).to have_content(
+      "Course length and salary"
+    )
+    expect(course_salary_page.course_length_one_year).to be_checked
+    expect(course_salary_page.course_length_two_years).to_not be_checked
+    expect(course_salary_page.course_salary_details).to have_content(
+      course.salary_details
+    )
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/course_salary.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_salary.rb
@@ -1,0 +1,15 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseSalary < PageObjects::Base
+        set_url '/organisations/{provider_code}/courses/{course_code}/salary'
+
+        element :title, '.govuk-heading-xl'
+        element :caption, '.govuk-caption-xl'
+        element :course_length_one_year, '#course_course_length_oneyear'
+        element :course_length_two_years, '#course_course_length_twoyears'
+        element :course_salary_details, '#course_salary_details'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Re-creating `/organisation/2cf/course/self/2yn6/salary` in rails

### Changes proposed in this pull request
Add `/salary` to a course

### Guidance to review
> This is a "dumb" read only form at present because there is some backend work todo 

c# | rails
:--:|:--:
![c#](https://user-images.githubusercontent.com/3071606/57695970-8bb28980-7647-11e9-9ba2-b952ccd4a7cb.png)|![rails](https://user-images.githubusercontent.com/3071606/57695975-8f461080-7647-11e9-8180-c3f18534589c.png)