### PR TITLE
[1578] Fix copy content summary message

### DIFF
--- a/app/views/courses/_copy_content_warning.html.erb
+++ b/app/views/courses/_copy_content_warning.html.erb
@@ -1,18 +1,20 @@
-<div class="govuk-warning-summary" aria-labelledby="warning-summary-heading" tabindex="-1" data-module="error-summary" data-copy-course="warning" role="alert">
-  <h2 class="govuk-heading govuk-warning-summary__title" id="warning-summary-heading">
-    Your changes are not yet saved
-  </h2>
-  <div class="govuk-warning-summary__body">
-    <p class="govuk-body">
-      We’ve copied these fields from <%= @source_course.name %> (<%= @source_course.course_code %>):
-    </p>
-    <ul class="govuk-list">
-      <% copied_fields.each do |field| %>
-        <li><%= link_to field[0], field[1], class: 'govuk-link' %></li>
-      <% end %>
-    </ul>
-    <p class="govuk-body">
-      Please check them and make your changes before saving.
-    </p>
+<% if copied_fields.any? { |_, attr| @source_course.__send__(attr).present? } %>
+  <div class="govuk-warning-summary" aria-labelledby="warning-summary-heading" tabindex="-1" data-module="error-summary" data-copy-course="warning" role="alert">
+    <h2 class="govuk-heading govuk-warning-summary__title" id="warning-summary-heading">
+      Your changes are not yet saved
+    </h2>
+    <div class="govuk-warning-summary__body">
+      <p class="govuk-body">
+        We’ve copied these fields from <%= @source_course.name %> (<%= @source_course.course_code %>):
+      </p>
+      <ul class="govuk-list">
+        <% copied_fields.select{ |_, attr| @source_course.__send__(attr).present? }.each do |field| %>
+          <li><%= link_to field[0], "##{field[1]}_wrapper", class: 'govuk-link' %></li>
+        <% end %>
+      </ul>
+      <p class="govuk-body">
+        Please check them and make your changes before saving.
+      </p>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -7,9 +7,9 @@
 <%= render partial: 'courses/copy_content_warning',
                     locals: {
                       copied_fields: [
-                        ['About the course', '#about_course_wrapper'],
-                        ['Interview process', '#interview_process_wrapper'],
-                        ['How school placements work', '#how_school_placements_work_wrapper']
+                        ['About the course', 'about_course'],
+                        ['Interview process', 'interview_process'],
+                        ['How school placements work', 'how_school_placements_work']
                       ]} if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -7,11 +7,11 @@
 <%= render partial: 'courses/copy_content_warning',
                     locals: {
                       copied_fields: [
-                        ['Course length', '#course_length_wrapper'],
-                        ['Fee for UK and EU students', '#fee_uk_eu_wrapper'],
-                        ['Fee for international students', '#fee_international_wrapper'],
-                        ['Fee details', '#fee_details_wrapper'],
-                        ['Financial support', '#financial_support_wrapper']
+                        ['Course length', 'course_length'],
+                        ['Fee for UK and EU students', 'fee_uk_eu'],
+                        ['Fee for international students', 'fee_international'],
+                        ['Fee details', 'fee_details'],
+                        ['Financial support', 'financial_support']
                       ]} if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -7,9 +7,9 @@
 <%= render partial: 'courses/copy_content_warning',
                     locals: {
                       copied_fields: [
-                        ['Qualifications needed', '#required_qualifications_wrapper'],
-                        ['Personal qualities', '#personal_qualities_wrapper'],
-                        ['Other requirements', '#other_requirements_wrapper']
+                        ['Qualifications needed', 'required_qualifications'],
+                        ['Personal qualities', 'personal_qualities'],
+                        ['Other requirements', 'other_requirements']
                       ]} if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -7,8 +7,8 @@
 <%= render partial: 'courses/copy_content_warning',
                     locals: {
                       copied_fields: [
-                        ['Course length', '#course_length_wrapper'],
-                        ['Salary details', '#salary_details_wrapper']
+                        ['Course length', 'course_length'],
+                        ['Salary details', 'salary_details']
                       ]} if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">


### PR DESCRIPTION
### Context
Follow up to https://github.com/DFE-Digital/manage-courses-frontend/pull/332

### Changes proposed in this pull request
- Send "course name" and "course code" into copy warning summary partial
- Only render the summary box when there is actually content being copied
- Only render deep links for content that's been copied

### Guidance to review
Example - `https://localhost:3000/organisations/2AT/courses/35L7/about?utf8=%E2%9C%93&copy_from=35L6` Message in the summary box should have course code `35L6`
