### PR TITLE
[1471] Add a new features page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,5 +9,7 @@ class PagesController < ApplicationController
 
   def guidance; end
 
+  def new_features; end
+
   def transition_info; end
 end

--- a/app/views/pages/new_features.html.erb
+++ b/app/views/pages/new_features.html.erb
@@ -21,7 +21,6 @@
       <li>change locations assigned to a course</li>
       <li>add a new location</li>
       <li>edit the UCAS Apply eligibility requirements for a course</li>
-      <li>edit the outcome of a course</li>
     </ul>
 
     <h2 class="govuk-heading-l">July to September 2019</h2>

--- a/app/views/pages/new_features.html.erb
+++ b/app/views/pages/new_features.html.erb
@@ -1,0 +1,35 @@
+<%= content_for :page_title, "New features coming to Publish" %>
+
+<h1 class="govuk-heading-xl">
+  New features coming to Publish
+</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">Here’s a list of new features we plan to introduce to Publish teacher training courses in the coming months. This list is only a guide and may change.</p>
+
+    <h2 class="govuk-heading-l">Recently released</h2>
+    <p class="govuk-body">You can now:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>edit course vacancies</li>
+      <li>edit a location name and address</li>
+      <li>request a new course or location using a Google Form</li>
+    </ul>
+
+    <h2 class="govuk-heading-l">May to June 2019</h2>
+    <p class="govuk-body">You’ll be able to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>change locations assigned to a course</li>
+      <li>add a new location</li>
+      <li>edit the UCAS Apply eligibility requirements for a course</li>
+      <li>edit the outcome of a course</li>
+    </ul>
+
+    <h2 class="govuk-heading-l">July to September 2019</h2>
+    <p class="govuk-body">You’ll be able to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>rollover and prepare your courses for the next cycle</li>
+      <li>edit all aspects of a course</li>
+      <li>add a new course</li>
+    </ul>
+  </div>
+</div>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -47,6 +47,9 @@
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="related">
+      <h2 class="govuk-heading-m">New features in Publish</h2>
+      <p class="govuk-body"><%= govuk_link_to "View a list of new features", new_features_path %> we plan to introduce in the coming months.</p>
+
       <h2 class="govuk-heading-m">Support and guidance</h2>
       <p class="govuk-body">If you have a question, or you’ve had a problem using Publish, you can email:</p>
       <p class="govuk-body govuk-!-margin-bottom-0"><%= bat_contact_mail_to bat_contact_email_address_with_wrap, subject: "Support and guidance" %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
   get "/terms-conditions", to: "pages#terms", as: :terms
   get "/privacy-policy", to: "pages#privacy", as: :privacy
   get "/guidance", to: "pages#guidance", as: :guidance
+  get "/new-features", to: "pages#new_features", as: :new_features
   get "/transition-info", to: "pages#transition_info", as: :transition_info
   patch '/accept-transition-info', to: 'users#accept_transition_info'
 

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -22,6 +22,13 @@ RSpec.feature 'View pages', type: :feature do
     expect(find('h1')).to have_content('Privacy policy')
   end
 
+  scenario "Navigate to /new-features" do
+    stub_omniauth
+
+    visit "/new-features"
+    expect(find('h1')).to have_content('New features coming to Publish')
+  end
+
   scenario "Navigate to /guidance" do
     visit "/guidance"
     expect(find('h1')).to have_content('Guidance for Publish teacher training courses')


### PR DESCRIPTION
### Context

Give context to users about what we are working on and when they can expect these features.

### Changes proposed in this pull request

* Add a `/new-features` page
* Link to it from the organisation page

I want the page to have a `Back` link that returns them to the organisation page they came from but couldn’t work out how to do this.

Draft PR because we might need to update the content based on feedback from @mtbleary and @benilovj 

https://trello.com/c/jnhDmnAQ/1471-create-page-for-roadmap