### PR TITLE
[1624] Refer to @provider instead of course.provider in html

### DIFF
--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "About this course – #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
+  <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course, url: provider_course_path(course.provider.provider_code, course.course_code) do |f| %>
+    <%= form_with model: course, url: provider_course_path(@provider.provider_code, course.course_code) do |f| %>
       <p class="govuk-body">Give applicants a short description of the course.</p>
 
       <p class="govuk-body">You could include:</p>
@@ -82,7 +82,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', description_provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', description_provider_course_path(@provider.provider_code, course.course_code), class: "govuk-link" %>
       </p>
     <% end %>
   </div>
@@ -91,6 +91,6 @@
     <%= render partial: 'courses/related_sidebar',
                         locals: {
                           course: course,
-                          page_path: about_provider_course_path(course.provider.provider_code, course.course_code) } %>
+                          page_path: about_provider_course_path(@provider.provider_code, course.course_code) } %>
   </div>
 </div>

--- a/app/views/courses/delete.html.erb
+++ b/app/views/courses/delete.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Are you sure you want to delete #{course.name_and_code})?" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
+  <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Course length and fees - #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
+  <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course, url: provider_course_path(course.provider.provider_code, course.course_code) do |f| %>
+    <%= form_with model: course, url: provider_course_path(@provider.provider_code, course.course_code) do |f| %>
       <%= render partial: 'courses/course_length', locals: { f: f } %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
@@ -79,7 +79,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', description_provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', description_provider_course_path(@provider.provider_code, course.course_code), class: "govuk-link" %>
       </p>
     <% end %>
   </div>
@@ -87,6 +87,6 @@
     <%= render partial: 'courses/related_sidebar',
                         locals: {
                           course: course,
-                          page_path: fees_provider_course_path(course.provider.provider_code, course.course_code) } %>
+                          page_path: fees_provider_course_path(@provider.provider_code, course.course_code) } %>
   </div>
 </div>

--- a/app/views/courses/preview/_apply.html.erb
+++ b/app/views/courses/preview/_apply.html.erb
@@ -14,7 +14,7 @@
     <ul class="govuk-list">
       <li class="govuk-!-margin-bottom-2">
         Training provider code:
-        <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold"><%= course.provider.provider_code %></span>
+        <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold"><%= @provider.provider_code %></span>
       </li>
       <li>
         Training programme code:

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Requirements and eligibility – #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
+  <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course, url: provider_course_path(course.provider.provider_code, course.course_code) do |f| %>
+    <%= form_with model: course, url: provider_course_path(@provider.provider_code, course.course_code) do |f| %>
       <h3 class="govuk-heading-l remove-top-margin">Qualifications needed</h3>
 
       <p class="govuk-body">State the minimum academic qualifications needed for this course.</p>
@@ -55,7 +55,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', description_provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', description_provider_course_path(@provider.provider_code, course.course_code), class: "govuk-link" %>
       </p>
     <% end %>
   </div>
@@ -64,6 +64,6 @@
     <%= render partial: 'courses/related_sidebar',
                         locals: {
                           course: course,
-                          page_path: requirements_provider_course_path(course.provider.provider_code, course.course_code) } %>
+                          page_path: requirements_provider_course_path(@provider.provider_code, course.course_code) } %>
   </div>
 </div>

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Course length and salary - #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
+  <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course, url: provider_course_path(course.provider.provider_code, course.course_code) do |f| %>
+    <%= form_with model: course, url: provider_course_path(@provider.provider_code, course.course_code) do |f| %>
       <%= render partial: 'courses/course_length', locals: { f: f } %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
@@ -38,7 +38,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', description_provider_course_path(course.provider.provider_code, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', description_provider_course_path(@provider.provider_code, course.course_code), class: "govuk-link" %>
       </p>
     <% end %>
   </div>
@@ -46,6 +46,6 @@
     <%= render partial: 'courses/related_sidebar',
                         locals: {
                           course: course,
-                          page_path: salary_provider_course_path(course.provider.provider_code, course.course_code) } %>
+                          page_path: salary_provider_course_path(@provider.provider_code, course.course_code) } %>
   </div>
 </div>

--- a/app/views/courses/status_panel/_unpublished.html.erb
+++ b/app/views/courses/status_panel/_unpublished.html.erb
@@ -3,7 +3,7 @@
 <p class="govuk-body">See how your unpublished changes look.</p>
 <p class="govuk-body">Preview your course to check for mistakes before publishing.</p>
 <p class="govuk-body">
-  <%= link_to 'Preview course', preview_provider_course_path(course.provider.provider_code, course.course_code), class: 'govuk-link', "data-qa": "course__preview-link" %>
+  <%= link_to 'Preview course', preview_provider_course_path(@provider.provider_code, course.course_code), class: 'govuk-link', "data-qa": "course__preview-link" %>
 </p>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
@@ -11,6 +11,6 @@
 <h4 class="govuk-heading-m">Publish</h4>
 <p class="govuk-body">Publish your changes.</p>
 <p class="govuk-body">You can make changes to this course after publishing it.</p>
-<%= form_for course, url: publish_provider_course_path(course.provider.provider_code, course.course_code), method: :post do |f| %>
+<%= form_for course, url: publish_provider_course_path(@provider.provider_code, course.course_code), method: :post do |f| %>
   <%= f.submit "Publish", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: 'course__publish' } %>
 <% end %>

--- a/app/views/courses/withdraw.html.erb
+++ b/app/views/courses/withdraw.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Are you sure you want to withdraw #{course.name_and_code})?" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_course_path(course.provider.provider_code, course.course_code)) %>
+  <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
### Context

Refactoring to prepare for validations.

### Changes proposed in this pull request

The necessity of this is because when you do a `@course.update`, and it fails, the `@course.provider` is blatted away because the response from the backend API does not contain a provider, only course info. The provider info is still available in the `@provider` though.

This is also terser.

### Guidance to review

I have not manually tested this and am relying on the fact that none of these pages are live yet and mostly have coverage.