### PR TITLE
[1480] Wire up course length and fees form to update course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -10,6 +10,20 @@ class CoursesController < ApplicationController
 
   def show; end
 
+  def update
+    @course.provider_code = @provider.provider_code
+
+    if @course.save
+      flash[:success] = 'Your changes have been saved'
+      redirect_to(
+        description_provider_course_path(
+          @provider.provider_code,
+          @course.course_code
+        )
+      )
+    end
+  end
+
   def description
     @published = flash[:success]
     flash.delete(:success)
@@ -75,7 +89,7 @@ class CoursesController < ApplicationController
         ]
       }.to_h
     else
-      flash[:success] = 'Your changes have been published'
+      flash[:success] = "Your course has been published. The link for this course is: #{Settings.search_ui.base_url}/course/#{@provider.provider_code}/#{@course.course_code}"
     end
 
     redirect_to description_provider_course_path(@provider.provider_code, @course.course_code)

--- a/app/views/courses/description.html.erb
+++ b/app/views/courses/description.html.erb
@@ -42,7 +42,7 @@
 <% if @published.present? %>
   <div class="govuk-success-summary" aria-labelledby="success-summary-title" role="alert" tabindex="-1" data-module="error-summary">
     <h2 class="govuk-success-summary__title" id="success-summary-title">
-      Your course has been published
+      <%= @published %>
     </h2>
     <div class="govuk-error-summary__body">
       <p class="govuk-body">

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for course, url: publish_provider_course_path(course.provider.provider_code, course.course_code), method: :post do |f| %>
+    <%= form_with model: course, url: provider_course_path(course.provider.provider_code, course.course_code) do |f| %>
       <%= render partial: 'courses/course_length', locals: { f: f } %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -80,6 +80,14 @@ FactoryBot.define do
       study_mode { 'part_time' }
     end
 
+    trait :with_fees do
+      course_length { 'TwoYears' }
+      fee_uk_eu { 7000 }
+      fee_international { 14000 }
+      fee_details { Faker::Lorem.sentence(100) }
+      financial_support { Faker::Lorem.sentence(100) }
+    end
+
     after :initialize do |course|
       course.provider_code = provider.provider_code if course.provider
     end

--- a/spec/features/courses/description_spec.rb
+++ b/spec/features/courses/description_spec.rb
@@ -167,7 +167,7 @@ feature 'Course description', type: :feature do
             course_page.publish.click
 
             expect(course_page).to be_displayed
-            expect(course_page.success_summary).to have_content("Your course has been published\nThe link for this course is: https://localhost:5000/course/#{provider.provider_code}/#{course.course_code}")
+            expect(course_page.success_summary).to have_content("Your course has been published. The link for this course is: https://localhost:5000/course/#{provider.provider_code}/#{course.course_code}")
           end
         end
 

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -25,7 +25,7 @@ describe 'Courses' do
       end
 
       it 'redirects to the course description page' do
-        expect(flash[:success]).to eq('Your changes have been published')
+        expect(flash[:success]).to include('Your course has been published')
         expect(response).to redirect_to(description_provider_course_path(provider_code: provider.provider_code, code: course.course_code))
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/course_fees.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_fees.rb
@@ -8,10 +8,11 @@ module PageObjects
         element :caption, '.govuk-caption-xl'
         element :course_length_one_year, '#course_course_length_oneyear'
         element :course_length_two_years, '#course_course_length_twoyears'
-        element :course_fees_uk, '#course_fee_uk_eu'
+        element :course_fees_uk_eu, '#course_fee_uk_eu'
         element :course_fees_international, '#course_fee_international'
         element :fee_details, '#course_fee_details'
         element :financial_support, '#course_financial_support'
+        element :flash, '.govuk-success-summary'
       end
     end
   end


### PR DESCRIPTION
### Context

This is a precursor PR to this whole story. Although it does implement most of the functionality, it's still missing a couple of things that will be done separately.

This will unblock similar work that needs to be done on a few other forms.

### Changes proposed in this pull request

The fee form was wired up to post to the publish endpoint. We added an
update action to the course controller and wired up the fees form to use
that instead.

Paired with Sau and Tim.

### Guidance to review

Validations are blocked by the backend implementing validation on update. Right now they only fire on publish.