### PR TITLE
[1458] Switch factories to use the JSONAPI renderer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,11 +51,22 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
 
+  # Factories to build models
+  gem 'factory_bot_rails'
+
+  # Get us some fake!
+  gem 'faker'
+
   # GOV.UK interpretation of rubocop for linting Ruby
   gem 'govuk-lint'
 
+  # Ability to render JSONAPI
+  gem 'jsonapi-renderer'
+  gem 'jsonapi-serializable'
+
   # Debugging
   gem 'pry-byebug'
+  gem 'pry-rails'
 
   # Testing framework
   gem 'rspec-rails', '~> 3.8'
@@ -97,8 +108,6 @@ group :test do
 
   gem 'webmock'
 
-  gem 'factory_bot_rails'
-
   # Show test coverage %
   gem 'simplecov', require: false
 
@@ -107,9 +116,6 @@ group :test do
 
   # Page object for Capybara
   gem 'site_prism'
-
-  # Get us some fake!
-  gem 'faker'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,9 @@ GEM
       addressable (~> 2.2)
       faraday (~> 0.15, >= 0.15.2)
       faraday_middleware (~> 0.9)
+    jsonapi-renderer (0.2.0)
+    jsonapi-serializable (0.3.1)
+      jsonapi-renderer (~> 0.2.0)
     jwt (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -243,6 +246,8 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (3.0.3)
     puma (3.12.1)
     rack (2.0.7)
@@ -425,12 +430,15 @@ DEPENDENCIES
   guard-rspec
   guard-rubocop
   json_api_client
+  jsonapi-renderer
+  jsonapi-serializable
   jwt
   listen (>= 3.0.5, < 3.2)
   omniauth (~> 1.8)
   omniauth_openid_connect (~> 0.3)
   pkg-config (~> 1.3.7)
   pry-byebug
+  pry-rails
   puma (~> 3.12)
   rails (~> 5.2.3)
   rspec-rails (~> 3.8)

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SessionsController, type: :controller do
         email: "email@example.com",
       }
     }
-    let(:user) { jsonapi :user, **user_info }
+    let(:user) { build :user, **user_info }
     let(:user_id) { '101' }
     let(:sign_in_user_id) { SecureRandom.uuid }
 
@@ -39,7 +39,7 @@ RSpec.describe SessionsController, type: :controller do
       before do
         allow(Session).to receive(:create)
           .with(first_name: user.first_name, last_name: user.last_name)
-          .and_return(user.to_resource)
+          .and_return(user)
         allow(Base).to receive(:connection)
       end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe UsersController, type: :controller do
-  let(:user) { jsonapi :user }
+  let(:user) { build :user }
 
   before do
     stub_omniauth(user: user)

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
-  factory :user, class: Hash do
+  factory :user do
+    skip_create
+
     sequence(:id)
     first_name { Faker::Name.first_name }
     last_name  { Faker::Name.last_name }
@@ -9,16 +11,6 @@ FactoryBot.define do
 
     trait :new do
       state { 'new' }
-    end
-
-    initialize_with do |_evaluator|
-      data_attributes = attributes.except(:id)
-
-      JSONAPIMockSerializable.new(
-        id,
-        'users',
-        attributes: data_attributes
-      )
     end
   end
 end

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -23,7 +23,7 @@ feature 'Index courses', type: :feature do
 
   describe "without accrediting providers" do
     before do
-      user = jsonapi(:user)
+      user = build(:user)
       stub_omniauth(user: user)
       stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
       stub_api_v2_request("/providers/A123", provider_response)
@@ -96,7 +96,7 @@ feature 'Index courses', type: :feature do
     let(:course_3) { jsonapi :course, accrediting_provider: provider_2 }
 
     before do
-      user = jsonapi(:user)
+      user = build(:user)
       stub_omniauth(user: user)
       stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
       stub_api_v2_request("/providers/A123", provider_response)

--- a/spec/features/locations/index_spec.rb
+++ b/spec/features/locations/index_spec.rb
@@ -21,7 +21,7 @@ feature 'View locations', type: :feature do
   let(:location_page) { PageObjects::Page::LocationPage.new }
 
   before do
-    user = jsonapi(:user)
+    user = build(:user)
     stub_omniauth(user: user)
     stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider[:data]]))
     stub_api_v2_request("/providers/#{provider_code}", provider)

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -6,7 +6,7 @@ feature 'Sign in', type: :feature do
   let(:root_page)            { PageObjects::Page::RootPage.new }
 
   scenario 'using DfE Sign-in' do
-    user = jsonapi :user
+    user = build :user
 
     stub_omniauth(user: user)
     stub_api_v2_request('/providers', jsonapi(:providers_response))
@@ -19,11 +19,11 @@ feature 'Sign in', type: :feature do
   end
 
   scenario 'new user accepts the transition info page' do
-    user = jsonapi :user, :new
+    user = build :user, :new
 
     stub_omniauth(user: user)
     stub_api_v2_request('/providers', jsonapi(:providers_response))
-    request = stub_api_v2_request "/users/#{user.id}/accept_transition_screen", user, :patch
+    request = stub_api_v2_request "/users/#{user.id}/accept_transition_screen", user.to_jsonapi, :patch
 
     visit '/signin'
 

--- a/spec/support/define_factory_jsonapi_render_methods.rb
+++ b/spec/support/define_factory_jsonapi_render_methods.rb
@@ -1,0 +1,25 @@
+FactoryBot.define do
+  # This defines an after build callback that goes on ALL factories.
+  after :build do |record|
+    # This defines an instance method called to_jsonapi on the object we just
+    # created with the factory.
+    record.define_singleton_method(:to_jsonapi) do
+      # Create a string that holds the name of the class, for example
+      # "UserSerializer"
+      serializer_class = "#{record.class}Serializer"
+
+      renderer = JSONAPI::Serializable::Renderer.new
+      renderer.render(
+        record,
+        class: {
+          # This tells the renderer what serializers to use. The key is going
+          # to be the name of the class as a symbol, and the value is the
+          # serializer class.
+          #
+          # For example: User: UserSerializer
+          record.class.name.to_sym => serializer_class.constantize
+        }
+      )
+    end
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,7 +1,7 @@
 module Helpers
   def stub_omniauth(user: nil)
-    user_resource = user || jsonapi(:user)
-    user = user_resource.to_resource
+    user ||= build(:user)
+
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:dfe] = {
       'provider' => 'dfe',
@@ -22,7 +22,7 @@ module Helpers
     # TODO: Move this to be returned with the user.
     stub_api_v2_request('/providers', jsonapi(:provider).render)
     Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:dfe]
-    stub_api_v2_request('/sessions', user_resource.render, :post)
+    stub_api_v2_request('/sessions', user.to_jsonapi, :post)
   end
 
   def stub_api_v2_request(url_path, stub, method = :get, status = 200, token: nil)

--- a/spec/support/initialize_factory_serializers.rb
+++ b/spec/support/initialize_factory_serializers.rb
@@ -1,0 +1,24 @@
+FactoryBot.factories.each do |factory|
+  next unless factory.name.in? []
+
+  # Create a string that holds the name of the class, for example
+  # "UserSerializer"
+  serializer_class_name = "#{factory.name.capitalize}Serializer"
+
+  # Create a new class (of type Class) and make it inherit from the JSONAPI
+  # serializer resource. Everything in the block is related to the serializer.
+  #
+  # We set the serializer type to the plural of the factory name, for example
+  # "users".
+  # We set the attributes to render out to the attributes we define in the
+  # factory.
+  serializer_class      = Class.new(JSONAPI::Serializable::Resource) do
+    type(factory.name.to_s.pluralize)
+    attributes(*FactoryBot.attributes_for(factory.name).keys)
+  end
+
+  # Create a new constant with the class name and make it point to the class
+  # we created. For example "UserSerializer", and it would point to the class
+  # we created.
+  Object.const_set(serializer_class_name, serializer_class)
+end

--- a/spec/support/initialize_factory_serializers.rb
+++ b/spec/support/initialize_factory_serializers.rb
@@ -1,5 +1,5 @@
 FactoryBot.factories.each do |factory|
-  next unless factory.name.in? []
+  next unless factory.name.in? %i[user]
 
   # Create a string that holds the name of the class, for example
   # "UserSerializer"


### PR DESCRIPTION
### Context

Using the `jsonapi-rb` gems to render JSONAPI responses based on our factories. 

### Changes proposed in this pull request

A few lines of metaprogramming magic to create serializers and make our models able to turn themselves into JSONAPI hashes.

### Guidance to review

TODO:

* Still need to do this for the rest of the factories (should be easy)
* Relations (easy to add in)
* Custom meta attributes (might be easier to declare the serializers manually for these)
* Need to support the `includes` parameter (should be easy)
* Need to figure out how to make this work with `build_list` (a bit of a pain)