### PR TITLE
[1580] Update courses description and locations edit titles

### DIFF
--- a/app/views/courses/description.html.erb
+++ b/app/views/courses/description.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{course.name_and_code} - Courses" %>
+<%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}#{course.name_and_code} - Courses" %>
 
 <% content_for :before_content do %>
   <nav class="govuk-breadcrumbs">

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Locations - #{course.name_and_code}" %>
+<%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}Locations - #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>

--- a/spec/features/courses/description_spec.rb
+++ b/spec/features/courses/description_spec.rb
@@ -184,6 +184,7 @@ feature 'Course description', type: :feature do
           scenario 'it shows the description page with validation errors' do
             course_page.publish.click
 
+            expect(page.title).to have_content('Error:')
             expect(course_page).to be_displayed
             expect(course_page.error_summary).to have_content("About course can't be blank")
           end

--- a/spec/features/courses/sites/edit_spec.rb
+++ b/spec/features/courses/sites/edit_spec.rb
@@ -113,6 +113,7 @@ feature 'Edit course sites', type: :feature do
 
       locations_page.save.click
 
+      expect(page.title).to have_content('Error:')
       expect(locations_page).to be_displayed(provider_code: provider.provider_code, course_code: course.course_code)
       expect(locations_page.error_summary).to have_content('Removing all locations would prevent people from applying to this course')
     end


### PR DESCRIPTION
They should contain "Error:" in case of validation errors, for better accessibility.