### PR TITLE
[1617] Fix course enrichment cancel links

### DIFF
--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -82,7 +82,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', description_provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -79,7 +79,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', description_provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -55,7 +55,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', description_provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -38,7 +38,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', description_provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
       </p>
     <% end %>
   </div>


### PR DESCRIPTION
### Context
Cancel links on course enrichment pages

### Changes proposed in this pull request
Update links to go back to the description page instead of the basic details page

### Guidance to review
Check links on `/about`, `/fees`, `/salary`, `/requirements`