### PR TITLE
[xxxx] Add feature specs for copying each type of enrichment

### DIFF
--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -1,43 +1,35 @@
 require 'rails_helper'
 
 feature 'About course', type: :feature do
-  let(:course_1) { jsonapi :course, name: 'English', provider: provider, include_nulls: [:accrediting_provider] }
-  let(:course_2) { jsonapi :course, name: 'Biology', include_nulls: [:accrediting_provider] }
-  let(:course_3) { jsonapi :course, name: 'Physics', include_nulls: [:accrediting_provider] }
-  let(:course_4) { jsonapi :course, name: 'Science', include_nulls: [:accrediting_provider] }
-  let(:courses)  { [course_2, course_3, course_4] }
   let(:provider) do
-    jsonapi(:provider, courses: courses, accredited_body?: true, provider_code: 'AO')
+    jsonapi(:provider, provider_code: 'AO')
   end
-  let(:provider_response) { provider.render }
-  let(:course)            { course_1.to_resource }
-  let(:course_response)   { course_1.render }
+
+  let(:course) do
+    jsonapi(
+      :course,
+      name: 'English',
+      provider: provider,
+      about_course: 'About course',
+      interview_process: 'Interview process',
+      how_school_placements_work: 'How school placements work'
+    )
+  end
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/providers/AO/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
-      course_response
-    )
-    stub_api_v2_request(
-      "/providers/AO?include=courses.accrediting_provider",
-      provider_response
-    )
-    stub_api_v2_request(
-      "/providers/AO/courses/#{course.course_code}",
-      course_response,
-      :patch
-    )
+    stub_course_request(provider, course)
+    stub_api_v2_request("/providers/AO?include=courses.accrediting_provider", provider.render)
+    stub_api_v2_request("/providers/AO/courses/#{course.course_code}", course.render, :patch)
   end
 
   let(:about_course_page) { PageObjects::Page::Organisations::CourseAbout.new }
 
   scenario 'viewing the about courses page' do
     visit description_provider_course_path(provider.provider_code, course.course_code)
-
     click_on 'About this course'
 
-    expect(current_path).to eq about_provider_course_path('AO', course.course_code)
+    expect(current_path).to eq about_provider_course_path(provider.provider_code, course.course_code)
 
     expect(about_course_page.caption).to have_content(
       "#{course.name} (#{course.course_code})"
@@ -45,19 +37,18 @@ feature 'About course', type: :feature do
     expect(about_course_page.title).to have_content(
       "About this course"
     )
-    expect(about_course_page.about_textarea).to have_content(
+    expect(about_course_page.about_textarea.value).to eq(
       course.about_course
     )
-    expect(about_course_page.interview_process_textarea).to have_content(
+    expect(about_course_page.interview_process_textarea.value).to eq(
       course.interview_process
     )
-    expect(about_course_page.how_school_placements_work_textarea).to have_content(
+    expect(about_course_page.how_school_placements_work_textarea.value).to eq(
       course.how_school_placements_work
     )
 
     fill_in 'About this course', with: 'Something interesting about this course'
     fill_in 'How school placements work', with: 'Something about how school placements work'
-
     click_on 'Save'
 
     expect(about_course_page.flash).to have_content(
@@ -80,5 +71,12 @@ feature 'About course', type: :feature do
         "#{course.name} (#{course.course_code})"
       )
     end
+  end
+
+  def stub_course_request(provider, course)
+    stub_api_v2_request(
+      "/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
+      course.render
+    )
   end
 end

--- a/spec/features/courses/fees_spec.rb
+++ b/spec/features/courses/fees_spec.rb
@@ -1,50 +1,33 @@
 require 'rails_helper'
 
 feature 'Course fees', type: :feature do
+  let(:provider) { jsonapi(:provider, provider_code: 'AO') }
   let(:course_1) do
     jsonapi(
       :course,
       :with_fees,
-      provider: provider,
-      include_nulls: [:accrediting_provider]
+      provider: provider
     )
   end
-  let(:course_2) { jsonapi :course, name: 'Biology', include_nulls: [:accrediting_provider] }
-  let(:provider) do
-    jsonapi(:provider, courses: [course_2], accredited_body?: true, provider_code: 'AO')
-  end
-  let(:provider_response) { provider.render }
-  let(:course)            { course_1.to_resource }
-  let(:course_response)   { course_1.render }
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/providers/AO/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
-      course_response
-    )
-    stub_api_v2_request(
-      "/providers/AO?include=courses.accrediting_provider",
-      provider_response
-    )
-    stub_api_v2_request(
-      "/providers/AO/courses/#{course.course_code}",
-      course_response,
-      :patch
-    )
+    stub_course_response(provider, course_1)
+    stub_api_v2_request("/providers/AO?include=courses.accrediting_provider", provider.render)
+    stub_api_v2_request("/providers/AO/courses/#{course_1.course_code}", course_1.render, :patch)
   end
 
   let(:course_fees_page) { PageObjects::Page::Organisations::CourseFees.new }
 
   scenario 'viewing the courses fees page' do
-    visit description_provider_course_path(provider.provider_code, course.course_code)
+    visit description_provider_course_path(provider.provider_code, course_1.course_code)
 
     click_on 'Course length and fees'
 
-    expect(current_path).to eq fees_provider_course_path('AO', course.course_code)
+    expect(current_path).to eq fees_provider_course_path('AO', course_1.course_code)
 
     expect(course_fees_page.caption).to have_content(
-      "#{course.name} (#{course.course_code})"
+      "#{course_1.name} (#{course_1.course_code})"
     )
     expect(course_fees_page.title).to have_content(
       "Course length and fees"
@@ -52,16 +35,16 @@ feature 'Course fees', type: :feature do
     expect(course_fees_page.course_length_one_year).not_to be_checked
     expect(course_fees_page.course_length_two_years).to be_checked
     expect(course_fees_page.course_fees_uk_eu.value).to have_content(
-      course.fee_uk_eu
+      course_1.fee_uk_eu
     )
     expect(course_fees_page.course_fees_international.value).to have_content(
-      course.fee_international
+      course_1.fee_international
     )
     expect(course_fees_page.fee_details).to have_content(
-      course.fee_details
+      course_1.fee_details
     )
     expect(course_fees_page.financial_support).to have_content(
-      course.financial_support
+      course_1.financial_support
     )
 
     choose '1 year'
@@ -78,6 +61,103 @@ feature 'Course fees', type: :feature do
     expect(course_fees_page.flash).to have_content(
       'Your changes have been saved'
     )
-    expect(current_path).to eq description_provider_course_path('AO', course.course_code)
+    expect(current_path).to eq description_provider_course_path('AO', course_1.course_code)
+  end
+
+  context 'when copying course fees from another course' do
+    let(:course_2) {
+      jsonapi(
+        :course,
+        name: 'Biology',
+        provider: provider,
+        course_length: 'TwoYears',
+        fee_uk_eu: '9500',
+        fee_international: '1200',
+        fee_details: 'Some information about the fees',
+        financial_support: 'Some information about the finance support'
+      )
+    }
+
+    let(:course_3) {
+      jsonapi(
+        :course,
+        name: 'Biology',
+        provider: provider,
+        fee_details: 'Course 3 has just fee details',
+        financial_support: 'and financial support (Course 3)'
+      )
+    }
+
+    let(:provider_for_copy_from_list) do
+      jsonapi(:provider, courses: [course_1, course_2, course_3], provider_code: 'AO')
+    end
+
+    before do
+      stub_course_response(provider, course_2)
+      stub_course_response(provider, course_3)
+      stub_api_v2_request("/providers/AO?include=courses.accrediting_provider", provider_for_copy_from_list.render)
+    end
+
+    scenario 'all fields get copied if all were present' do
+      copy_fees(from: course_2, to: course_1)
+
+      [
+        'Your changes are not yet saved',
+        'Course length',
+        'Fee for UK and EU students',
+        'Fee for international students',
+        'Fee details',
+        'Financial support'
+      ].each do |name|
+        expect(course_fees_page.warning_message).to have_content(name)
+      end
+
+      expect(course_fees_page.course_length_one_year).to_not be_checked
+      expect(course_fees_page.course_length_two_years).to be_checked
+      expect(course_fees_page.course_fees_uk_eu.value).to eq(course_2.fee_uk_eu)
+      expect(course_fees_page.course_fees_international.value).to eq(course_2.fee_international)
+      expect(course_fees_page.fee_details.value).to eq(course_2.fee_details)
+      expect(course_fees_page.financial_support.value).to eq(course_2.financial_support)
+    end
+
+    scenario 'only fields with values are copied if the source was incomplete' do
+      copy_fees(from: course_3, to: course_2)
+
+      [
+        'Your changes are not yet saved',
+        'Fee details',
+        'Financial support'
+      ].each do |name|
+        expect(course_fees_page.warning_message).to have_content(name)
+      end
+
+      [
+        'Course length',
+        'Fee for UK and EU students',
+        'Fee for international students'
+      ].each do |name|
+        expect(course_fees_page.warning_message).not_to have_content(name)
+      end
+
+      expect(course_fees_page.course_length_one_year).to_not be_checked
+      expect(course_fees_page.course_length_two_years).to be_checked
+      expect(course_fees_page.course_fees_uk_eu.value).to eq(course_2.fee_uk_eu)
+      expect(course_fees_page.course_fees_international.value).to eq(course_2.fee_international)
+      expect(course_fees_page.fee_details.value).to eq(course_3.fee_details)
+      expect(course_fees_page.financial_support.value).to eq(course_3.financial_support)
+    end
+  end
+
+  def copy_fees(from:, to:)
+    visit fees_provider_course_path(provider.provider_code, to.course_code)
+    select("#{from.name} (#{from.course_code})", from: 'Copy from')
+    click_on('Copy content')
+  end
+
+  def stub_course_response(provider, course)
+    stub_api_v2_request(
+      "/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
+      course.render
+    )
   end
 end

--- a/spec/features/courses/fees_spec.rb
+++ b/spec/features/courses/fees_spec.rb
@@ -12,7 +12,7 @@ feature 'Course fees', type: :feature do
 
   before do
     stub_omniauth
-    stub_course_response(provider, course_1)
+    stub_course_request(provider, course_1)
     stub_api_v2_request("/providers/AO?include=courses.accrediting_provider", provider.render)
     stub_api_v2_request("/providers/AO/courses/#{course_1.course_code}", course_1.render, :patch)
   end
@@ -93,8 +93,8 @@ feature 'Course fees', type: :feature do
     end
 
     before do
-      stub_course_response(provider, course_2)
-      stub_course_response(provider, course_3)
+      stub_course_request(provider, course_2)
+      stub_course_request(provider, course_3)
       stub_api_v2_request("/providers/AO?include=courses.accrediting_provider", provider_for_copy_from_list.render)
     end
 
@@ -154,7 +154,7 @@ feature 'Course fees', type: :feature do
     click_on('Copy content')
   end
 
-  def stub_course_response(provider, course)
+  def stub_course_request(provider, course)
     stub_api_v2_request(
       "/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
       course.render

--- a/spec/features/courses/requirements_spec.rb
+++ b/spec/features/courses/requirements_spec.rb
@@ -1,37 +1,32 @@
 require 'rails_helper'
 
 feature 'Course requirements', type: :feature do
-  let(:course_1) { jsonapi :course, name: 'English', provider: provider, include_nulls: [:accrediting_provider] }
-  let(:course_2) { jsonapi :course, name: 'Biology', include_nulls: [:accrediting_provider] }
   let(:provider) do
-    jsonapi(:provider, courses: [course_2], accredited_body?: true, provider_code: 'AO')
+    jsonapi(:provider, provider_code: 'AO')
   end
-  let(:provider_response) { provider.render }
-  let(:course)            { course_1.to_resource }
-  let(:course_response)   { course_1.render }
+
+  let(:course) do
+    jsonapi(
+      :course,
+      name: 'English',
+      provider: provider,
+      required_qualifications: 'Required qualifications',
+      personal_qualities: 'Personal qualities',
+      other_requirements: 'Other requirements'
+    )
+  end
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/providers/AO/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
-      course_response
-    )
-    stub_api_v2_request(
-      "/providers/AO?include=courses.accrediting_provider",
-      provider_response
-    )
-    stub_api_v2_request(
-      "/providers/AO/courses/#{course.course_code}",
-      course_response,
-      :patch
-    )
+    stub_course_request(provider, course)
+    stub_api_v2_request("/providers/AO?include=courses.accrediting_provider", provider.render)
+    stub_api_v2_request("/providers/AO/courses/#{course.course_code}", course.render, :patch)
   end
 
   let(:course_requirements_page) { PageObjects::Page::Organisations::CourseRequirements.new }
 
   scenario 'viewing the courses requirements page' do
     visit description_provider_course_path(provider.provider_code, course.course_code)
-
     click_on 'Requirements and eligibility'
 
     expect(current_path).to eq requirements_provider_course_path('AO', course.course_code)
@@ -42,13 +37,13 @@ feature 'Course requirements', type: :feature do
     expect(course_requirements_page.title).to have_content(
       "Requirements and eligibility"
     )
-    expect(course_requirements_page.required_qualifications).to have_content(
+    expect(course_requirements_page.required_qualifications.value).to eq(
       course.required_qualifications
     )
-    expect(course_requirements_page.personal_qualities).to have_content(
+    expect(course_requirements_page.personal_qualities.value).to eq(
       course.personal_qualities
     )
-    expect(course_requirements_page.other_requirements).to have_content(
+    expect(course_requirements_page.other_requirements.value).to eq(
       course.other_requirements
     )
 
@@ -63,5 +58,12 @@ feature 'Course requirements', type: :feature do
     )
 
     expect(current_path).to eq description_provider_course_path('AO', course.course_code)
+  end
+
+  def stub_course_request(provider, course)
+    stub_api_v2_request(
+      "/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
+      course.render
+    )
   end
 end

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -55,6 +55,82 @@ feature 'Course salary', type: :feature do
     expect(current_path).to eq description_provider_course_path('AO', course.course_code)
   end
 
+  context 'when copying course salary from another course' do
+    let(:course_2) {
+      jsonapi(
+        :course,
+        name: 'Biology',
+        provider: provider,
+        course_length: 'TwoYears',
+        salary_details: 'Course 2 salary details',
+        funding: 'salary'
+      )
+    }
+
+    let(:course_3) {
+      jsonapi(
+        :course,
+        name: 'Biology',
+        provider: provider,
+        course_length: 'TwoYears',
+        funding: 'salary'
+      )
+    }
+
+    let(:provider_for_copy_from_list) do
+      jsonapi(:provider, courses: [course, course_2, course_3], provider_code: 'AO')
+    end
+
+    before do
+      stub_course_request(provider, course_2)
+      stub_course_request(provider, course_3)
+      stub_api_v2_request("/providers/AO?include=courses.accrediting_provider", provider_for_copy_from_list.render)
+    end
+
+    scenario 'all fields get copied if all were present' do
+      copy_fees(from: course_2, to: course)
+
+      [
+        'Your changes are not yet saved',
+        'Course length',
+        'Salary details'
+      ].each do |name|
+        expect(course_salary_page.warning_message).to have_content(name)
+      end
+
+      expect(course_salary_page.course_length_one_year).to_not be_checked
+      expect(course_salary_page.course_length_two_years).to be_checked
+      expect(course_salary_page.course_salary_details.value).to eq(course_2.salary_details)
+    end
+
+    scenario 'only fields with values are copied if the source was incomplete' do
+      copy_fees(from: course_3, to: course_2)
+
+      [
+        'Your changes are not yet saved',
+        'Course length'
+      ].each do |name|
+        expect(course_salary_page.warning_message).to have_content(name)
+      end
+
+      [
+        'Salary details'
+      ].each do |name|
+        expect(course_salary_page.warning_message).not_to have_content(name)
+      end
+
+      expect(course_salary_page.course_length_one_year).to_not be_checked
+      expect(course_salary_page.course_length_two_years).to be_checked
+      expect(course_salary_page.course_salary_details.value).to eq(course_2.salary_details)
+    end
+  end
+
+  def copy_fees(from:, to:)
+    visit salary_provider_course_path(provider.provider_code, to.course_code)
+    select("#{from.name} (#{from.course_code})", from: 'Copy from')
+    click_on('Copy content')
+  end
+
   def stub_course_request(provider, course)
     stub_api_v2_request(
       "/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",

--- a/spec/site_prism/page_objects/page/organisations/course_about.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_about.rb
@@ -11,6 +11,7 @@ module PageObjects
         element :how_school_placements_work_textarea, '#course_how_school_placements_work'
         element :warning_message, '[data-copy-course=warning]'
         element :flash, '.govuk-success-summary'
+        element :warning_message, '[data-copy-course=warning]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_fees.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_fees.rb
@@ -13,6 +13,7 @@ module PageObjects
         element :fee_details, '#course_fee_details'
         element :financial_support, '#course_financial_support'
         element :flash, '.govuk-success-summary'
+        element :warning_message, '[data-copy-course=warning]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_requirements.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_requirements.rb
@@ -10,6 +10,7 @@ module PageObjects
         element :personal_qualities, '#course_personal_qualities'
         element :other_requirements, '#course_other_requirements'
         element :flash, '.govuk-success-summary'
+        element :warning_message, '[data-copy-course=warning]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_salary.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_salary.rb
@@ -10,6 +10,7 @@ module PageObjects
         element :course_length_two_years, '#course_course_length_twoyears'
         element :course_salary_details, '#course_salary_details'
         element :flash, '.govuk-success-summary'
+        element :warning_message, '[data-copy-course=warning]'
       end
     end
   end


### PR DESCRIPTION
### Context

We had some request specs but no end to end tests for copying enrichments.

### Changes proposed in this pull request

* Add interactions for selecting a course and copying it
* Checks the warning message shown
* Checks the correct values were copied
* Fixes existing checks by looking for `.value` rather than `.have_content` on an `input`

Follow up to #344 