### PR TITLE
[1624] Display all site validation errors

### DIFF
--- a/app/views/sites/_error_messages.html.erb
+++ b/app/views/sites/_error_messages.html.erb
@@ -1,0 +1,7 @@
+<% if @errors[field]&.any? %>
+  <span id="<%= field.to_s %>-error" class="govuk-error-message">
+    <% @errors[field].each do |error| %>
+      <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
+    <% end %>
+  </span>
+<% end %>

--- a/app/views/sites/_errors.html.erb
+++ b/app/views/sites/_errors.html.erb
@@ -7,9 +7,9 @@
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
         <% @errors.each do |id, messages| %>
-          <li>
-            <%= link_to messages.first, "##{id.to_s}-error" %>
-          </li>
+          <% messages.each do |message| %>
+            <li><%= link_to message, "##{id.to_s}-error" %></li>
+          <% end %>
         <% end %>
       </ul>
     </div>

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -2,13 +2,7 @@
   <%= f.label :location_name, class: "govuk-label" do %>
     <h2 class="govuk-heading-m<%= " govuk-!-margin-bottom-0" if @errors[:location_name]&.any? %>">Name</h2>
   <% end %>
-  <% if @errors[:location_name]&.any? %>
-    <span id="location_name-error" class="govuk-error-message">
-      <% @errors[:location_name].each do |error| %>
-        <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
-      <% end %>
-    </span>
-  <% end %>
+  <%= render "error_messages", field: :location_name %>
   <%= f.text_field :location_name, class: "govuk-input govuk-!-width-full", aria: { describedby: @errors[:location_name] ? "location_name-error" : '' }, data: { qa: 'location__name' } %>
 </div>
 
@@ -19,13 +13,7 @@
     Building and street
     <span class="govuk-visually-hidden">line 1 of 2</span>
   <% end %>
-  <% if @errors[:address1]&.any? %>
-    <span id="address1-error" class="govuk-error-message">
-      <% @errors[:address1].each do |error| %>
-        <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
-      <% end %>
-    </span>
-  <% end %>
+  <%= render "error_messages", field: :address1 %>
   <%= f.text_field :address1, class: "govuk-input govuk-!-width-full", aria: { describedby: @errors[:address1] ? "address1-error" : '' } %>
 </div>
 
@@ -38,13 +26,7 @@
 
 <div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:address3]&.any? %>">
   <%= f.label :address3, "Town or city", class: "govuk-label" %>
-  <% if @errors[:address3]&.any? %>
-    <span id="address3-error" class="govuk-error-message">
-      <% @errors[:address3].each do |error| %>
-        <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
-      <% end %>
-    </span>
-  <% end %>
+  <%= render "error_messages", field: :address3 %>
   <%= f.text_field :address3, class: "govuk-input govuk-!-width-full", aria: { describedby: @errors[:address3] ? "address3-error" : '' } %>
 </div>
 
@@ -55,24 +37,12 @@
 
 <div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:postcode]&.any? %>">
   <%= f.label :postcode, class: "govuk-label" %>
-  <% if @errors[:postcode]&.any? %>
-    <span id="postcode-error" class="govuk-error-message">
-      <% @errors[:postcode].each do |error| %>
-        <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
-      <% end %>
-    </span>
-  <% end %>
+  <%= render "error_messages", field: :postcode %>
   <%= f.text_field :postcode, class: "govuk-input form-control-small", aria: { describedby: @errors[:postcode] ? "postcode-error" : '' } %>
 </div>
 
 <div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:region_code]&.any? %>">
   <%= f.label :region_code, "Region of UK", class: "govuk-label" %>
-  <% if @errors[:region_code]&.any? %>
-    <span id="region_code-error" class="govuk-error-message">
-      <% @errors[:region_code].each do |error| %>
-        <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
-      <% end %>
-    </span>
-  <% end %>
+  <%= render "error_messages", field: :region_code %>
   <%= f.select :region_code, Site::REGIONS, {}, class: "govuk-select", aria: { describedby: @errors[:region_code] ? "region_code-error": '' } %>
 </div>

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,10 +1,12 @@
 <div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:location_name]&.any? %>">
   <%= f.label :location_name, class: "govuk-label" do %>
-    <h2 class="govuk-heading-m">Name</h2>
+    <h2 class="govuk-heading-m<%= " govuk-!-margin-bottom-0" if @errors[:location_name]&.any? %>">Name</h2>
   <% end %>
-  <% if @errors[:location_name]&.any? then %>
+  <% if @errors[:location_name]&.any? %>
     <span id="location_name-error" class="govuk-error-message">
-      <span class="govuk-visually-hidden">Error:</span> <%= @errors[:location_name]&.first %>
+      <% @errors[:location_name].each do |error| %>
+        <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
+      <% end %>
     </span>
   <% end %>
   <%= f.text_field :location_name, class: "govuk-input govuk-!-width-full", aria: { describedby: @errors[:location_name] ? "location_name-error" : '' }, data: { qa: 'location__name' } %>
@@ -17,9 +19,11 @@
     Building and street
     <span class="govuk-visually-hidden">line 1 of 2</span>
   <% end %>
-  <% if @errors[:address1]&.any? then %>
+  <% if @errors[:address1]&.any? %>
     <span id="address1-error" class="govuk-error-message">
-      <span class="govuk-visually-hidden">Error:</span> <%= @errors[:address1]&.first %>
+      <% @errors[:address1].each do |error| %>
+        <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
+      <% end %>
     </span>
   <% end %>
   <%= f.text_field :address1, class: "govuk-input govuk-!-width-full", aria: { describedby: @errors[:address1] ? "address1-error" : '' } %>
@@ -34,9 +38,11 @@
 
 <div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:address3]&.any? %>">
   <%= f.label :address3, "Town or city", class: "govuk-label" %>
-  <% if @errors[:address3]&.any? then %>
+  <% if @errors[:address3]&.any? %>
     <span id="address3-error" class="govuk-error-message">
-      <span class="govuk-visually-hidden">Error:</span> <%= @errors[:address3]&.first %>
+      <% @errors[:address3].each do |error| %>
+        <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
+      <% end %>
     </span>
   <% end %>
   <%= f.text_field :address3, class: "govuk-input govuk-!-width-full", aria: { describedby: @errors[:address3] ? "address3-error" : '' } %>
@@ -49,9 +55,11 @@
 
 <div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:postcode]&.any? %>">
   <%= f.label :postcode, class: "govuk-label" %>
-  <% if @errors[:postcode]&.any? then %>
+  <% if @errors[:postcode]&.any? %>
     <span id="postcode-error" class="govuk-error-message">
-      <span class="govuk-visually-hidden">Error:</span> <%= @errors[:postcode]&.first %>
+      <% @errors[:postcode].each do |error| %>
+        <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
+      <% end %>
     </span>
   <% end %>
   <%= f.text_field :postcode, class: "govuk-input form-control-small", aria: { describedby: @errors[:postcode] ? "postcode-error" : '' } %>
@@ -59,9 +67,11 @@
 
 <div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:region_code]&.any? %>">
   <%= f.label :region_code, "Region of UK", class: "govuk-label" %>
-  <% if @errors[:region_code]&.any? then %>
+  <% if @errors[:region_code]&.any? %>
     <span id="region_code-error" class="govuk-error-message">
-      <span class="govuk-visually-hidden">Error:</span> <%= @errors[:region_code]&.first %>
+      <% @errors[:region_code].each do |error| %>
+        <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
+      <% end %>
     </span>
   <% end %>
   <%= f.select :region_code, Site::REGIONS, {}, class: "govuk-select", aria: { describedby: @errors[:region_code] ? "region_code-error": '' } %>

--- a/spec/factories/errors.rb
+++ b/spec/factories/errors.rb
@@ -6,6 +6,16 @@ FactoryBot.define do
           title: "Invalid location_name",
           detail: "Location name can't be blank",
           source: { pointer: "/data/attributes/location_name" }
+        },
+        {
+          title: "Invalid postcode",
+          detail: "Postcode is missing",
+          source: { pointer: "/data/attributes/postcode" }
+        },
+        {
+          title: "Invalid postcode",
+          detail: "Postcode is invalid",
+          source: { pointer: "/data/attributes/postcode" }
         }
       ]
     }

--- a/spec/features/sites/edit_spec.rb
+++ b/spec/features/sites/edit_spec.rb
@@ -48,6 +48,8 @@ feature 'Edit locations', type: :feature do
 
       expect(location_page).to be_displayed(provider_code: provider_code, site_id: site.id)
       expect(location_page.error_summary).to have_content('Name is missing')
+      expect(location_page.error_summary).to have_content('Postcode is missing')
+      expect(location_page.error_summary).to have_content('Postcode is invalid')
     end
 
     scenario 'displays the old location name when the change fails' do


### PR DESCRIPTION
### Context

These were being "swallowed" by the template. Part of refactoring validations.

### Changes proposed in this pull request

Refactor the errors template so it's DRYer and also iterate through all the errors being passed in.

Also tweak the Name heading so that it doesn't have an awkward space between it and the validation error underneath.

### Screenshots after

#### Multiple postcode errors in summary

<img width="1038" alt="Screenshot 2019-06-18 at 14 41 11" src="https://user-images.githubusercontent.com/1650875/59696194-75b65c80-91e3-11e9-8a26-213a4845896f.png">

#### Multiple postcode errors in field

<img width="669" alt="Screenshot 2019-06-18 at 14 40 30" src="https://user-images.githubusercontent.com/1650875/59696193-75b65c80-91e3-11e9-97e6-53b962d935bb.png">

#### Tweaked spacing for Name field

<img width="694" alt="Screenshot 2019-06-18 at 14 42 00" src="https://user-images.githubusercontent.com/1650875/59696195-764ef300-91e3-11e9-8022-1fa1091594d2.png">