### PR TITLE
[1610] Add provider code to course factory

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -11,8 +11,6 @@ class CoursesController < ApplicationController
   def show; end
 
   def update
-    @course.provider_code = @provider.provider_code
-
     if @course.save
       flash[:success] = 'Your changes have been saved'
       redirect_to(

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -7,6 +7,9 @@ FactoryBot.define do
 
     sequence(:id)
     sequence(:course_code) { |n| "X10#{n}" }
+    # This hardcodes the provider code to AO. This should probably be fixed at
+    # some point. Right now it doesn't break anything.
+    sequence(:provider_code) { 'AO' }
     name { "English" }
     description { "PGCE with QTS full time" }
     findable? { true }


### PR DESCRIPTION
### Context

Due to the way we use the factories, it's difficult to set the
provider_code on the course without causing an endless loop.

Also, setting provider_code on the course factory gets overwritten by
the provider being set to nil in the factory, and removing that breaks
things.

This is further broken by a bug in the JSONAPI client.

### Changes proposed in this pull request

Added workaround for broken factories/jsonapi client.
Removed workaround for `provider_code` not being in responses.

### Guidance to review

I cleaned up the test affected, some of that is unrelated to these changes, sorry.