### PR TITLE
[1505] Refactor copy content warning

### DIFF
--- a/app/views/courses/_copy_content_warning.html.erb
+++ b/app/views/courses/_copy_content_warning.html.erb
@@ -7,24 +7,8 @@
       We’ve copied these fields from <%= @source_course.name %> (<%= @source_course.course_code %>):
     </p>
     <ul class="govuk-list">
-      <% case content %>
-      <% when 'course_about' %>
-        <li><%= link_to 'About the course', '#about_course_wrapper', class: 'govuk-link' %></li>
-        <li><%= link_to 'Interview process', '#interview_process_wrapper', class: 'govuk-link' %></li>
-        <li><%= link_to 'How school placements work', '#how_school_placements_work_wrapper', class: 'govuk-link' %></li>
-      <% when 'course_requirements' %>
-        <li><%= link_to 'Qualifications needed', '#required_qualifications_wrapper', class: 'govuk-link' %></li>
-        <li><%= link_to 'Personal qualities', '#personal_qualities_wrapper', class: 'govuk-link' %></li>
-        <li><%= link_to 'Other requirements', '#other_requirements_wrapper', class: 'govuk-link' %></li>
-      <% when 'course_fees' %>
-        <li><%= link_to 'Course length', '#course_length_wrapper', class: 'govuk-link' %></li>
-        <li><%= link_to 'Fee for UK and EU students', '#fee_uk_eu_wrapper', class: 'govuk-link' %></li>
-        <li><%= link_to 'Fee for international students', '#fee_international_wrapper', class: 'govuk-link' %></li>
-        <li><%= link_to 'Fee details', '#fee_details_wrapper', class: 'govuk-link' %></li>
-        <li><%= link_to 'Financial support', '#financial_support_wrapper', class: 'govuk-link' %></li>
-      <% when 'course_salary' %>
-        <li><%= link_to 'Course length', '#course_length_wrapper', class: 'govuk-link' %></li>
-        <li><%= link_to 'Salary details', '#salary_details_wrapper', class: 'govuk-link' %></li>
+      <% copied_fields.each do |field| %>
+        <li><%= link_to field[0], field[1], class: 'govuk-link' %></li>
       <% end %>
     </ul>
     <p class="govuk-body">

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -4,7 +4,13 @@
   <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
 <% end %>
 
-<%= render partial: 'courses/copy_content_warning', locals: { content: 'course_about' } if params[:copy_from].present? %>
+<%= render partial: 'courses/copy_content_warning',
+                    locals: {
+                      copied_fields: [
+                        ['About the course', '#about_course_wrapper'],
+                        ['Interview process', '#interview_process_wrapper'],
+                        ['How school placements work', '#how_school_placements_work_wrapper']
+                      ]} if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -4,7 +4,15 @@
   <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
 <% end %>
 
-<%= render partial: 'courses/copy_content_warning', locals: { content: 'course_fees' } if params[:copy_from].present? %>
+<%= render partial: 'courses/copy_content_warning',
+                    locals: {
+                      copied_fields: [
+                        ['Course length', '#course_length_wrapper'],
+                        ['Fee for UK and EU students', '#fee_uk_eu_wrapper'],
+                        ['Fee for international students', '#fee_international_wrapper'],
+                        ['Fee details', '#fee_details_wrapper'],
+                        ['Financial support', '#financial_support_wrapper']
+                      ]} if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -4,7 +4,13 @@
   <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
 <% end %>
 
-<%= render partial: 'courses/copy_content_warning', locals: { content: 'course_requirements' } if params[:copy_from].present? %>
+<%= render partial: 'courses/copy_content_warning',
+                    locals: {
+                      copied_fields: [
+                        ['Qualifications needed', '#required_qualifications_wrapper'],
+                        ['Personal qualities', '#personal_qualities_wrapper'],
+                        ['Other requirements', '#other_requirements_wrapper']
+                      ]} if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -4,7 +4,12 @@
   <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
 <% end %>
 
-<%= render partial: 'courses/copy_content_warning', locals: { content: 'course_salary' } if params[:copy_from].present? %>
+<%= render partial: 'courses/copy_content_warning',
+                    locals: {
+                      copied_fields: [
+                        ['Course length', '#course_length_wrapper'],
+                        ['Salary details', '#salary_details_wrapper']
+                      ]} if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>


### PR DESCRIPTION
Move copied fields out of partial and into parent calling the partial to better split the responsibility between the templates.

_copy_content_warning.html.erb now doesn't have logic that's specific to the about/fees/req's/salary forms.