### PR TITLE
[1438] Add about accrediting body to course preview

### DIFF
--- a/app/views/courses/preview/_about_the_provider.html.erb
+++ b/app/views/courses/preview/_about_the_provider.html.erb
@@ -5,4 +5,11 @@
   <% else %>
     <p class="missing-section">Please add details <%= link_to 'about your organisation', manage_ui_url("/organisation/#{@provider.provider_code}/about") %>.</p>
   <% end %>
+
+  <% if course.about_accrediting_body.present? %>
+    <div data-qa="course__about_accrediting_body">
+      <h3 class="govuk-heading-m">About the accredited body</h3>
+      <%= markdown(course.about_accrediting_body) %>
+    </div>
+  <% end %>
 </div>

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -67,7 +67,9 @@ $button-colour: #00823b;
   padding-top: govuk-spacing(1);
 }
 
-.preview-banner {
+.preview-banner,
+.missing-section {
+  @extend %govuk-body-m;
   background: govuk-colour("grey-4");
   margin-top: govuk-spacing(2);
   padding: govuk-spacing(4);

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -43,6 +43,7 @@ FactoryBot.define do
     has_early_career_payments? { nil }
     scholarship_amount { 20000 }
     bursary_amount { 22000 }
+    about_accrediting_body { nil }
 
     trait :with_vacancy do
       has_vacancies? { true }

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -16,6 +16,7 @@ feature 'Preview course', type: :feature do
             bursary_amount: '22000',
             personal_qualities: 'We are looking for ambitious trainee teachers who are passionate and enthusiastic about their subject and have a desire to share that with young people of all abilities in this particular age range.',
             other_requirements: 'You will need three years of prior work experience, but not necessarily in an educational context.',
+            about_accrediting_body: 'Something great about the accredited body',
             has_vacancies?: true,
             site_statuses: [site_status])
   end
@@ -134,6 +135,10 @@ feature 'Preview course', type: :feature do
 
     expect(preview_course_page.train_with_us).to have_content(
       provider.train_with_us
+    )
+
+    expect(preview_course_page.about_accrediting_body).to have_content(
+      course.about_accrediting_body
     )
 
     expect(preview_course_page.train_with_disability).to have_content(

--- a/spec/site_prism/page_objects/page/organisations/course_preview.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_preview.rb
@@ -27,6 +27,7 @@ module PageObjects
         element :personal_qualities, '[data-qa=course__personal_qualities]'
         element :other_requirements, '[data-qa=course__other_requirements]'
         element :train_with_us, '#section-about-provider'
+        element :about_accrediting_body, '[data-qa=course__about_accrediting_body]'
         element :train_with_disability, '#section-train-with-disabilities'
         element :contact_email, '[data-qa=provider__email]'
         element :contact_telephone, '[data-qa=provider__telephone]'


### PR DESCRIPTION
### Context
Frontend work to https://github.com/DFE-Digital/manage-courses-backend/pull/425 which needs to be merged before this

### Changes proposed in this pull request
Add `about accrediting body` to course preview

### Guidance to review
Any course preview page with an accrediting body