### PR TITLE
[1483] Add provider contact details to course preview

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -7,4 +7,8 @@ class Provider < Base
   def course_count
     relationships.courses[:meta][:count]
   end
+
+  def full_address
+    [address1, address2, address3, address4, postcode].select(&:present?).join("<br> ").html_safe
+  end
 end

--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -62,6 +62,7 @@
       <li><%= link_to 'About the training provider', '#section-about-provider', class: 'govuk-link' %></li>
       <li><%= link_to 'Training with disabilities and other needs', '#section-train-with-disabilities', class: 'govuk-link' %></li>
       <li><%= link_to 'Contact details', '#section-contact', class: 'govuk-link' %></li>
+      <li><%= link_to 'Support and advice', '#section-advice', class: 'govuk-link' %></li>
     </ul>
 
     <%= render partial: 'courses/preview/about_course' %>
@@ -85,5 +86,7 @@
     <%= render partial: 'courses/preview/train_with_disabilities' %>
 
     <%= render partial: 'courses/preview/contact_details' %>
+
+    <%= render partial: 'courses/preview/advice' %>
   </div>
 </div>

--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -61,6 +61,7 @@
       <li><%= link_to 'Requirements', '#section-entry', class: 'govuk-link' %></li>
       <li><%= link_to 'About the training provider', '#section-about-provider', class: 'govuk-link' %></li>
       <li><%= link_to 'Training with disabilities and other needs', '#section-train-with-disabilities', class: 'govuk-link' %></li>
+      <li><%= link_to 'Contact details', '#section-contact', class: 'govuk-link' %></li>
     </ul>
 
     <%= render partial: 'courses/preview/about_course' %>
@@ -82,5 +83,7 @@
     <%= render partial: 'courses/preview/about_the_provider' %>
 
     <%= render partial: 'courses/preview/train_with_disabilities' %>
+
+    <%= render partial: 'courses/preview/contact_details' %>
   </div>
 </div>

--- a/app/views/courses/preview/_advice.html.erb
+++ b/app/views/courses/preview/_advice.html.erb
@@ -1,0 +1,11 @@
+<h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
+<p class="govuk-body">For questions about this course you should contact the training provider using <%= link_to "the contact details above", "#contact_section", class: "govuk-link" %>.</p>
+
+<h4 class="govuk-heading-m">Get support and advice about teaching</h4>
+<p class="govuk-body">Register with <%= link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk/user/register', class: "govuk-link" %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events. You can also call them free on 0800 389 2500, or speak to an adviser using their <%= link_to "online chat service", "https://ta-chat.education.gov.uk/chat/chatstart.aspx?domain=www.education.gov.uk&department=GetIntoTeaching%27,%27new_win%27,%27width=0,height=0%27);return%20false;%22&SID=1", class: 'govuk-link' %>, from 8am to 8pm, Monday to Friday.</p>
+
+<h4 class="govuk-heading-m">Website support</h4>
+<p class="govuk-body">If you have feedback or have had a problem using Find postgraduate teacher training you can <%= bat_contact_mail_to "contact us by email" %>.</p>
+
+<h4 class="govuk-heading-m">Is there something wrong with this page?</h4>
+<p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to "contact the Becoming a Teacher team", subject: "Edit #{course.name} (#{@provider_code}/#{course.course_code})" %></p>

--- a/app/views/courses/preview/_contact_details.html.erb
+++ b/app/views/courses/preview/_contact_details.html.erb
@@ -1,0 +1,35 @@
+<div id="contact_section" class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-contact">Contact details</h2>
+
+  <div class="course-basicinfo">
+    <dl class="govuk-list--description">
+      <% if @provider.email.present? %>
+        <dt class="govuk-list--description__label">Email</dt>
+        <dd data-qa="provider__email">
+          <%= mail_to @provider.email, @provider.email, title: "Send email to course contact", aria: { label: "Send email to course contact" }, class: "govuk-link" %>
+        </dd>
+      <% end %>
+
+      <% if @provider.telephone.present? %>
+        <dt class="govuk-list--description__label">Telephone</dt>
+        <dd data-qa="provider__telephone">
+          <%= @provider.telephone %>
+        </dd>
+      <% end %>
+
+      <% if @provider.website.present? %>
+        <dt class="govuk-list--description__label">Website</dt>
+        <dd data-qa="provider__website">
+          <%= link_to @provider.website, @provider.website, class: "govuk-link" %>
+        </dd>
+      <% end %>
+
+      <% if @provider.full_address.present? %>
+        <dt class="govuk-list--description__label">Address</dt>
+        <dd data-qa="provider__address">
+          <%= @provider.full_address %>
+        </dd>
+      <% end %>
+    </dl>
+  </div>
+</div>

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -10,11 +10,18 @@ FactoryBot.define do
     provider_name { "ACME SCITT #{provider_code}" }
     accredited_body? { false }
     can_add_more_sites? { true }
-    website { nil }
     courses { [] }
     sites { [] }
     train_with_us { nil }
     train_with_disability { nil }
+    website { nil }
+    email { 'info@acme-scitt.org' }
+    telephone { '020 8123 4567' }
+    address1 { nil }
+    address2 { nil }
+    address3 { nil }
+    address4 { nil }
+    postcode { nil }
 
     initialize_with do |_evaluator|
       data_attributes = attributes.except(:id, *relationships)

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -16,7 +16,13 @@ feature 'Preview course', type: :feature do
             personal_qualities: 'We are looking for ambitious trainee teachers who are passionate and enthusiastic about their subject and have a desire to share that with young people of all abilities in this particular age range.',
             other_requirements: 'You will need three years of prior work experience, but not necessarily in an educational context.')
   end
-  let(:provider)         { jsonapi(:provider, provider_code: 'AO', website: 'https://scitt.org') }
+  let(:provider) {
+    jsonapi(:provider,
+            provider_code: 'AO',
+              website: 'https://scitt.org',
+              address1: '1 Long Rd',
+              postcode: 'E1 ABC')
+  }
   let(:course)           { course_jsonapi.to_resource }
   let(:course_response)  { course_jsonapi.render }
   let(:decorated_course) { course.decorate }
@@ -122,6 +128,22 @@ feature 'Preview course', type: :feature do
 
     expect(preview_course_page.train_with_disability).to have_content(
       provider.train_with_disability
+    )
+
+    expect(preview_course_page.contact_email).to have_content(
+      provider.email
+    )
+
+    expect(preview_course_page.contact_telephone).to have_content(
+      provider.telephone
+    )
+
+    expect(preview_course_page.contact_website).to have_content(
+      provider.website
+    )
+
+    expect(preview_course_page.contact_address).to have_content(
+      '1 Long Rd E1 ABC'
     )
   end
 end

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -145,5 +145,7 @@ feature 'Preview course', type: :feature do
     expect(preview_course_page.contact_address).to have_content(
       '1 Long Rd E1 ABC'
     )
+
+    expect(preview_course_page).to have_course_advice
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/course_preview.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_preview.rb
@@ -31,6 +31,7 @@ module PageObjects
         element :contact_telephone, '[data-qa=provider__telephone]'
         element :contact_website, '[data-qa=provider__website]'
         element :contact_address, '[data-qa=provider__address]'
+        element :course_advice, '#section-advice'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_preview.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_preview.rb
@@ -27,6 +27,10 @@ module PageObjects
         element :other_requirements, '[data-qa=course__other_requirements]'
         element :train_with_us, '#section-about-provider'
         element :train_with_disability, '#section-train-with-disabilities'
+        element :contact_email, '[data-qa=provider__email]'
+        element :contact_telephone, '[data-qa=provider__telephone]'
+        element :contact_website, '[data-qa=provider__website]'
+        element :contact_address, '[data-qa=provider__address]'
       end
     end
   end


### PR DESCRIPTION
### Context
Course preview

### Changes proposed in this pull request
Add provider contact details to course preview

### Guidance to review
# After
![localhost_3000_organisations_2AT_courses_3CXD_preview(Laptop with MDPI screen) (2)](https://user-images.githubusercontent.com/3071606/58496789-7a529c80-8172-11e9-8da6-92ea39e0749e.png)
