### PR TITLE
[1608] Don't sync when editing locations or vacancies

### DIFF
--- a/app/controllers/courses/sites_controller.rb
+++ b/app/controllers/courses/sites_controller.rb
@@ -18,8 +18,6 @@ module Courses
       @course.sites = @provider.sites.select { |site| selected_site_ids.include?(site.id) }
 
       if @course.save
-        @course.sync_with_search_and_compare(provider_code: params[:provider_code])
-
         success_message = @course.is_running? ? 'Course locations saved and published' : 'Course locations saved'
         redirect_to provider_course_path(params[:provider_code], params[:code]), flash: { success: success_message }
       else

--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -24,8 +24,6 @@ module Courses
           site_status.save
         end
 
-      @course.sync_with_search_and_compare(provider_code: params[:provider_code])
-
       flash[:success] = 'Course vacancies published'
       redirect_to provider_courses_path(params[:provider_code])
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,7 +3,6 @@ class Course < Base
   has_many :site_statuses
   has_many :sites, through: :site_statuses, source: :site
 
-  custom_endpoint :sync_with_search_and_compare, on: :member, request_method: :post
   custom_endpoint :publish, on: :member, request_method: :post
 
   self.primary_key = :course_code

--- a/spec/features/courses/sites/edit_spec.rb
+++ b/spec/features/courses/sites/edit_spec.rb
@@ -20,13 +20,6 @@ feature 'Edit course sites', type: :feature do
   let(:course_page) { PageObjects::Page::Organisations::Course.new }
   let(:locations_page) { PageObjects::Page::Organisations::CourseLocations.new }
 
-  let!(:sync_courses_request_stub) do
-    stub_api_v2_request(
-      "/providers/#{provider.provider_code}/courses/#{course.course_code}/sync_with_search_and_compare",
-      {}, :post, 201
-    )
-  end
-
   before do
     stub_omniauth
     stub_api_v2_request(
@@ -91,7 +84,6 @@ feature 'Edit course sites', type: :feature do
         'Course locations saved'
       )
       expect(locations_page.title).to have_content(course.course_code)
-      expect(sync_courses_request_stub).to have_been_requested
     end
   end
 

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -27,13 +27,6 @@ feature 'Edit course vacancies', type: :feature do
   let(:edit_vacancies_path) do
     "/organisations/AO/courses/#{course_attributes[:course_code]}/vacancies"
   end
-  let!(:sync_courses_request_stub) do
-    stub_request(
-      :post,
-      "http://localhost:3001/api/v2/providers/AO/courses/" \
-        "#{course_attributes[:course_code]}/sync_with_search_and_compare"
-    ).to_return(status: 201, body: "")
-  end
 
   before do
     stub_omniauth
@@ -119,7 +112,6 @@ feature 'Edit course vacancies', type: :feature do
         'Course vacancies published'
       )
       expect(find('h1')).to have_content('Courses')
-      expect(sync_courses_request_stub).to have_been_requested
     end
 
     scenario 'removing all vacancies' do
@@ -136,7 +128,6 @@ feature 'Edit course vacancies', type: :feature do
         'Course vacancies published'
       )
       expect(find('h1')).to have_content('Courses')
-      expect(sync_courses_request_stub).to have_been_requested
     end
   end
 
@@ -169,7 +160,6 @@ feature 'Edit course vacancies', type: :feature do
         'Course vacancies published'
       )
       expect(find('h1')).to have_content('Courses')
-      expect(sync_courses_request_stub).to have_been_requested
     end
   end
 end


### PR DESCRIPTION
### Context

The frontend doesn't necessarily know when a course is due to be synced with search-and-compare, the concern for that knowledge should be in the backend.