### PR TITLE
[XXXX] Fix incorrectly matched location form label

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -10,7 +10,7 @@ class Site < Base
     ['West Midlands', :west_midlands],
     ['East Midlands', :east_midlands],
     ['Eastern', :eastern],
-    ['Noth West', :north_west],
+    ['North West', :north_west],
     ['Yorkshire and the Humber', :yorkshire_and_the_humber],
     ['North East', :north_east],
     ['Scotland', :scotland],

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -26,7 +26,7 @@
 </div>
 
 <div class="govuk-form-group">
-  <%= f.label :address1, class: "govuk-label" do %>
+  <%= f.label :address2, class: "govuk-label" do %>
     <span class="govuk-visually-hidden">line 2 of 2</span>
   <% end %>
   <%= f.text_field :address2, class: "govuk-input govuk-!-width-full" %>


### PR DESCRIPTION
Label for address2 should match the field for address2.

Also fix a typo in the regions.

<h3>Other important notes</h3>

PR number 300 💯 💯 💯 