### PR TITLE
[1485] Reduce cookie size

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,17 @@ class SessionsController < ApplicationController
   end
 
   def create
-    session[:auth_user] = auth_hash
+    session[:auth_user] = HashWithIndifferentAccess.new(
+      "uid" => auth_hash.dig("uid"),
+      "info" => HashWithIndifferentAccess.new(
+        email: auth_hash.dig("info", 'email'),
+        first_name: auth_hash.dig("info", 'first_name'),
+        last_name: auth_hash.dig("info", 'last_name')
+      ),
+      'credentials' => HashWithIndifferentAccess.new(
+        'id_token' => auth_hash.dig('credentials', :id_token)
+      )
+    )
 
     Raven.tags_context(sign_in_user_id: current_user.fetch('uid'))
     add_token_to_connection

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SessionsController, type: :controller do
 
     before do
       @request.env["omniauth.auth"] = {
-        "info" => user.attributes,
+        "info" => user.attributes.stringify_keys,
         'uid' => sign_in_user_id
       }
     end
@@ -47,8 +47,11 @@ RSpec.describe SessionsController, type: :controller do
         get :create
 
         expect(subject).to redirect_to("/")
+        user_info = @request.session[:auth_user]['info']
         expect(@request.session[:auth_user]['user_id']).to eq user_id
-        expect(@request.session[:auth_user]["info"]).to eq user.attributes
+        expect(user_info['email']).to eq user.attributes[:email]
+        expect(user_info['first_name']).to eq user.attributes[:first_name]
+        expect(user_info['last_name']).to eq user.attributes[:last_name]
       end
 
       describe 'sentry contexts' do


### PR DESCRIPTION
### Context
Our cookies were getting too big. With all the auth info from DSI (DfE Sign In) + encryption + some extra stuff, it overflows.

We only use the DSI ID, email, first and last name, and the ID token, the rest of the data we get from DSI we don't use

### Changes proposed in this pull request

Only save the data we need from DSI, throw the rest away. This makes the cookie much smaller.

### Guidance to review

I want to refactor this badly, but I'm holding off so I can finish the factories. I'm hoping we can replace much of this code with a shared DSI gem.