### PR TITLE
1483 course preview about course

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,9 @@ gem 'sentry-raven'
 # Decorate logic to keep it of the views and helper methods
 gem 'draper'
 
+# Render nice markdown
+gem 'redcarpet'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,6 +290,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    redcarpet (3.4.0)
     regexp_parser (1.5.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -441,6 +442,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.12)
   rails (~> 5.2.3)
+  redcarpet
   rspec-rails (~> 3.8)
   rspec_junit_formatter
   rubocop
@@ -462,4 +464,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,7 @@
+module ApplicationHelper
+  def markdown(source)
+    render = Govuk::MarkdownRenderer
+    markdown = Redcarpet::Markdown.new(render)
+    markdown.render(source).html_safe
+  end
+end

--- a/app/lib/govuk/markdown_renderer.rb
+++ b/app/lib/govuk/markdown_renderer.rb
@@ -1,0 +1,64 @@
+module Govuk
+  class MarkdownRenderer < ::Redcarpet::Render::Safe
+    def block_html(raw_html)
+      # No user input HTML please
+    end
+
+    def raw_html(raw_html)
+      # No user input HTML please
+    end
+
+    def list(content, list_type)
+      case list_type
+      when :ordered
+        <<~HTML
+          <ol class="govuk-list govuk-list--number">
+            #{content}
+          </ol>
+        HTML
+      when :unordered
+        <<~HTML
+          <ul class="govuk-list govuk-list--bullet">
+            #{content}
+          </ul>
+        HTML
+      end
+    end
+
+    def link(link, title, content)
+      <<~HTML
+        <a href="#{link}" title="#{title}" class="govuk-link">
+          #{content}
+        </a>
+      HTML
+    end
+
+    def paragraph(text)
+      %(<p class="govuk-body">#{text}</p>)
+    end
+
+    def header(text, heading_level)
+      tag  = "h#{heading_level}"
+      size = case heading_level
+             when 1
+               'xl'
+             when 2
+               'l'
+             when 3
+               'm'
+             else
+               's'
+             end
+
+      <<~HTML
+        <#{tag} class="govuk-heading-#{size}">
+          #{text}
+        </#{tag}>
+      HTML
+    end
+
+    def self.render(content)
+      Redcarpet::Markdown.new(self).render(content)
+    end
+  end
+end

--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -16,7 +16,7 @@
 
 <p class="govuk-body-l" data-qa='course__description'><%= course.description %></p>
 
-<dl class="govuk-list--description">
+<dl class="govuk-list--description govuk-!-margin-bottom-8">
   <dt class="govuk-list--description__label">Qualification</dt>
   <dd data-qa="course__qualifications">
     <%= render partial: 'courses/preview/qualification' %>
@@ -44,3 +44,14 @@
     <dd data-qa="course__vacancies">No</dd>
   <% end %>
 </dl>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">Contents</h2>
+    <ul class="govuk-list govuk-list--dash course-contents govuk-!-margin-bottom-8">
+      <li><%= link_to 'About the course', '#section-about', class: 'govuk-link' %></li>
+    </ul>
+
+    <%= render partial: 'courses/preview/about_course' %>
+  </div>
+</div>

--- a/app/views/courses/preview/_about_course.html.erb
+++ b/app/views/courses/preview/_about_course.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-about">About the course</h2>
+  <% if course.about_course.present? %>
+    <%= course.about_course %>
+  <% else %>
+    <p class="missing-section">Please add details for this section.</p>
+  <% end %>
+</div>

--- a/app/views/courses/preview/_about_course.html.erb
+++ b/app/views/courses/preview/_about_course.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-about">About the course</h2>
   <% if course.about_course.present? %>
-    <%= course.about_course %>
+    <%= markdown(course.about_course) %>
   <% else %>
     <p class="missing-section">Please add details for this section.</p>
   <% end %>

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -72,3 +72,20 @@ $button-colour: #00823b;
   margin-top: govuk-spacing(2);
   padding: govuk-spacing(4);
 }
+
+.govuk-list--dash {
+  padding-left: govuk-spacing(3);
+  margin-bottom: govuk-spacing(8);
+
+  li {
+    position: relative;
+
+    &:before {
+      color: $govuk-border-colour;
+      content: '\00af';
+      left: -16px;
+      position: absolute;
+      top: 5px;
+    }
+  }
+}

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -62,5 +62,9 @@ feature 'Preview course', type: :feature do
     expect(preview_course_page.vacancies).to have_content(
       'No'
     )
+
+    expect(preview_course_page.about_course).to have_content(
+      course.about_course
+    )
   end
 end

--- a/spec/lib/govuk/markdown_renderer_spec.rb
+++ b/spec/lib/govuk/markdown_renderer_spec.rb
@@ -1,0 +1,180 @@
+require 'rails_helper'
+
+# Ignore whitespace
+def expect_equal_ignoring_ws(first, second)
+  expect(first.lines.map(&:strip).join('')).to eq(second.lines.map(&:strip).join(''))
+end
+
+describe Govuk::MarkdownRenderer do
+  let(:html) { Govuk::MarkdownRenderer.render(markdown) }
+
+  describe 'ul' do
+    let(:markdown) do
+      <<~MD
+        - item
+        - item
+        - item
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <ul class="govuk-list govuk-list--bullet">
+          <li>item</li>
+          <li>item</li>
+          <li>item</li>
+        </ul>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'ol' do
+    let(:markdown) do
+      <<~MD
+        1. item
+        1. item
+        1. item
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <ol class="govuk-list govuk-list--number">
+          <li>item</li>
+          <li>item</li>
+          <li>item</li>
+        </ol>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'link' do
+    let(:markdown) do
+      <<~MD
+        [link](https://href)
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <p class="govuk-body">
+          <a href="https://href" title="" class="govuk-link">link</a>
+        </p>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'script safe' do
+    let(:markdown) do
+      <<~MD
+        <script>alert(1);</script>
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expect(html).to eq('')
+    end
+  end
+
+  describe 'h1' do
+    let(:markdown) do
+      <<~MD
+        # heading level 1
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h1 class="govuk-heading-xl">heading level 1</h1>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'h2' do
+    let(:markdown) do
+      <<~MD
+        ## heading level 2
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h2 class="govuk-heading-l">heading level 2</h2>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'h3' do
+    let(:markdown) do
+      <<~MD
+        ### heading level 3
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h3 class="govuk-heading-m">heading level 3</h3>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'h4' do
+    let(:markdown) do
+      <<~MD
+        #### heading level 4
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h4 class="govuk-heading-s">heading level 4</h4>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'h5' do
+    let(:markdown) do
+      <<~MD
+        ##### heading level 5
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h5 class="govuk-heading-s">heading level 5</h5>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  context 'h6' do
+    let(:markdown) do
+      <<~MD
+        ###### heading level 6
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h6 class="govuk-heading-s">heading level 6</h6>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/course_preview.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_preview.rb
@@ -13,6 +13,7 @@ module PageObjects
         element :start_date, '[data-qa=course__start_date]'
         element :provider_website, '[data-qa=course__provider_website]'
         element :vacancies, '[data-qa=course__vacancies]'
+        element :about_course, '#section-about'
       end
     end
   end


### PR DESCRIPTION
### Context
Course preview

### Changes proposed in this pull request
- Setup course preview contents nav
- Add about course content
- Add markdown and a nice parser from [GDS RE team](https://github.com/alphagov/re-rotas/blob/master/app/lib/rotas/markdown_renderer.rb)

### Guidance to review
Example - `/organisations/2AT/courses/3CXF/preview`

# After
![localhost_3000_organisations_2AT_courses_3CXF_preview(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/58264716-39274a80-7d76-11e9-9788-0e9469759605.png)
