### PR TITLE
[1571] 'New feature' page updates

### DIFF
--- a/app/views/pages/new_features.html.erb
+++ b/app/views/pages/new_features.html.erb
@@ -11,15 +11,15 @@
     <p class="govuk-body">You can now:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>edit course vacancies</li>
+      <li>add a new location</li>
       <li>edit a location name and address</li>
-      <li>request a new course or location using a Google Form</li>
+      <li>request a new course using a Google Form</li>
     </ul>
 
     <h2 class="govuk-heading-l">May to June 2019</h2>
     <p class="govuk-body">You’ll be able to:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>change locations assigned to a course</li>
-      <li>add a new location</li>
       <li>edit the UCAS Apply eligibility requirements for a course</li>
     </ul>
 

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'View pages', type: :feature do
+  let(:new_features_page) { PageObjects::Page::NewFeaturesPage.new }
+
   scenario "Navigate to /cookies" do
     stub_omniauth
 
@@ -25,8 +27,8 @@ RSpec.feature 'View pages', type: :feature do
   scenario "Navigate to /new-features" do
     stub_omniauth
 
-    visit "/new-features"
-    expect(find('h1')).to have_content('New features coming to Publish')
+    new_features_page.load
+    expect(new_features_page.title).to have_content('New features coming to Publish')
   end
 
   scenario "Navigate to /guidance" do

--- a/spec/site_prism/page_objects/page/new_features_page.rb
+++ b/spec/site_prism/page_objects/page/new_features_page.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module Page
+    class NewFeaturesPage < PageObjects::Base
+      set_url '/new-features'
+
+      element :title, 'h1'
+    end
+  end
+end


### PR DESCRIPTION
### Context
Follow-on to #281.

### Changes proposed in this pull request
- introduce a siteprism pageobject for the `/new-features` page
- update recently shipped feature
