### PR TITLE
Fix titles on About this course and Requirements course enrichment pages

### DIFF
--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{course.name_and_code} - Courses" %>
+<%= content_for :page_title, "About this course – #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{course.name_and_code} - Courses" %>
+<%= content_for :page_title, "Requirements and eligibility – #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>


### PR DESCRIPTION
Update page titles so they are specific. Follow the same format as the titles on fees and salary pages.