### PR TITLE
[1478] Wire up update for about course

### DIFF
--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for course, url: publish_provider_course_path(course.provider.provider_code, course.course_code), method: :post do |f| %>
+    <%= form_with model: course, url: provider_course_path(course.provider.provider_code, course.course_code) do |f| %>
       <p class="govuk-body">Give applicants a short description of the course.</p>
 
       <p class="govuk-body">You could include:</p>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for course, url: publish_provider_course_path(course.provider.provider_code, course.course_code), method: :post do |f| %>
+    <%= form_with model: course, url: provider_course_path(course.provider.provider_code, course.course_code) do |f| %>
       <h3 class="govuk-heading-l remove-top-margin">Qualifications needed</h3>
 
       <p class="govuk-body">State the minimum academic qualifications needed for this course.</p>

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for course, url: publish_provider_course_path(course.provider.provider_code, course.course_code), method: :post do |f| %>
+    <%= form_with model: course, url: provider_course_path(course.provider.provider_code, course.course_code) do |f| %>
       <%= render partial: 'courses/course_length', locals: { f: f } %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -23,6 +23,11 @@ feature 'About course', type: :feature do
       "/providers/AO?include=courses.accrediting_provider",
       provider_response
     )
+    stub_api_v2_request(
+      "/providers/AO/courses/#{course.course_code}",
+      course_response,
+      :patch
+    )
   end
 
   let(:about_course_page) { PageObjects::Page::Organisations::CourseAbout.new }
@@ -45,6 +50,16 @@ feature 'About course', type: :feature do
     expect(about_course_page.how_school_placements_work_textarea).to have_content(
       course.how_school_placements_work
     )
+
+    fill_in 'About this course', with: 'Something interesting about this course'
+    fill_in 'How school placements work', with: 'Something about how school placements work'
+
+    click_on 'Save'
+
+    expect(about_course_page.flash).to have_content(
+      'Your changes have been saved'
+    )
+    expect(current_path).to eq description_provider_course_path('AO', course.course_code)
   end
 
   context 'when a provider has no self accredited courses (for example a School Direct provider)' do

--- a/spec/features/courses/requirements_spec.rb
+++ b/spec/features/courses/requirements_spec.rb
@@ -20,27 +20,44 @@ feature 'Course requirements', type: :feature do
       "/providers/AO?include=courses.accrediting_provider",
       provider_response
     )
+    stub_api_v2_request(
+      "/providers/AO/courses/#{course.course_code}",
+      course_response,
+      :patch
+    )
   end
 
-  let(:about_course_page) { PageObjects::Page::Organisations::CourseRequirements.new }
+  let(:course_requirements_page) { PageObjects::Page::Organisations::CourseRequirements.new }
 
   scenario 'viewing the courses requirements page' do
     visit requirements_provider_course_path('AO', course.course_code)
 
-    expect(about_course_page.caption).to have_content(
+    expect(course_requirements_page.caption).to have_content(
       "#{course.name} (#{course.course_code})"
     )
-    expect(about_course_page.title).to have_content(
+    expect(course_requirements_page.title).to have_content(
       "Requirements and eligibility"
     )
-    expect(about_course_page.required_qualifications).to have_content(
+    expect(course_requirements_page.required_qualifications).to have_content(
       course.required_qualifications
     )
-    expect(about_course_page.personal_qualities).to have_content(
+    expect(course_requirements_page.personal_qualities).to have_content(
       course.personal_qualities
     )
-    expect(about_course_page.other_requirements).to have_content(
+    expect(course_requirements_page.other_requirements).to have_content(
       course.other_requirements
     )
+
+    fill_in 'Qualifications needed', with: 'Something about the qualifications required for this course'
+    fill_in 'Personal qualities (optional)', with: 'Something about the personal qualities required for this course'
+    fill_in 'Other requirements (optional)', with: 'Something about the other requirements required for this course'
+
+    click_on 'Save'
+
+    expect(course_requirements_page.flash).to have_content(
+      'Your changes have been saved'
+    )
+
+    expect(current_path).to eq description_provider_course_path('AO', course.course_code)
   end
 end

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -31,6 +31,11 @@ feature 'Course salary', type: :feature do
       "/providers/AO?include=courses.accrediting_provider",
       provider_response
     )
+    stub_api_v2_request(
+      "/providers/AO/courses/#{course.course_code}",
+      course_response,
+      :patch
+    )
   end
 
   let(:course_salary_page) { PageObjects::Page::Organisations::CourseSalary.new }
@@ -49,5 +54,15 @@ feature 'Course salary', type: :feature do
     expect(course_salary_page.course_salary_details).to have_content(
       course.salary_details
     )
+
+    choose '2 years'
+    fill_in 'Salary', with: 'Test salary details'
+    click_on 'Save'
+
+    expect(course_salary_page.flash).to have_content(
+      'Your changes have been saved'
+    )
+
+    expect(current_path).to eq description_provider_course_path('AO', course.course_code)
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/course_about.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_about.rb
@@ -10,6 +10,7 @@ module PageObjects
         element :interview_process_textarea, '#course_interview_process'
         element :how_school_placements_work_textarea, '#course_how_school_placements_work'
         element :warning_message, '[data-copy-course=warning]'
+        element :flash, '.govuk-success-summary'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_requirements.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_requirements.rb
@@ -9,6 +9,7 @@ module PageObjects
         element :required_qualifications, '#course_required_qualifications'
         element :personal_qualities, '#course_personal_qualities'
         element :other_requirements, '#course_other_requirements'
+        element :flash, '.govuk-success-summary'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_salary.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_salary.rb
@@ -9,6 +9,7 @@ module PageObjects
         element :course_length_one_year, '#course_course_length_oneyear'
         element :course_length_two_years, '#course_course_length_twoyears'
         element :course_salary_details, '#course_salary_details'
+        element :flash, '.govuk-success-summary'
       end
     end
   end


### PR DESCRIPTION
### Context
Allowing the user to update "about course"

### Changes proposed in this pull request
The about form was wired up to post to the publish endpoint. We added an
update action to the course controller and wired up the fees form to use
that instead.

### Guidance to review
Validations are blocked by the backend implementing validation on update. Right now they only fire on publish.