### PR TITLE
[1624] Don't strip latest_enrichment__ from enrichment errors

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -82,7 +82,7 @@ class CoursesController < ApplicationController
     if errors.present?
       flash[:error_summary] = errors.map { |error|
         [
-          error[:title].last(error[:title].length - 'Invalid latest_enrichment__'.length),
+          error[:title].last(error[:title].length - 'Invalid '.length),
           error[:detail]
         ]
       }.to_h

--- a/spec/factories/errors.rb
+++ b/spec/factories/errors.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
       errors {
         [
           {
-            title: "Invalid latest_enrichment__about_course",
+            title: "Invalid about_course",
             detail: "About course can't be blank"
           }
         ]


### PR DESCRIPTION
### Context

This is being removed from the API, as it causes pointers to not be associated correctly.

Depends on:

- https://github.com/DFE-Digital/manage-courses-backend/pull/497

### Changes proposed in this pull request

Remove the `latest_enrichment__` prefix from course enrichment errors.