### PR TITLE
[1511] Allow users to see locations attached to a course

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,5 +8,7 @@ AllCops:
     - 'bin/setup'
     - 'bin/update'
     - 'bin/yarn'
+    - 'bin/webpack'
+    - 'bin/webpack-dev-server'
     - 'db/schema.rb'
     - 'node_modules/**/*'

--- a/app/controllers/courses/sites_controller.rb
+++ b/app/controllers/courses/sites_controller.rb
@@ -1,0 +1,27 @@
+module Courses
+  class SitesController < ApplicationController
+    decorates_assigned :course
+    before_action(
+      :build_course,
+      :build_provider
+    )
+
+    def edit; end
+
+  private
+
+    def build_course
+      @provider_code = params[:provider_code]
+      @course = Course
+        .includes(site_statuses: [:site])
+        .includes(provider: [:sites])
+        .where(provider_code: @provider_code)
+        .find(params[:code])
+        .first
+    end
+
+    def build_provider
+      @provider = @course.provider
+    end
+  end
+end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -82,6 +82,10 @@ class CourseDecorator < ApplicationDecorator
     object.site_statuses.sort_by { |ss| ss.site.location_name }
   end
 
+  def has_site?(site)
+    object.site_statuses.map(&:site).include?(site)
+  end
+
 private
 
   def status_tag_content

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -1,0 +1,41 @@
+<%= content_for :page_title, "Locations - #{course.name_and_code}" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
+<% end %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+  Locations
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for course, url: publish_provider_course_path(course.provider.provider_code, course.course_code), method: :post do |f| %>
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes">
+          <%= f.fields_for :site_statuses, @provider.sites do |sf| %>
+            <% site = sf.object %>
+            <div class="govuk-checkboxes__item">
+              <%= sf.check_box site.id, checked: course.has_site?(site), class: 'govuk-checkboxes__input' %>
+              <%= sf.label site.id, class: 'govuk-label govuk-checkboxes__label'  do %>
+                <strong><%= site.location_name %></strong>
+              <% end %>
+              <span class="govuk-hint govuk-checkboxes__hint">
+                <%= site.full_address %>
+              </span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <%= f.submit course.is_published? ? "Save and publish changes" : "Save",
+        class: "govuk-button", data: { qa: 'course__save' }
+      %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes', provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -28,14 +28,16 @@
           <% end %>
         </div>
       </div>
-
-      <%= f.submit course.is_published? ? "Save and publish changes" : "Save",
-        class: "govuk-button", data: { qa: 'course__save' }
-      %>
-
-      <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
-      </p>
     <% end %>
+
+    <%= link_to provider_course_path(course.provider.provider_code, course.course_code) do %>
+      <button class="govuk-button" data-qa="course__save">
+        <%= course.is_published? ? "Save and publish changes" : "Save" %>
+      </button>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= link_to 'Cancel changes', provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+    </p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
       get '/withdraw', on: :member, to: 'courses#withdraw'
       get '/delete', on: :member, to: 'courses#delete'
       get '/preview', on: :member, to: 'courses#preview'
+      get '/locations', on: :member, to: 'courses/sites#edit'
       post '/publish', on: :member, to: 'courses#publish'
     end
 

--- a/spec/features/courses/sites/edit_spec.rb
+++ b/spec/features/courses/sites/edit_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+feature 'Edit course sites', type: :feature do
+  let(:course) do
+    jsonapi(
+      :course,
+      site_statuses: [jsonapi(:site_status, site: site1)],
+      provider: provider
+      )
+  end
+  let(:site1) { jsonapi(:site) }
+  let(:site2) { jsonapi(:site) }
+  let(:provider) do
+    jsonapi(
+      :provider,
+      sites: [site1, site2]
+    )
+  end
+  let(:edit_locations_path) do
+    "/organisations/#{provider.provider_code}/courses/#{course.course_code}/locations"
+  end
+
+  before do
+    stub_omniauth
+    stub_api_v2_request(
+      "/providers/#{provider.provider_code}/courses/#{course.course_code}?include=site_statuses.site,provider.sites",
+      course.render
+    )
+
+    visit edit_locations_path
+  end
+
+  scenario 'viewing the edit locations page' do
+    expect(page).to have_link('Back', href: provider_course_path(provider.provider_code, course.course_code))
+    expect(page).to have_link('Cancel changes', href: provider_course_path(provider.provider_code, course.course_code))
+    expect(find('h1')).to have_content('Locations')
+    expect(find('.govuk-caption-xl')).to have_content(
+      "#{course.name} (#{course.course_code})"
+    )
+
+    expect(page).to have_checked_field("course[site_statuses_attributes][0][#{site1.id}]")
+    expect(page).to_not have_checked_field("course[site_statuses_attributes][0][#{site2.id}]")
+  end
+end


### PR DESCRIPTION
### Context

Prerequisite to adding the ability for users to edit locations attached to a course.

### Changes proposed in this pull request

Adds the template, action, and route.

### Guidance to review

TODO:

- [x] Populate `checked` correctly
- [x] Disable the save button (not required in this ticket)
- [x] Tests

<img width="584" alt="Screenshot 2019-05-30 at 13 06 39" src="https://user-images.githubusercontent.com/1650875/58631877-cc630180-82db-11e9-9ad2-1a0950531939.png">
