### PR TITLE
[1513] Don't .to_i selected_site_ids in course locations update

### DIFF
--- a/app/controllers/courses/sites_controller.rb
+++ b/app/controllers/courses/sites_controller.rb
@@ -13,7 +13,7 @@ module Courses
       selected_site_ids = params.dig(:course, :site_statuses_attributes)
         .values
         .select { |f| f["selected"] == "1" }
-        .map { |f| f["id"].to_i }
+        .map { |f| f["id"] }
 
       @course.sites = @provider.sites.select { |site| selected_site_ids.include?(site.id) }
 

--- a/spec/features/courses/sites/edit_spec.rb
+++ b/spec/features/courses/sites/edit_spec.rb
@@ -55,7 +55,21 @@ feature 'Edit course sites', type: :feature do
       stub_api_v2_request(
         "/providers/#{provider.provider_code}/courses/#{course.course_code}",
         {}, :patch, 200
-      )
+      ).with(body: {
+        data: {
+          course_code: course.course_code,
+          type: "courses",
+          relationships: {
+            sites: {
+              data: [
+                { type: "sites", id: site1.id.to_s },
+                { type: "sites", id: site2.id.to_s }
+              ]
+            },
+          },
+          attributes: {}
+        }
+      }.to_json)
       stub_api_v2_request(
         "/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
         course.render
@@ -80,10 +94,23 @@ feature 'Edit course sites', type: :feature do
       stub_api_v2_request(
         "/providers/#{provider.provider_code}/courses/#{course.course_code}",
         build(:error), :patch, 422
-      )
+      ).with(body: {
+        data: {
+          course_code: course.course_code,
+          type: "courses",
+          relationships: {
+            sites: {
+              data: []
+            },
+          },
+          attributes: {}
+        }
+      }.to_json)
     end
 
     scenario 'displays validation errors' do
+      uncheck(site1.location_name, allow_label_click: true)
+
       locations_page.save.click
 
       expect(locations_page).to be_displayed(provider_code: provider.provider_code, course_code: course.course_code)


### PR DESCRIPTION
### Context

Updating locations on courses is on dev but broken.

### Changes proposed in this pull request

I switched from using `.to_i` in both places to only doing it on the `selected_site_ids` in a previous refactor, and did not notice it broke functionality. This adds more tests to make sure we send the right payload to the API.