### PR TITLE
Add messaging around our location features

### DIFF
--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -25,6 +25,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @site, url: provider_site_path(params[:provider_code], @site.id), method: :put do |f| %>
+      <p class="govuk-body">To assign this location to a course contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses support" %></p>
+      <hr class="govuk-section-break govuk-section-break--l">
       <%= render 'form', f: f %>
       <%= f.submit "Save and publish changes", class: "govuk-button", data: { qa: 'location__publish-changes' } %>
     <% end %>

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -25,7 +25,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @site, url: provider_site_path(params[:provider_code], @site.id), method: :put do |f| %>
-      <p class="govuk-body">To assign this location to a course contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses support" %></p>
+      <p class="govuk-body">To assign this location to a course contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Assign a location (#{@site.code}) to a course (#{@provider.attributes[:provider_code]})" %></p>
       <hr class="govuk-section-break govuk-section-break--l">
       <%= render 'form', f: f %>
       <%= f.submit "Save and publish changes", class: "govuk-button", data: { qa: 'location__publish-changes' } %>

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -25,7 +25,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @site, url: provider_site_path(params[:provider_code], @site.id), method: :put do |f| %>
-      <p class="govuk-body">To assign this location to a course contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Assign a location (#{@site.code}) to a course (#{@provider.attributes[:provider_code]})" %></p>
+      <p class="govuk-body">To assign this location to a course contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Assign a location (#{@site.code}) to a course (#{@provider.provider_code})" %></p>
       <hr class="govuk-section-break govuk-section-break--l">
       <%= render 'form', f: f %>
       <%= f.submit "Save and publish changes", class: "govuk-button", data: { qa: 'location__publish-changes' } %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -19,15 +19,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">A location is a place that a candidate selects when making an application. They do this by choosing from a list on both the course page in Find and the UCAS application form.</p>
+
     <p class="govuk-body">Use this section to:</p>
-    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+    <ul class="govuk-list govuk-list--bullet">
       <li>edit location names and addresses</li>
       <li>add locations</li>
     </ul>
 
-    <div class="govuk-inset-text">
-      <p>By ‘location’ we mean the places that a candidate selects when making an application. They do this by choosing from a list on both the course page in Find and the UCAS application form.</p>
-    </div>
+    <p class="govuk-body">To assign locations to courses contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Assign locations to courses (#{@provider.attributes[:provider_code]})" %></p>
 
     <div class="govuk-warning-text">
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -27,7 +27,7 @@
       <li>add locations</li>
     </ul>
 
-    <p class="govuk-body">To assign locations to courses contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Assign locations to courses (#{@provider.attributes[:provider_code]})" %></p>
+    <p class="govuk-body">To assign locations to courses contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Assign locations to courses (#{@provider.provider_code})" %></p>
 
     <div class="govuk-warning-text">
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -26,7 +26,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @site, url: provider_sites_path(params[:provider_code]), method: :post do |f| %>
       <p class="govuk-body">Once a location is added (and assigned to a course), candidates can choose it as their preferred place of training when completing the UCAS application form.</p>
-      <p class="govuk-body">When you’ve added this location contact the Becoming a Teacher team to assign it to a course: <%= bat_contact_mail_to bat_contact_email_address, subject: "Assign a new location to a course (#{@provider.attributes[:provider_code]})" %></p>
+      <p class="govuk-body">When you’ve added this location contact the Becoming a Teacher team to assign it to a course: <%= bat_contact_mail_to bat_contact_email_address, subject: "Assign a new location to a course (#{@provider.provider_code})" %></p>
       <hr class="govuk-section-break govuk-section-break--l">
       <%= render 'form', f: f %>
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'location__publish-changes' } %>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -25,6 +25,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @site, url: provider_sites_path(params[:provider_code]), method: :post do |f| %>
+      <p class="govuk-body">Once a location is added (and assigned to a course), candidates can choose it as their preferred place of training when completing the UCAS application form.</p>
+      <p class="govuk-body">When you’ve added this location contact the Becoming a Teacher team to assign it to a course: <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses support" %></p>
+      <hr class="govuk-section-break govuk-section-break--l">
       <%= render 'form', f: f %>
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'location__publish-changes' } %>
     <% end %>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -26,7 +26,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @site, url: provider_sites_path(params[:provider_code]), method: :post do |f| %>
       <p class="govuk-body">Once a location is added (and assigned to a course), candidates can choose it as their preferred place of training when completing the UCAS application form.</p>
-      <p class="govuk-body">When you’ve added this location contact the Becoming a Teacher team to assign it to a course: <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses support" %></p>
+      <p class="govuk-body">When you’ve added this location contact the Becoming a Teacher team to assign it to a course: <%= bat_contact_mail_to bat_contact_email_address, subject: "Assign a new location to a course (#{@provider.attributes[:provider_code]})" %></p>
       <hr class="govuk-section-break govuk-section-break--l">
       <%= render 'form', f: f %>
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'location__publish-changes' } %>


### PR DESCRIPTION
### Context

Users need to contact us to assign locations to a course – we should tell them this in the places they might look for it.

This is especially true when adding a course.

### Changes proposed in this pull request

* Add links to support on edit, new and index pages for locations
* Improve context setting for locations on index and new

### Guidance to review

* Check the email subjects
