### PR TITLE
Update course enrichment links

### DIFF
--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -25,7 +25,7 @@
   <% if course.has_fees? %>
     <%= link_to 'Course length and fees', fees_provider_course_path(@provider.provider_code, course.course_code), class: 'govuk-link' %>
   <% else %>
-    <%= link_to 'Course length and salary', manage_ui_course_page_url(provider_code: @provider.provider_code, course_code: course.course_code) + '/salary', class: 'govuk-link' %>
+    <%= link_to 'Course length and salary', salary_provider_course_path(@provider.provider_code, course.course_code), class: 'govuk-link' %>
   <% end %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">
-  <%= link_to 'About this course', manage_ui_course_page_url(provider_code: @provider.provider_code, course_code: course.course_code) + '/about', class: 'govuk-link' %>
+  <%= link_to 'About this course', about_provider_course_path(@provider.provider_code, course.course_code), class: 'govuk-link' %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
   <%= course_summary_item('About this course', course.about_course, 'about_course') %>

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -23,7 +23,7 @@
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">
   <% if course.has_fees? %>
-    <%= link_to 'Course length and fees', manage_ui_course_page_url(provider_code: @provider.provider_code, course_code: course.course_code) + '/fees-and-length', class: 'govuk-link' %>
+    <%= link_to 'Course length and fees', fees_provider_course_path(@provider.provider_code, course.course_code), class: 'govuk-link' %>
   <% else %>
     <%= link_to 'Course length and salary', manage_ui_course_page_url(provider_code: @provider.provider_code, course_code: course.course_code) + '/salary', class: 'govuk-link' %>
   <% end %>

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -42,7 +42,7 @@
 </dl>
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">
-  <%= link_to 'Requirements and eligibility', manage_ui_course_page_url(provider_code: @provider.provider_code, course_code: course.course_code) + '/requirements', class: 'govuk-link' %>
+  <%= link_to 'Requirements and eligibility', requirements_provider_course_path(@provider.provider_code, course.course_code), class: 'govuk-link' %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
   <%= course_summary_item('Qualifications needed', course.required_qualifications, 'qualifications') %>

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -33,7 +33,11 @@ feature 'About course', type: :feature do
   let(:about_course_page) { PageObjects::Page::Organisations::CourseAbout.new }
 
   scenario 'viewing the about courses page' do
-    visit about_provider_course_path('AO', course.course_code)
+    visit description_provider_course_path(provider.provider_code, course.course_code)
+
+    click_on 'About this course'
+
+    expect(current_path).to eq about_provider_course_path('AO', course.course_code)
 
     expect(about_course_page.caption).to have_content(
       "#{course.name} (#{course.course_code})"

--- a/spec/features/courses/description_spec.rb
+++ b/spec/features/courses/description_spec.rb
@@ -23,7 +23,7 @@ feature 'Course description', type: :feature do
       "/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
       course_response
     )
-    visit "/organisations/#{provider.provider_code}/courses/#{course.course_code}/description"
+    visit description_provider_course_path(provider.provider_code, course.course_code)
   end
 
   let(:course_page) { PageObjects::Page::Organisations::CourseDescription.new }
@@ -70,6 +70,19 @@ feature 'Course description', type: :feature do
         'Last published: 5 March 2019'
       )
       expect(course_page).to_not have_preview_link
+
+      expect(course_page).to have_link(
+        'About this course',
+        href: "/organisations/#{provider.provider_code}/courses/#{course.course_code}/about"
+      )
+      expect(course_page).to have_link(
+        'Course length and fees',
+        href: "/organisations/#{provider.provider_code}/courses/#{course.course_code}/fees"
+      )
+      expect(course_page).to have_link(
+        'Requirements and eligibility',
+        href: "/organisations/#{provider.provider_code}/courses/#{course.course_code}/requirements"
+      )
     end
   end
 

--- a/spec/features/courses/fees_spec.rb
+++ b/spec/features/courses/fees_spec.rb
@@ -37,7 +37,11 @@ feature 'Course fees', type: :feature do
   let(:course_fees_page) { PageObjects::Page::Organisations::CourseFees.new }
 
   scenario 'viewing the courses fees page' do
-    visit fees_provider_course_path('AO', course.course_code)
+    visit description_provider_course_path(provider.provider_code, course.course_code)
+
+    click_on 'Course length and fees'
+
+    expect(current_path).to eq fees_provider_course_path('AO', course.course_code)
 
     expect(course_fees_page.caption).to have_content(
       "#{course.name} (#{course.course_code})"

--- a/spec/features/courses/requirements_spec.rb
+++ b/spec/features/courses/requirements_spec.rb
@@ -30,7 +30,11 @@ feature 'Course requirements', type: :feature do
   let(:course_requirements_page) { PageObjects::Page::Organisations::CourseRequirements.new }
 
   scenario 'viewing the courses requirements page' do
-    visit requirements_provider_course_path('AO', course.course_code)
+    visit description_provider_course_path(provider.provider_code, course.course_code)
+
+    click_on 'Requirements and eligibility'
+
+    expect(current_path).to eq requirements_provider_course_path('AO', course.course_code)
 
     expect(course_requirements_page.caption).to have_content(
       "#{course.name} (#{course.course_code})"

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -7,7 +7,8 @@ feature 'Course salary', type: :feature do
       name: 'English',
       provider: provider,
       include_nulls: [:accrediting_provider],
-      course_length: 'OneYear'
+      course_length: 'OneYear',
+      funding: 'salary'
     )
   end
   let(:course_2) { jsonapi :course, name: 'Biology', include_nulls: [:accrediting_provider] }
@@ -41,7 +42,11 @@ feature 'Course salary', type: :feature do
   let(:course_salary_page) { PageObjects::Page::Organisations::CourseSalary.new }
 
   scenario 'viewing the courses salary page' do
-    visit salary_provider_course_path('AO', course.course_code)
+    visit description_provider_course_path(provider.provider_code, course.course_code)
+
+    click_on 'Course length and salary'
+
+    expect(current_path).to eq salary_provider_course_path('AO', course.course_code)
 
     expect(course_salary_page.caption).to have_content(
       "#{course.name} (#{course.course_code})"


### PR DESCRIPTION
### Context
Allow users to edit course enrichments in rails and not c#

### Changes proposed in this pull request
Update individual enrichment page links to point to our rails app

### Guidance to review
Example `/organisations/2AT/courses/35L7/description`
