### PR TITLE
[1577] Fix error on enrichment pages when there are no self accredited courses

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -124,7 +124,7 @@ private
 
   def filter_courses
     @courses_by_accrediting_provider = @courses_by_accrediting_provider.reject { |c| c == course.id }
-    @self_accredited_courses = @self_accredited_courses.reject { |c| c.id == course.id }
+    @self_accredited_courses = @self_accredited_courses&.reject { |c| c.id == course.id }
   end
 
   def build_copy_course

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -46,4 +46,20 @@ feature 'About course', type: :feature do
       course.how_school_placements_work
     )
   end
+
+  context 'when a provider has no self accredited courses (for example a School Direct provider)' do
+    let(:course_1) { jsonapi :course, provider: provider, name: 'Computing', accrediting_provider: accredited_body }
+    let(:course_2) { jsonapi :course, name: 'Drama', accrediting_provider: accredited_body }
+    let(:courses)  { [course_2] }
+    let(:accredited_body) { jsonapi(:provider, accredited_body?: true, provider_code: 'A1') }
+    let(:provider) { jsonapi(:provider, courses: courses, accredited_body?: false, provider_code: 'AO') }
+
+    scenario 'viewing the about courses page' do
+      visit about_provider_course_path('AO', course.course_code)
+
+      expect(about_course_page.caption).to have_content(
+        "#{course.name} (#{course.course_code})"
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Context

We were seeing an error when accessing the enrichment pages for a course offered by a school direct provider (ie one with no self-accredited courses):

* /requirements
* /about
* /salary
* /fees

```
undefined method `reject' for nil:NilClass
```

Example path:
`/organisations/1XO/courses/2FPL/salary`

### Changes

- Added a failing test
- Fixed with a safe navigation operator