### PR TITLE
[1584] When copying course fields, don't blank a field if the source was blank

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -20,34 +20,42 @@ class CoursesController < ApplicationController
 
   def about
     if params[:copy_from].present?
-      course.about_course = @source_course.about_course
-      course.interview_process = @source_course.interview_process
-      course.how_school_placements_work = @source_course.how_school_placements_work
+      @copied_fields = [
+        ['About the course', 'about_course'],
+        ['Interview process', 'interview_process'],
+        ['How school placements work', 'how_school_placements_work']
+      ].keep_if { |_name, field| copy_field_if_present_in_source_course(field) }
     end
   end
 
   def requirements
     if params[:copy_from].present?
-      course.required_qualifications = @source_course.required_qualifications
-      course.personal_qualities = @source_course.personal_qualities
-      course.other_requirements = @source_course.other_requirements
+      @copied_fields = [
+        ['Qualifications needed', 'required_qualifications'],
+        ['Personal qualities', 'personal_qualities'],
+        ['Other requirements', 'other_requirements']
+      ].keep_if { |_name, field| copy_field_if_present_in_source_course(field) }
     end
   end
 
   def fees
     if params[:copy_from].present?
-      course.course_length = @source_course.course_length
-      course.fee_uk_eu = @source_course.fee_uk_eu
-      course.fee_international = @source_course.fee_international
-      course.fee_details = @source_course.fee_details
-      course.financial_support = @source_course.financial_support
+      @copied_fields = [
+        ['Course length', 'course_length'],
+        ['Fee for UK and EU students', 'fee_uk_eu'],
+        ['Fee for international students', 'fee_international'],
+        ['Fee details', 'fee_details'],
+        ['Financial support', 'financial_support']
+      ].keep_if { |_name, field| copy_field_if_present_in_source_course(field) }
     end
   end
 
   def salary
     if params[:copy_from].present?
-      course.course_length = @source_course.course_length
-      course.salary_details = @source_course.salary_details
+      @copied_fields = [
+        ['Course length', 'course_length'],
+        ['Salary details', 'salary_details']
+      ].keep_if { |_name, field| copy_field_if_present_in_source_course(field) }
     end
   end
 
@@ -134,5 +142,10 @@ private
                            .where(provider_code: @provider_code)
                            .find(params[:copy_from])
                            .first
+  end
+
+  def copy_field_if_present_in_source_course(field)
+    source_value = @source_course[field]
+    course[field] = source_value if source_value.present?
   end
 end

--- a/app/views/courses/_copy_content_warning.html.erb
+++ b/app/views/courses/_copy_content_warning.html.erb
@@ -1,4 +1,4 @@
-<% if copied_fields.any? { |_, attr| @source_course.__send__(attr).present? } %>
+<% if copied_fields.any? %>
   <div class="govuk-warning-summary" aria-labelledby="warning-summary-heading" tabindex="-1" data-module="error-summary" data-copy-course="warning" role="alert">
     <h2 class="govuk-heading govuk-warning-summary__title" id="warning-summary-heading">
       Your changes are not yet saved
@@ -8,8 +8,8 @@
         We’ve copied these fields from <%= @source_course.name %> (<%= @source_course.course_code %>):
       </p>
       <ul class="govuk-list">
-        <% copied_fields.select{ |_, attr| @source_course.__send__(attr).present? }.each do |field| %>
-          <li><%= link_to field[0], "##{field[1]}_wrapper", class: 'govuk-link' %></li>
+        <% copied_fields.each do |name, field| %>
+          <li><%= link_to name, "##{field}_wrapper", class: 'govuk-link' %></li>
         <% end %>
       </ul>
       <p class="govuk-body">

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -5,12 +5,7 @@
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',
-                    locals: {
-                      copied_fields: [
-                        ['About the course', 'about_course'],
-                        ['Interview process', 'interview_process'],
-                        ['How school placements work', 'how_school_placements_work']
-                      ]} if params[:copy_from].present? %>
+                    locals: { copied_fields: @copied_fields } if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -5,14 +5,7 @@
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',
-                    locals: {
-                      copied_fields: [
-                        ['Course length', 'course_length'],
-                        ['Fee for UK and EU students', 'fee_uk_eu'],
-                        ['Fee for international students', 'fee_international'],
-                        ['Fee details', 'fee_details'],
-                        ['Financial support', 'financial_support']
-                      ]} if params[:copy_from].present? %>
+                    locals: { copied_fields: @copied_fields } if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -5,12 +5,7 @@
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',
-                    locals: {
-                      copied_fields: [
-                        ['Qualifications needed', 'required_qualifications'],
-                        ['Personal qualities', 'personal_qualities'],
-                        ['Other requirements', 'other_requirements']
-                      ]} if params[:copy_from].present? %>
+                    locals: { copied_fields: @copied_fields } if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -5,11 +5,7 @@
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',
-                    locals: {
-                      copied_fields: [
-                        ['Course length', 'course_length'],
-                        ['Salary details', 'salary_details']
-                      ]} if params[:copy_from].present? %>
+                    locals: { copied_fields: @copied_fields } if params[:copy_from].present? %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>

--- a/spec/requests/courses/about_spec.rb
+++ b/spec/requests/courses/about_spec.rb
@@ -53,7 +53,7 @@ describe 'Courses', type: :request do
       )
     end
 
-    context 'with copy_form parameter' do
+    context 'with copy_from parameter' do
       it 'renders the course about with data from chosen' do
         get(about_provider_course_path(provider_code: provider.provider_code,
                                        code: course.course_code,

--- a/spec/requests/courses/fees_spec.rb
+++ b/spec/requests/courses/fees_spec.rb
@@ -68,7 +68,7 @@ describe 'Courses', type: :request do
       )
     end
 
-    context 'with copy_form parameter' do
+    context 'with copy_from parameter' do
       it 'renders the course length and fees with data from chosen course' do
         get(fees_provider_course_path(provider_code: provider.provider_code,
                                       code: course.course_code,

--- a/spec/requests/courses/fees_spec.rb
+++ b/spec/requests/courses/fees_spec.rb
@@ -13,13 +13,22 @@ describe 'Courses', type: :request do
               name: 'Biology',
               include_nulls: [:accrediting_provider],
               course_length: 'TwoYears',
+              provider: provider,
               fee_uk_eu: '9500',
               fee_international: '1200',
               fee_details: 'Some information about the fees',
               financial_support: 'Some information about the finance support'
     end
-    let(:course_2)            { course_2_json_api.to_resource }
-    let(:courses)             { [course_1_json_api, course_2_json_api] }
+    let(:course_2) { course_2_json_api.to_resource }
+    let(:course_3_json_api) do
+      jsonapi :course,
+              name: 'Chemistry',
+              include_nulls: [:accrediting_provider],
+              fee_details: 'Course 3 fees',
+              financial_support: 'Course 3 financial support'
+    end
+    let(:course_3)            { course_3_json_api.to_resource }
+    let(:courses)             { [course_1_json_api, course_2_json_api, course_3_json_api] }
     let(:provider2)           { jsonapi(:provider, courses: courses, accredited_body?: true, provider_code: 'AO') }
     let(:provider_2_response) { provider2.render }
 
@@ -33,6 +42,10 @@ describe 'Courses', type: :request do
       stub_api_v2_request(
         "/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=sites,provider.sites,accrediting_provider",
         course_2_json_api.render
+      )
+      stub_api_v2_request(
+        "/providers/#{provider.provider_code}/courses/#{course_3.course_code}?include=sites,provider.sites,accrediting_provider",
+        course_3_json_api.render
       )
       stub_api_v2_request(
         "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
@@ -56,7 +69,7 @@ describe 'Courses', type: :request do
     end
 
     context 'with copy_form parameter' do
-      it 'renders the course length and fees with data from chosen' do
+      it 'renders the course length and fees with data from chosen course' do
         get(fees_provider_course_path(provider_code: provider.provider_code,
                                       code: course.course_code,
                                       params: { copy_from: course_2.course_code }))
@@ -79,6 +92,31 @@ describe 'Courses', type: :request do
         expect(response.body).to include(
           course_2.financial_support
         )
+      end
+
+      it 'doesn’t blank fields that were empty in the copied source' do
+        get(fees_provider_course_path(provider_code: provider.provider_code,
+                                      code: course_2.course_code,
+                                      params: { copy_from: course_3.course_code }))
+
+        expect(response.body).to include(
+          'Your changes are not yet saved'
+        )
+
+        original_course_details = [
+                                    course_2.course_length,
+                                    course_2.fee_uk_eu,
+                                    course_2.fee_international
+                                  ]
+
+        copied_course_details = [
+                                  course_3.fee_details,
+                                  course_3.financial_support
+                                ]
+
+        (original_course_details + copied_course_details).each do |value|
+          expect(response.body).to include(value)
+        end
       end
     end
   end

--- a/spec/requests/courses/requirements_spec.rb
+++ b/spec/requests/courses/requirements_spec.rb
@@ -53,7 +53,7 @@ describe 'Courses', type: :request do
       )
     end
 
-    context 'with copy_form parameter' do
+    context 'with copy_from parameter' do
       it 'renders the course requirements with data from chosen' do
         get(requirements_provider_course_path(provider_code: provider.provider_code,
                                        code: course.course_code,

--- a/spec/requests/courses/salary_spec.rb
+++ b/spec/requests/courses/salary_spec.rb
@@ -52,7 +52,7 @@ describe 'Courses', type: :request do
       )
     end
 
-    context 'with copy_form parameter' do
+    context 'with copy_from parameter' do
       it 'renders the course length and fees with data from chosen' do
         get(salary_provider_course_path(provider_code: provider.provider_code,
                                         code: course.course_code,


### PR DESCRIPTION
### Context

Previously, in the live rails version, if a field was empty in the course being copied, it would cause that field to be emptied in the new course.

In the C# version if the field was empty in the course being copied, then that field would be left alone.

The C# version was correct.

### Changes proposed in this pull request

* Move the logic for checking if a value is present out of view and into controller
* Only set values on the destination course if present in the source course
* Add a test to illustrate

### Guidance to review

* Test by copying from courses where only some data is available, but into courses that are otherwise complete (eg add something to an empty course and copy that to a published one).

* Seems like the copy course features are in the `spec/requests` when I'd expect to find them using SitePrism in `spec/features`. I've avoided adding further specs because I think this should be refactored after this PR.
