### PR TITLE
[1580] Display validation errors when editing course locations

### DIFF
--- a/app/controllers/courses/sites_controller.rb
+++ b/app/controllers/courses/sites_controller.rb
@@ -22,8 +22,7 @@ module Courses
 
         redirect_to provider_course_path(params[:provider_code], params[:code]), flash: { success: 'Course locations saved' }
       else
-        # TODO: Change this to be @course.errors when the API is updated.
-        flash[:error] = "You must choose at least one location"
+        @errors = @course.errors.full_messages
 
         render :edit
       end

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -4,6 +4,24 @@
   <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>
 <% end %>
 
+<% if @errors.present? %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      <%= @errors.first %>
+    </h2>
+    <div class="govuk-error-summary__body">
+      <p class="govuk-body">
+        Removing all locations would prevent people from applying to this course.
+        If you want to close applications, you can
+        <%= link_to "edit the vacancies for this course",
+          vacancies_provider_course_path(code: course.course_code),
+          class: "govuk-link"
+        %>.
+      </p>
+    </div>
+  </div>
+<% end %>
+
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>
   Locations

--- a/spec/features/courses/sites/edit_spec.rb
+++ b/spec/features/courses/sites/edit_spec.rb
@@ -114,7 +114,7 @@ feature 'Edit course sites', type: :feature do
       locations_page.save.click
 
       expect(locations_page).to be_displayed(provider_code: provider.provider_code, course_code: course.course_code)
-      expect(locations_page.error_summary).to have_content('You must choose at least one location')
+      expect(locations_page.error_summary).to have_content('Removing all locations would prevent people from applying to this course')
     end
   end
 end


### PR DESCRIPTION
### Context

This will allow us to display an appropriate error message on the frontend when the user submits an empty array of sites.

### After

<img width="1025" alt="Screenshot 2019-06-06 at 17 14 00" src="https://user-images.githubusercontent.com/1650875/59048906-c1c9de80-887e-11e9-95c7-2c1038f63828.png">
