### PR TITLE
[1611] Hide the status panel on Not running courses

### DIFF
--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -1,3 +1,17 @@
+<% if course.not_running? %>
+  <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-3">
+    <div class="govuk-warning-text app-warning-text--inline">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        This course is not running.
+      </strong>
+    </div>
+    <p class="govuk-body">
+      It won’t appear online. To publish it you’ll need to contact the Becoming a Teacher team:<br /><%= bat_contact_mail_to bat_contact_email_address_with_wrap, subject: "Course not running" %>
+    </p>
+  </div>
+<% end %>
+
 <h3 class="govuk-heading-m govuk-!-font-size-27">
   <%= link_to 'About this course', manage_ui_course_page_url(provider_code: @provider.provider_code, course_code: course.course_code) + '/about', class: 'govuk-link' %>
 </h3>

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -21,7 +21,7 @@
   <%= course_summary_item('How school placements work', course.how_school_placements_work, 'how_school_placements_work') %>
 </dl>
 
-<h3 class="govuk-heading-m">
+<h3 class="govuk-heading-m govuk-!-font-size-27">
   <% if course.has_fees? %>
     <%= link_to 'Course length and fees', manage_ui_course_page_url(provider_code: @provider.provider_code, course_code: course.course_code) + '/fees-and-length', class: 'govuk-link' %>
   <% else %>
@@ -41,7 +41,7 @@
   <% end %>
 </dl>
 
-<h3 class="govuk-heading-m">
+<h3 class="govuk-heading-m govuk-!-font-size-27">
   <%= link_to 'Requirements and eligibility', manage_ui_course_page_url(provider_code: @provider.provider_code, course_code: course.course_code) + '/requirements', class: 'govuk-link' %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">

--- a/app/views/courses/description.html.erb
+++ b/app/views/courses/description.html.erb
@@ -88,9 +88,11 @@
       <div class="govuk-grid-column-two-thirds">
         <%= render partial: 'courses/description_content' %>
       </div>
-      <div class="govuk-grid-column-one-third">
-        <%= render partial: 'courses/status_panel' %>
-      </div>
+      <% unless course.not_running? %>
+        <div class="govuk-grid-column-one-third" data-qa="course__status_panel">
+          <%= render partial: 'courses/status_panel' %>
+        </div>
+      <% end %>
     </div>
   </section>
 </div>

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -83,6 +83,15 @@ $button-colour: #00823b;
   padding: govuk-spacing(4);
 }
 
+.app-warning-text--inline {
+  margin-bottom: 0;
+
+  + .govuk-body {
+    padding-left: govuk-spacing(8);
+    margin-bottom: govuk-spacing(8);
+  }
+}
+
 .govuk-list--dash {
   padding-left: govuk-spacing(3);
   margin-bottom: govuk-spacing(8);

--- a/spec/features/courses/description_spec.rb
+++ b/spec/features/courses/description_spec.rb
@@ -9,7 +9,6 @@ feature 'Course description', type: :feature do
             funding: 'fee',
             sites: [site],
             provider: provider,
-            accrediting_provider: provider,
             last_published_at: '2019-03-05T14:42:34Z')
   }
   let(:site) { jsonapi(:site) }
@@ -128,9 +127,7 @@ feature 'Course description', type: :feature do
               ucas_status: 'running',
               has_vacancies?: true,
               open_for_applications?: true,
-              sites: [site],
-              provider: provider,
-              accrediting_provider: provider)
+              provider: provider)
     }
     let(:course)          { course_jsonapi.to_resource }
     let(:course_response) { course_jsonapi.render }
@@ -147,12 +144,8 @@ feature 'Course description', type: :feature do
   context 'when the course is not running' do
     let(:course_jsonapi) {
       jsonapi(:course,
-              findable?: true,
-              content_status: 'empty',
               ucas_status: 'not_running',
-              sites: [site],
-              provider: provider,
-              accrediting_provider: provider)
+              provider: provider)
     }
     let(:course)          { course_jsonapi.to_resource }
     let(:course_response) { course_jsonapi.render }
@@ -172,9 +165,7 @@ feature 'Course description', type: :feature do
               findable?: false,
               content_status: 'draft',
               ucas_status: 'new',
-              sites: [site],
-              provider: provider,
-              accrediting_provider: provider)
+              provider: provider)
     }
     let(:course)          { course_jsonapi.to_resource }
     let(:course_response) { course_jsonapi.render }

--- a/spec/site_prism/page_objects/page/organisations/course_description.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_description.rb
@@ -27,6 +27,7 @@ module PageObjects
         element :publish, '[data-qa=course__publish]'
         element :success_summary, '.govuk-success-summary'
         element :error_summary, '.govuk-error-summary'
+        element :status_panel, '[data-qa=course__status_panel]'
       end
     end
   end


### PR DESCRIPTION
### Context

On the C# version – a Not running course has no status column and a warning message:
https://bat-dev-manage-courses-ui-app.azurewebsites.net/organisation/2AT/course/self/35L7

We need to do the same thing in Rails:
https://bat-dev-manage-courses-frontend-app.azurewebsites.net/organisations/2AT/courses/35L7/description

### Changes proposed in this pull request

* Hide status column
* Be more explicit about course states in description feature spec
* Show a warning message
* Fix heading sizes

### Screenshot from this PR

![Screen Shot 2019-06-10 at 16 22 51](https://user-images.githubusercontent.com/319055/59206052-04036080-8b9c-11e9-808c-67672f473eb9.png)

### Screenshot from C#
![Screen Shot 2019-06-10 at 15 27 24](https://user-images.githubusercontent.com/319055/59205894-b981e400-8b9b-11e9-8ba6-a975de38055c.png)