### PR TITLE
[1476] copy course length and salary content

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,9 +1,9 @@
 class CoursesController < ApplicationController
   decorates_assigned :course
-  before_action :build_courses, only: %i[index about requirements fees]
+  before_action :build_courses, only: %i[index about requirements fees salary]
   before_action :build_course, except: :index
   before_action :build_provider, except: :index
-  before_action :filter_courses, only: %i[about requirements fees]
+  before_action :filter_courses, only: %i[about requirements fees salary]
   before_action :build_copy_course, if: -> { params[:copy_from].present? }
 
   def index; end
@@ -44,7 +44,12 @@ class CoursesController < ApplicationController
     end
   end
 
-  def salary; end
+  def salary
+    if params[:copy_from].present?
+      course.course_length = @source_course.course_length
+      course.salary_details = @source_course.salary_details
+    end
+  end
 
   def withdraw; end
 

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -4,6 +4,26 @@
   <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
 <% end %>
 
+<% if params[:copy_from].present? %>
+  <div class="govuk-warning-summary" aria-labelledby="warning-summary-heading" tabindex="-1" data-module="error-summary" data-copy-course="warning" role="alert">
+    <h2 class="govuk-heading govuk-warning-summary__title" id="warning-summary-heading">
+      Your changes are not yet saved
+    </h2>
+    <div class="govuk-warning-summary__body">
+      <p class="govuk-body">
+        We’ve copied these fields from <%= @source_course.name %> (<%= @source_course.course_code %>):
+      </p>
+      <ul class="govuk-list">
+        <li><%= link_to 'Course length', '#course_length_wrapper', class: 'govuk-link' %></li>
+        <li><%= link_to 'Salary details', '#salary_details_wrapper', class: 'govuk-link' %></li>
+      </ul>
+      <p class="govuk-body">
+        Please check them and make your changes before saving.
+      </p>
+    </div>
+  </div>
+<% end %>
+
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>
   Course length and salary
@@ -25,7 +45,7 @@
         <li>say whether there are any fees or others costs – if there are no fees for this course, you should also say so</li>
       </ul>
 
-      <div class="govuk-character-count" data-module="character-count" data-maxwords="250">
+      <div id="salary_details_wrapper" class="govuk-character-count" data-module="character-count" data-maxwords="250">
         <div class="govuk-form-group">
           <%= f.label :salary_details, 'Salary', class: 'govuk-label govuk-label--s' %>
           <%= f.text_area :salary_details, rows: 15, class: 'govuk-textarea js-character-count' %>
@@ -38,5 +58,11 @@
         <%= link_to 'Cancel changes', provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
       </p>
     <% end %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: 'courses/related_sidebar',
+                        locals: {
+                          course: course,
+                          page_path: salary_provider_course_path(course.provider.provider_code, course.course_code) } %>
   </div>
 </div>

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -1,21 +1,35 @@
 require 'rails_helper'
 
 feature 'Course salary', type: :feature do
-  let(:course_jsonapi) do
+  let(:course_1) do
     jsonapi(
       :course,
-      provider: jsonapi(:provider, provider_code: 'A0'),
+      name: 'English',
+      provider: provider,
+      include_nulls: [:accrediting_provider],
       course_length: 'OneYear'
     )
   end
-  let(:course)          { course_jsonapi.to_resource }
-  let(:course_response) { course_jsonapi.render }
+  let(:course_2) { jsonapi :course, name: 'Biology', include_nulls: [:accrediting_provider] }
+  let(:course_3) { jsonapi :course, name: 'Physics', include_nulls: [:accrediting_provider] }
+  let(:course_4) { jsonapi :course, name: 'Science', include_nulls: [:accrediting_provider] }
+  let(:courses)  { [course_2, course_3, course_4] }
+  let(:provider) do
+    jsonapi(:provider, courses: courses, accredited_body?: true, provider_code: 'AO')
+  end
+  let(:provider_response) { provider.render }
+  let(:course)            { course_1.to_resource }
+  let(:course_response)   { course_1.render }
 
   before do
     stub_omniauth
     stub_api_v2_request(
       "/providers/AO/courses/#{course.course_code}?include=site_statuses.site,provider.sites,accrediting_provider",
       course_response
+    )
+    stub_api_v2_request(
+      "/providers/AO?include=courses.accrediting_provider",
+      provider_response
     )
   end
 

--- a/spec/requests/courses/salary_spec.rb
+++ b/spec/requests/courses/salary_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+describe 'Courses', type: :request do
+  describe 'GET salary' do
+    let(:course_json_api)   { jsonapi :course, name: 'English', course_code: 'EN01', provider: provider, include_nulls: [:accrediting_provider] }
+    let(:provider)          { jsonapi(:provider, accredited_body?: true, provider_code: 'AO') }
+    let(:course)            { course_json_api.to_resource }
+    let(:course_response)   { course_json_api.render }
+
+    let(:course_1_json_api) { jsonapi :course, name: 'English', course_code: 'EN01', include_nulls: [:accrediting_provider] }
+    let(:course_2_json_api) do
+      jsonapi :course,
+              name: 'Biology',
+              include_nulls: [:accrediting_provider],
+              course_length: 'TwoYears',
+              salary_details: 'Some information about the salary'
+    end
+    let(:course_2)            { course_2_json_api.to_resource }
+    let(:courses)             { [course_1_json_api, course_2_json_api] }
+    let(:provider2)           { jsonapi(:provider, courses: courses, accredited_body?: true, provider_code: 'AO') }
+    let(:provider_2_response) { provider2.render }
+
+    before do
+      stub_omniauth
+      get(auth_dfe_callback_path)
+      stub_api_v2_request(
+        "/providers/#{provider.provider_code}/courses/#{course.course_code}?include=site_statuses.site,provider.sites,accrediting_provider",
+        course_response
+      )
+      stub_api_v2_request(
+        "/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=site_statuses.site,provider.sites,accrediting_provider",
+        course_2_json_api.render
+      )
+      stub_api_v2_request(
+        "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
+        provider_2_response
+      )
+    end
+
+    it 'renders the course length and fees' do
+      get(salary_provider_course_path(provider_code: provider.provider_code,
+                                      code: course.course_code))
+
+      expect(response.body).to include(
+        "#{course.name} (#{course.course_code})"
+      )
+      expect(response.body).to include(
+        'Course length and salary'
+      )
+      expect(response.body).to_not include(
+        'Your changes are not yet saved'
+      )
+    end
+
+    context 'with copy_form parameter' do
+      it 'renders the course length and fees with data from chosen' do
+        get(salary_provider_course_path(provider_code: provider.provider_code,
+                                        code: course.course_code,
+                                        params: { copy_from: course_2.course_code }))
+
+        expect(response.body).to include(
+          'Your changes are not yet saved'
+        )
+        expect(response.body).to include(
+          course_2.course_length
+        )
+        expect(response.body).to include(
+          course_2.salary_details
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Copying course length and salary content

### Changes proposed in this pull request
Add "Copy from" select to enable users to copy content from another course within their org

### Guidance to review
Example - `/organisations/2AT/courses/3CXD/salary`