### PR TITLE
[1624] Simplify site validation errors

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -13,11 +13,7 @@ class SitesController < ApplicationController
     if @site.save
       redirect_to provider_sites_path, flash: { success: 'Your location has been created' }
     else
-      @errors = @site.errors.reduce({}) { |errors, (field, message)|
-        errors[field] ||= []
-        errors[field].push(map_errors(message))
-        errors
-      }
+      @errors = @site.errors.messages
 
       render :new
     end
@@ -37,11 +33,8 @@ class SitesController < ApplicationController
     if @site.update(site_params)
       redirect_to provider_sites_path, flash: { success: 'Your changes have been published' }
     else
-      @errors = @site.errors.reduce({}) { |errors, (field, message)|
-        errors[field] ||= []
-        errors[field].push(map_errors(message))
-        errors
-      }
+      @errors = @site.errors.messages
+
       render :edit
     end
   end
@@ -71,16 +64,5 @@ private
 
   def initialise_errors
     @errors = {}
-  end
-
-  def map_errors(message)
-    {
-      "Location name can't be blank"             => "Name is missing",
-      "Location name has already been taken"     => "Name is in use by another location",
-      "Address1 can't be blank"                  => "Building and street is missing",
-      "Address3 can't be blank"                  => "Town or city is missing",
-      "Postcode can't be blank"                  => "Postcode is missing",
-      "Postcode not recognised as a UK postcode" => "Postcode is not valid (for example, BN1 1AA)"
-    }[message] || message
   end
 end

--- a/spec/factories/errors.rb
+++ b/spec/factories/errors.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
       [
         {
           title: "Invalid location_name",
-          detail: "Location name can't be blank",
+          detail: "Name is missing",
           source: { pointer: "/data/attributes/location_name" }
         }
       ]


### PR DESCRIPTION
### Context

These are now being sent from the API with correct formatting and can be directly displayed in the frontend.

### Changes proposed in this pull request

Remove `map_errors`.