### PR TITLE
Use live search URL

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -8,4 +8,4 @@ manage_backend:
 manage_ui:
   base_url: https://www.publish-teacher-training-courses.service.gov.uk
 search_ui:
-  base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://find-postgraduate-teacher-training.education.gov.uk


### PR DESCRIPTION
Use https://find-postgraduate-teacher-training.education.gov.uk instead of https://www.find-postgraduate-teacher-training.service.gov.uk.

`https://www.find-postgraduate-teacher-training.service.gov.uk` works but isn't the official URL yet.

The [start page](https://www.gov.uk/guidance/find-postgraduate-teacher-training-courses-in-england) on GOV.UK links to https://find-postgraduate-teacher-training.education.gov.uk 