### PR TITLE
[1483] Add course meta to preview page

### DIFF
--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -15,3 +15,32 @@
 </h1>
 
 <p class="govuk-body-l" data-qa='course__description'><%= course.description %></p>
+
+<dl class="govuk-list--description">
+  <dt class="govuk-list--description__label">Qualification</dt>
+  <dd data-qa="course__qualifications">
+    <%= render partial: 'courses/preview/qualification' %>
+  </dd>
+  <% if course.length.present? %>
+    <dt class="govuk-list--description__label">Course length</dt>
+    <dd data-qa="course__length"><%= course.length %></dd>
+  <% end %>
+  <% if course.applications_open_from.present? %>
+    <dt class="govuk-list--description__label">Date you can apply from</dt>
+    <dd data-qa="course__applications_open"><%= l(course.applications_open_from&.to_date) %></dd>
+  <% end %>
+  <% if course.applications_open_from.present? %>
+    <dt class="govuk-list--description__label">Date course starts</dt>
+    <dd data-qa="course__start_date"><%= l(course.start_date&.to_date, format: :short) %></dd>
+  <% end %>
+  <% if @provider.website.present? %>
+    <dt class="govuk-list--description__label">Website</dt>
+    <dd data-qa="course__provider_website">
+      <%= link_to @provider.website, @provider.website, class: 'govuk-link' %>
+    </dd>
+  <% end %>
+  <% unless course.has_vacancies? %>
+    <dt class="govuk-list--description__label">Vacancies</dt>
+    <dd data-qa="course__vacancies">No</dd>
+  <% end %>
+</dl>

--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{course.name_and_code} - Courses" %>
+<%= content_for :page_title, "Preview: #{course.name_and_code} with #{@provider.provider_name}" %>
 
 <% content_for :before_content do %>
   <%= link_to "Back to course", provider_course_path, class: "govuk-back-link" %>

--- a/app/views/courses/preview/_qualification.html.erb
+++ b/app/views/courses/preview/_qualification.html.erb
@@ -1,0 +1,12 @@
+<% case course.outcome %>
+<% when 'QTS' %>
+  <%= render partial: 'courses/preview/qualification/qts' %>
+<% when 'PGCE with QTS' %>
+  <%= render partial: 'courses/preview/qualification/pgce_with_qts' %>
+<% when 'PGDE with QTS' %>
+  <%= render partial: 'courses/preview/qualification/pgde_with_qts' %>
+<% when 'PGCE' %>
+  <%= render partial: 'courses/preview/qualification/pgce' %>
+<% when 'PGDE' %>
+  <%= render partial: 'courses/preview/qualification/pgde' %>
+<% end %>

--- a/app/views/courses/preview/qualification/_pgce.html.erb
+++ b/app/views/courses/preview/qualification/_pgce.html.erb
@@ -1,0 +1,11 @@
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">PGCE</span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      A postgraduate certificate in education (PGCE) is recognised internationally.
+      This course does not lead to the award of qualified teacher status (QTS).
+    </p>
+  </div>
+</details>

--- a/app/views/courses/preview/qualification/_pgce_with_qts.html.erb
+++ b/app/views/courses/preview/qualification/_pgce_with_qts.html.erb
@@ -1,0 +1,14 @@
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">PGCE with QTS</span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) allows you to
+      teach in England, Scotland, Wales and Northern Ireland. It&rsquo;s also recognised internationally.
+    </p>
+    <p class="govuk-body">
+      Many PGCE courses include credits that count toward a Master&rsquo;s degree.
+    </p>
+  </div>
+</details>

--- a/app/views/courses/preview/qualification/_pgde.html.erb
+++ b/app/views/courses/preview/qualification/_pgde.html.erb
@@ -1,0 +1,11 @@
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">PGDE</span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      A postgraduate diploma in education (PGDE) is recognised internationally.
+      This course does not lead to the award of qualified teacher status (QTS).
+    </p>
+  </div>
+</details>

--- a/app/views/courses/preview/qualification/_pgde_with_qts.html.erb
+++ b/app/views/courses/preview/qualification/_pgde_with_qts.html.erb
@@ -1,0 +1,12 @@
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">PGDE with QTS</span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) allows you to
+      teach in England, Scotland, Wales and Northern Ireland. It&rsquo;s also recognised internationally.
+      PGDE courses include credits that count toward a Master&rsquo;s degree.
+    </p>
+  </div>
+</details>

--- a/app/views/courses/preview/qualification/_qts.html.erb
+++ b/app/views/courses/preview/qualification/_qts.html.erb
@@ -1,0 +1,16 @@
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">QTS</span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      QTS (qualified teacher status) allows you to teach in state schools in England.
+    </p>
+    <p class="govuk-body">
+      It may also allow you to teach in <%= link_to "the EU, the EEA and Switzerland", "https://www.gov.uk/eu-eea", class: "govuk-link" %>. You should check with the institution you’d like to teach in for confirmation. The status of QTS in these countries may change after the UK leaves the EU. Please check <%= link_to 'GOV.UK', 'https://www.gov.uk', class: 'govuk-link' %> for updates.
+    </p>
+    <p class="govuk-body">
+      To teach in the rest of the UK or internationally, you may wish to consider a &lsquo;PGCE (or PGDE) with QTS&rsquo; qualification instead.
+    </p>
+  </div>
+</details>

--- a/app/webpacker/stylesheets/_definition-list.scss
+++ b/app/webpacker/stylesheets/_definition-list.scss
@@ -1,0 +1,53 @@
+%govuk-list--description {
+  @include govuk-clearfix;
+  margin-top: 0;
+}
+
+%govuk-list--description > dt {
+  @include govuk-font($size: 19, $weight: normal);
+  vertical-align: top;
+
+  @include mq ($from: desktop) {
+    clear: left;
+    float: left;
+    margin-bottom: govuk-spacing(1);
+    width: 30%;
+  }
+}
+
+%govuk-list--description > dd {
+  @include govuk-font($size: 19, $weight: normal);
+  margin: 0 0 govuk-spacing(2) 0;
+  vertical-align: top;
+
+  @include mq ($from: desktop) {
+    float: left;
+    margin-bottom: govuk-spacing(1);
+    width: 70%;
+  }
+
+  .govuk-details,
+  .govuk-details__summary {
+    margin-bottom: 0;
+  }
+
+  .govuk-details__text {
+    margin-bottom: govuk-spacing(2);
+  }
+}
+
+.govuk-list--description {
+  @extend %govuk-list--description;
+
+  &__label:after {
+    content: ":";
+    display: inline-block;
+  }
+
+  &__hint {
+    @include govuk-font($size: 16, $weight: normal);
+    color: $govuk-secondary-text-colour;
+    display: block;
+    margin-bottom: govuk-space(1);
+  }
+}

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -10,6 +10,7 @@ $button-colour: #00823b;
 @import "course-tabs";
 @import "currency-input";
 @import "warning-summary";
+@import "definition-list";
 
 .text-decoration-underline-dotted {
   text-decoration: underline dotted;

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     sequence(:id)
     sequence(:course_code) { |n| "X10#{n}" }
     name { "English" }
-    description { "PGCE with QTS" }
+    description { "PGCE with QTS full time" }
     findable? { true }
     open_for_applications? { false }
     has_vacancies? { false }
@@ -18,7 +18,7 @@ FactoryBot.define do
     content_status { "published" }
     ucas_status { 'running' }
     accrediting_provider { nil }
-    qualifications { %w[qts pcge] }
+    qualifications { %w[qts pgce] }
     start_date     { Time.new(2019) }
     funding        { 'fee' }
     applications_open_from { DateTime.new(2019).utc.iso8601 }

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     provider_name { "ACME SCITT #{provider_code}" }
     accredited_body? { false }
     can_add_more_sites? { true }
+    website { nil }
     courses { [] }
     sites { [] }
 

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -1,10 +1,18 @@
 require 'rails_helper'
 
 feature 'Preview course', type: :feature do
-  let(:course_jsonapi) { jsonapi(:course, name: 'English', provider: provider) }
-  let(:provider)       { jsonapi(:provider, provider_code: 'AO') }
-  let(:course)          { course_jsonapi.to_resource }
-  let(:course_response) { course_jsonapi.render }
+  let(:course_jsonapi) do
+    jsonapi(:course,
+            name: 'English',
+            provider: provider,
+            course_length: 'OneYear',
+            applications_open_from: '2019-01-01T00:00:00Z',
+            start_date: '2019-09-01T00:00:00Z')
+  end
+  let(:provider)         { jsonapi(:provider, provider_code: 'AO', website: 'https://scitt.org') }
+  let(:course)           { course_jsonapi.to_resource }
+  let(:course_response)  { course_jsonapi.render }
+  let(:decorated_course) { course.decorate }
 
   before do
     stub_omniauth
@@ -29,6 +37,30 @@ feature 'Preview course', type: :feature do
 
     expect(preview_course_page.description).to have_content(
       course.description
+    )
+
+    expect(preview_course_page.qualifications).to have_content(
+      'PGCE with QTS'
+    )
+
+    expect(preview_course_page.length).to have_content(
+      decorated_course.length
+    )
+
+    expect(preview_course_page.applications_open_from).to have_content(
+      '1 January 2019'
+    )
+
+    expect(preview_course_page.start_date).to have_content(
+      'September 2019'
+    )
+
+    expect(preview_course_page.provider_website).to have_content(
+      provider.website
+    )
+
+    expect(preview_course_page.vacancies).to have_content(
+      'No'
     )
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/course_preview.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_preview.rb
@@ -7,6 +7,12 @@ module PageObjects
         element :title, '.govuk-heading-xl'
         element :sub_title, '[data-qa=course__provider_name]'
         element :description, '[data-qa=course__description]'
+        element :qualifications, '[data-qa=course__qualifications]'
+        element :length, '[data-qa=course__length]'
+        element :applications_open_from, '[data-qa=course__applications_open]'
+        element :start_date, '[data-qa=course__start_date]'
+        element :provider_website, '[data-qa=course__provider_website]'
+        element :vacancies, '[data-qa=course__vacancies]'
       end
     end
   end


### PR DESCRIPTION
### Context
Course preview

### Changes proposed in this pull request
Add meta data to course preview

### Guidance to review
Example - `/organisations/2AT/courses/3CXD/preview`

# After
![localhost_3000_organisations_2AT_courses_3CXD_preview(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/58249109-e342aa80-7d55-11e9-8687-cf38a43b74cb.png)