### PR TITLE
[1608] Sync courses when updating vacancies

### DIFF
--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -24,6 +24,8 @@ module Courses
           site_status.save
         end
 
+      @course.sync_with_search_and_compare(provider_code: params[:provider_code])
+
       flash[:success] = 'Course vacancies published'
       redirect_to provider_courses_path(params[:provider_code])
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,6 +3,7 @@ class Course < Base
   has_many :site_statuses
   has_many :sites, through: :site_statuses, source: :site
 
+  custom_endpoint :sync_with_search_and_compare, on: :member, request_method: :post
   custom_endpoint :publish, on: :member, request_method: :post
 
   self.primary_key = :course_code

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -27,6 +27,13 @@ feature 'Edit course vacancies', type: :feature do
   let(:edit_vacancies_path) do
     "/organisations/AO/courses/#{course_attributes[:course_code]}/vacancies"
   end
+  let!(:sync_courses_request_stub) do
+    stub_request(
+      :post,
+      "http://localhost:3001/api/v2/providers/AO/courses/" \
+        "#{course_attributes[:course_code]}/sync_with_search_and_compare"
+    ).to_return(status: 201, body: "")
+  end
 
   before do
     stub_omniauth
@@ -112,6 +119,7 @@ feature 'Edit course vacancies', type: :feature do
         'Course vacancies published'
       )
       expect(find('h1')).to have_content('Courses')
+      expect(sync_courses_request_stub).to have_been_requested
     end
 
     scenario 'removing all vacancies' do
@@ -128,6 +136,7 @@ feature 'Edit course vacancies', type: :feature do
         'Course vacancies published'
       )
       expect(find('h1')).to have_content('Courses')
+      expect(sync_courses_request_stub).to have_been_requested
     end
   end
 
@@ -160,6 +169,7 @@ feature 'Edit course vacancies', type: :feature do
         'Course vacancies published'
       )
       expect(find('h1')).to have_content('Courses')
+      expect(sync_courses_request_stub).to have_been_requested
     end
   end
 end


### PR DESCRIPTION
### Context

We removed this because we were planning on implementing it on the backend, but we're thinking about including it back in temporarily.