### PR TITLE
[1629] Fix other course length

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -11,6 +11,12 @@ class CoursesController < ApplicationController
   def show; end
 
   def update
+    # Course length should be saved as `course_length` so if "other" is selected then pass that text value into `course_length`
+    if params[:course][:course_length_other_length].present? && params[:course][:course_length] == 'Other'
+      params[:course][:course_length] = params[:course][:course_length_other_length]
+    end
+    params[:course].delete(:course_length_other_length)
+
     if @course.update(course_params)
       flash[:success] = 'Your changes have been saved'
       redirect_to(
@@ -99,6 +105,7 @@ private
     params.require(:course).permit(
       :about_course,
       :course_length,
+      :course_length_other_length,
       :fee_details,
       :fee_international,
       :fee_uk_eu,

--- a/app/views/courses/_course_length.html.erb
+++ b/app/views/courses/_course_length.html.erb
@@ -18,8 +18,8 @@
       </div>
       <div class="govuk-radios__conditional" id="other-container">
         <div class="form-group">
-          <%= f.label 'course_length_other', 'Course Length', class: 'govuk-label govuk-label--s', for: 'course_length_other' %>
-          <%= f.text_field 'course_length_other', value: course.course_length, class: 'govuk-input' %>
+          <%= f.label 'course_length_other_length', 'Course Length', class: 'govuk-label govuk-label--s', for: 'course_length_other_length' %>
+          <%= f.text_field 'course_length_other_length', value: course.course_length, class: 'govuk-input' %>
         </div>
       </div>
     </div>

--- a/spec/features/courses/fees_spec.rb
+++ b/spec/features/courses/fees_spec.rb
@@ -64,6 +64,28 @@ feature 'Course fees', type: :feature do
     expect(current_path).to eq description_provider_course_path('AO', course_1.course_code)
   end
 
+  context 'with course_length_other selected' do
+    let(:course_1) do
+      jsonapi(
+        :course,
+        :with_fees,
+        course_length: '6 months',
+        provider: provider
+      )
+    end
+
+    scenario 'passes the value into course_length' do
+      visit description_provider_course_path(provider.provider_code, course_1.course_code)
+
+      click_on 'Course length and fees'
+
+      expect(current_path).to eq fees_provider_course_path('AO', course_1.course_code)
+
+      expect(course_fees_page.course_length_other).to be_checked
+      expect(course_fees_page.course_length_other_length.value).to eq('6 months')
+    end
+  end
+
   context 'when copying course fees from another course' do
     let(:course_2) {
       jsonapi(

--- a/spec/site_prism/page_objects/page/organisations/course_fees.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_fees.rb
@@ -8,6 +8,8 @@ module PageObjects
         element :caption, '.govuk-caption-xl'
         element :course_length_one_year, '#course_course_length_oneyear'
         element :course_length_two_years, '#course_course_length_twoyears'
+        element :course_length_other, '#course_course_length_other'
+        element :course_length_other_length, '#course_course_length_other_length'
         element :course_fees_uk_eu, '#course_fee_uk_eu'
         element :course_fees_international, '#course_fee_international'
         element :fee_details, '#course_fee_details'


### PR DESCRIPTION
### Context
Setting "other" course length

### Changes proposed in this pull request
Pass across the "other" length into `course_length` when the user has selected it

### Guidance to review
Try setting "other" for course length