### PR TITLE
[1633] Fail the build when tests fail

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,3 +106,4 @@ steps:
   inputs:
     testRunner: JUnit
     testResultsFiles: '*.xml'
+    failedTaskOnFailedTest: true


### PR DESCRIPTION
### Context

Pipeline says a build is successful even when tests fail.

### Changes proposed in this pull request

Make the build fail when tests fail.

### Guidance to review
