### PR TITLE
Remove blue border from sidebar

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -153,7 +153,7 @@
   </div>
   <% if course.is_running? || course.new_and_not_running? %>
     <div class="govuk-grid-column-one-third">
-      <div class="status-box">
+      <div class="related">
         <h2 class="govuk-heading-m">Changing your basic details</h2>
         <p>To make any changes to your basic details, or to <%= course.is_running? ? "withdraw" : "delete" %> this course, <%= bat_contact_mail_to "contact the Becoming a Teacher team", subject: "Edit #{course.name} (#{@provider_code}/#{course.course_code})" %>.</p>
       </div>

--- a/app/views/courses/_status_panel.html.erb
+++ b/app/views/courses/_status_panel.html.erb
@@ -1,4 +1,4 @@
-<div class="status-box">
+<div class="related">
   <h3 class="govuk-heading-m">Status</h3>
   <div class="govuk-!-margin-bottom-6" data-qa="course__content-status">
     <%= course.status_tag %>

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -22,7 +22,6 @@ $button-colour: #00823b;
 }
 
 .related {
-  border-top: 5px solid govuk-colour("blue");
   background-color: govuk-colour("grey-4");
   padding: govuk-spacing(4);
 
@@ -33,11 +32,6 @@ $button-colour: #00823b;
 
 .courses-locations-list li:last-child {
   margin-bottom: 0;
-}
-
-.status-box {
-  background-color: govuk-colour("grey-4");
-  padding: govuk-spacing(4);
 }
 
 .govuk-summary-list--short {


### PR DESCRIPTION
The top border clashed with the new tab styles. Brings the sidebar inline with prototype design.

![Screen Shot 2019-05-21 at 15 22 21](https://user-images.githubusercontent.com/319055/58104201-48729080-7bdc-11e9-94fd-2a5d761f4f20.png)
![Screen Shot 2019-05-21 at 15 22 16](https://user-images.githubusercontent.com/319055/58104202-48729080-7bdc-11e9-8e1f-4bbb36160b6d.png)
