### PR TITLE
Add rspec results export

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,9 @@ steps:
     containerCommand: rails webpacker:compile
     runInBackground: false
 
-- bash: docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter'
+- bash: |
+    docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter' | tee rspec-results.xml
+    sed -i '$d;1,5d' rspec-results.xml
   displayName: 'Run tests'
 
 - task: Docker@1


### PR DESCRIPTION
### Context

Since https://github.com/DFE-Digital/manage-courses-frontend/pull/336 the RSpec results xml is not generated therefore the results can't be published to Azure DevOps

### Changes proposed in this pull request

Include export of results xml and format for import using PublishTestResults task
Tidy up formatting so it's a valid JUnit XML file

### Guidance to review
