### PR TITLE
Expose email address for copying and pasting

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -23,8 +23,17 @@ module ViewHelper
     search_ui_url("/course/#{provider_code}/#{course_code}")
   end
 
+  def bat_contact_email_address
+    Settings.service_support.contact_email_address
+  end
+
+  def bat_contact_email_address_with_wrap
+    # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
+    # The <wbr> element will not be copied when copying and pasting the email address
+    bat_contact_email_address.gsub('@', '<wbr>@').html_safe
+  end
+
   def bat_contact_mail_to(name = nil, subject: nil, link_class: "govuk-link")
-    contact_email_address = Settings.service_support.contact_email_address
-    mail_to contact_email_address, name || contact_email_address, subject: subject, class: link_class
+    mail_to bat_contact_email_address, name || bat_contact_email_address, subject: subject, class: link_class
   end
 end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,7 +3,8 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds govuk-footer__content-container">
         <p class="govuk-footer__content">
-          <%= bat_contact_mail_to "Contact the Becoming a Teacher team", subject: "Publish teacher training courses support", link_class: "govuk-footer__link" %> for support.
+          Contact the Becoming a Teacher team for support:
+          <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses support", link_class: "govuk-footer__link" %>
         </p>
       </div>
     </div>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -48,7 +48,8 @@
   <div class="govuk-grid-column-one-third">
     <div class="related">
       <h2 class="govuk-heading-m">Support and guidance</h2>
-      <p class="govuk-body govuk-!-margin-bottom-0">If you have a question, or you’ve had a problem using Publish, you can <%= bat_contact_mail_to "email the Becoming a Teacher team", subject: "Support and guidance" %>.</p>
+      <p class="govuk-body">If you have a question, or you’ve had a problem using Publish, you can email:</p>
+      <p class="govuk-body govuk-!-margin-bottom-0"><%= bat_contact_mail_to bat_contact_email_address_with_wrap, subject: "Support and guidance" %></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Context

Some users struggle to use mailto links, either they don't have an email client set up on their machine or they don't know how to get the email from the link.

### Changes proposed in this pull request

Expose the email address so it's easier to copy and paste for everyone.

The address is long, so allow it to wrap before the '@'

### Guidance to review

Side column on an organisation page and in the footer

![Screen Shot 2019-05-15 at 11 21 30](https://user-images.githubusercontent.com/319055/57769275-608e6f80-7705-11e9-8e30-a8caae558640.png)

![Screen Shot 2019-05-15 at 11 34 33](https://user-images.githubusercontent.com/319055/57769293-6dab5e80-7705-11e9-915f-f92673cf0109.png)
