### PR TITLE
[1624] Display error summary at top of enrichment pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,6 +119,9 @@ group :test do
 
   # Page object for Capybara
   gem 'site_prism'
+
+  # Allows assert_template in request specs
+  gem 'rails-controller-testing'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,6 +275,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.3)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -442,6 +446,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.12)
   rails (~> 5.2.3)
+  rails-controller-testing
   redcarpet
   rspec-rails (~> 3.8)
   rspec_junit_formatter

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,6 @@
 class CoursesController < ApplicationController
   decorates_assigned :course
+  before_action :initialise_errors
   before_action :build_courses, only: %i[index about requirements fees salary]
   before_action :build_course, except: :index
   before_action :build_provider, except: :index
@@ -25,6 +26,10 @@ class CoursesController < ApplicationController
           @course.course_code
         )
       )
+    else
+      @errors = @course.errors.messages
+
+      render course_params["page"].to_sym
     end
   end
 
@@ -103,6 +108,7 @@ private
 
   def course_params
     params.require(:course).permit(
+      :page,
       :about_course,
       :course_length,
       :course_length_other_length,
@@ -183,5 +189,9 @@ private
   def copy_field_if_present_in_source_course(field)
     source_value = @source_course[field]
     course[field] = source_value if source_value.present?
+  end
+
+  def initialise_errors
+    @errors = {}
   end
 end

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -7,6 +7,8 @@
 <%= render partial: 'courses/copy_content_warning',
                     locals: { copied_fields: @copied_fields } if params[:copy_from].present? %>
 
+<%= render 'shared/errors' %>
+
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>
   About this course
@@ -14,7 +16,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course, url: provider_course_path(@provider.provider_code, course.course_code) do |f| %>
+    <%= form_with model: course, url: about_provider_course_path(@provider.provider_code, course.course_code) do |f| %>
+      <%= f.hidden_field :page, value: :about %>
       <p class="govuk-body">Give applicants a short description of the course.</p>
 
       <p class="govuk-body">You could include:</p>

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -7,6 +7,8 @@
 <%= render partial: 'courses/copy_content_warning',
                     locals: { copied_fields: @copied_fields } if params[:copy_from].present? %>
 
+<%= render 'shared/errors' %>
+
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>
   Course length and fees
@@ -14,7 +16,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course, url: provider_course_path(@provider.provider_code, course.course_code) do |f| %>
+    <%= form_with model: course, url: fees_provider_course_path(@provider.provider_code, course.course_code) do |f| %>
+      <%= f.hidden_field :page, value: :fees %>
       <%= render partial: 'courses/course_length', locals: { f: f } %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -7,6 +7,8 @@
 <%= render partial: 'courses/copy_content_warning',
                     locals: { copied_fields: @copied_fields } if params[:copy_from].present? %>
 
+<%= render 'shared/errors' %>
+
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>
   Requirements and eligibility
@@ -14,7 +16,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course, url: provider_course_path(@provider.provider_code, course.course_code) do |f| %>
+    <%= form_with model: course, url: requirements_provider_course_path(@provider.provider_code, course.course_code) do |f| %>
+      <%= f.hidden_field :page, value: :requirements %>
       <h3 class="govuk-heading-l remove-top-margin">Qualifications needed</h3>
 
       <p class="govuk-body">State the minimum academic qualifications needed for this course.</p>

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -7,6 +7,8 @@
 <%= render partial: 'courses/copy_content_warning',
                     locals: { copied_fields: @copied_fields } if params[:copy_from].present? %>
 
+<%= render 'shared/errors' %>
+
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>
   Course length and salary
@@ -14,7 +16,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course, url: provider_course_path(@provider.provider_code, course.course_code) do |f| %>
+    <%= form_with model: course, url: salary_provider_course_path(@provider.provider_code, course.course_code) do |f| %>
+      <%= f.hidden_field :page, value: :salary %>
       <%= render partial: 'courses/course_length', locals: { f: f } %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,16 @@ Rails.application.routes.draw do
       get '/vacancies', on: :member, to: 'courses/vacancies#edit'
       put '/vacancies', on: :member, to: 'courses/vacancies#update'
       get '/description', on: :member, to: 'courses#description'
+
       get '/about', on: :member, to: 'courses#about'
+      patch '/about', on: :member, to: 'courses#update'
       get '/requirements', on: :member, to: 'courses#requirements'
+      patch '/requirements', on: :member, to: 'courses#update'
       get '/fees', on: :member, to: 'courses#fees'
+      patch '/fees', on: :member, to: 'courses#update'
       get '/salary', on: :member, to: 'courses#salary'
+      patch '/salary', on: :member, to: 'courses#update'
+
       get '/withdraw', on: :member, to: 'courses#withdraw'
       get '/delete', on: :member, to: 'courses#delete'
       get '/preview', on: :member, to: 'courses#preview'

--- a/spec/requests/courses/about_spec.rb
+++ b/spec/requests/courses/about_spec.rb
@@ -83,6 +83,7 @@ describe 'Courses', type: :request do
 
     let(:course_params) do
       {
+        page: "about",
         about_course: "Something about this course",
         how_school_placements_work: "Something about how school placements work",
         interview_process: "Something about the interview process",
@@ -128,12 +129,27 @@ describe 'Courses', type: :request do
           }
         }.to_json)
 
-        patch provider_course_path(provider.provider_code, course.course_code), params: request_params
+        patch about_provider_course_path(provider.provider_code, course.course_code), params: request_params
       end
 
       it 'redirects to the course description page' do
         expect(flash[:success]).to include('Your changes have been saved')
         expect(response).to redirect_to(description_provider_course_path(provider.provider_code, course.course_code))
+      end
+    end
+
+    context "with errors" do
+      before do
+        stub_api_v2_request(
+          "/providers/#{provider.provider_code}/courses/#{course.course_code}",
+          build(:error, :for_course_publish), :patch, 422
+        )
+
+        patch about_provider_course_path(provider.provider_code, course.course_code), params: request_params
+      end
+
+      it 'redirects to the course about page' do
+        expect(response).to render_template :about
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -4,8 +4,6 @@ module PageObjects
       class Course < CourseBase
         set_url '/organisations/{provider_code}/courses/{course_code}'
 
-        element :title, '.govuk-heading-xl'
-        element :caption, '.govuk-caption-xl'
         element :qualifications, '[data-qa=course__qualifications]'
         element :study_mode, '[data-qa=course__study_mode]'
         element :start_date, '[data-qa=course__start_date]'

--- a/spec/site_prism/page_objects/page/organisations/course_about.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_about.rb
@@ -4,17 +4,9 @@ module PageObjects
       class CourseAbout < CourseBase
         set_url '/organisations/{provider_code}/courses/{course_code}/about'
 
-        element :title, '.govuk-heading-xl'
-        element :caption, '.govuk-caption-xl'
         element :about_textarea, '#course_about_course'
         element :interview_process_textarea, '#course_interview_process'
         element :how_school_placements_work_textarea, '#course_how_school_placements_work'
-        element :warning_message, '[data-copy-course=warning]'
-        element :flash, '.govuk-success-summary'
-        element :error_flash, '.govuk-error-summary'
-        element :warning_message, '[data-copy-course=warning]'
-
-        section :copy_content, PageObjects::Section::CopyContentSection
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_about.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_about.rb
@@ -11,6 +11,7 @@ module PageObjects
         element :how_school_placements_work_textarea, '#course_how_school_placements_work'
         element :warning_message, '[data-copy-course=warning]'
         element :flash, '.govuk-success-summary'
+        element :error_flash, '.govuk-error-summary'
         element :warning_message, '[data-copy-course=warning]'
 
         section :copy_content, PageObjects::Section::CopyContentSection

--- a/spec/site_prism/page_objects/page/organisations/course_base.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_base.rb
@@ -5,6 +5,14 @@ module PageObjects
         def load_with_course(course)
           self.load(provider_code: course.provider_code, course_code: course.course_code)
         end
+
+        element :title, '.govuk-heading-xl'
+        element :caption, '.govuk-caption-xl'
+        element :flash, '.govuk-success-summary'
+        element :error_flash, '.govuk-error-summary'
+        element :warning_message, '[data-copy-course=warning]'
+
+        section :copy_content, PageObjects::Section::CopyContentSection
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_description.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_description.rb
@@ -1,11 +1,9 @@
 module PageObjects
   module Page
     module Organisations
-      class CourseDescription < PageObjects::Base
+      class CourseDescription < CourseBase
         set_url '/organisations/{provider_code}/courses/{course_code}/description'
 
-        element :title, '.govuk-heading-xl'
-        element :caption, '.govuk-caption-xl'
         element :about, '[data-qa=course__about_course]'
         element :interview_process, '[data-qa=course__interview_process]'
         element :placements_info, '[data-qa=course__how_school_placements_work]'

--- a/spec/site_prism/page_objects/page/organisations/course_fees.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_fees.rb
@@ -15,6 +15,7 @@ module PageObjects
         element :fee_details, '#course_fee_details'
         element :financial_support, '#course_financial_support'
         element :flash, '.govuk-success-summary'
+        element :error_flash, '.govuk-error-summary'
         element :warning_message, '[data-copy-course=warning]'
 
         section :copy_content, PageObjects::Section::CopyContentSection

--- a/spec/site_prism/page_objects/page/organisations/course_fees.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_fees.rb
@@ -4,8 +4,6 @@ module PageObjects
       class CourseFees < CourseBase
         set_url '/organisations/{provider_code}/courses/{course_code}/fees'
 
-        element :title, '.govuk-heading-xl'
-        element :caption, '.govuk-caption-xl'
         element :course_length_one_year, '#course_course_length_oneyear'
         element :course_length_two_years, '#course_course_length_twoyears'
         element :course_length_other, '#course_course_length_other'
@@ -14,11 +12,6 @@ module PageObjects
         element :course_fees_international, '#course_fee_international'
         element :fee_details, '#course_fee_details'
         element :financial_support, '#course_financial_support'
-        element :flash, '.govuk-success-summary'
-        element :error_flash, '.govuk-error-summary'
-        element :warning_message, '[data-copy-course=warning]'
-
-        section :copy_content, PageObjects::Section::CopyContentSection
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_locations.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_locations.rb
@@ -1,11 +1,9 @@
 module PageObjects
   module Page
     module Organisations
-      class CourseLocations < PageObjects::Base
+      class CourseLocations < CourseBase
         set_url '/organisations/{provider_code}/courses/{course_code}/locations'
 
-        element :title, '.govuk-heading-xl'
-        element :caption, '.govuk-caption-xl'
         element :success_summary, '.govuk-success-summary'
         element :error_summary, '.govuk-error-summary'
         element :save, '[data-qa=course__save]'

--- a/spec/site_prism/page_objects/page/organisations/course_preview.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_preview.rb
@@ -4,7 +4,6 @@ module PageObjects
       class CoursePreview < PageObjects::Base
         set_url '/organisations/{provider_code}/courses/{course_code}/preview'
 
-        element :title, '.govuk-heading-xl'
         element :sub_title, '[data-qa=course__provider_name]'
         element :description, '[data-qa=course__description]'
         element :accredited_body, '[data-qa=course__accredited_body]'

--- a/spec/site_prism/page_objects/page/organisations/course_requirements.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_requirements.rb
@@ -4,16 +4,9 @@ module PageObjects
       class CourseRequirements < CourseBase
         set_url '/organisations/{provider_code}/courses/{course_code}/requirements'
 
-        element :title, '.govuk-heading-xl'
-        element :caption, '.govuk-caption-xl'
         element :required_qualifications, '#course_required_qualifications'
         element :personal_qualities, '#course_personal_qualities'
         element :other_requirements, '#course_other_requirements'
-        element :flash, '.govuk-success-summary'
-        element :error_flash, '.govuk-error-summary'
-        element :warning_message, '[data-copy-course=warning]'
-
-        section :copy_content, PageObjects::Section::CopyContentSection
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_requirements.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_requirements.rb
@@ -10,6 +10,7 @@ module PageObjects
         element :personal_qualities, '#course_personal_qualities'
         element :other_requirements, '#course_other_requirements'
         element :flash, '.govuk-success-summary'
+        element :error_flash, '.govuk-error-summary'
         element :warning_message, '[data-copy-course=warning]'
 
         section :copy_content, PageObjects::Section::CopyContentSection

--- a/spec/site_prism/page_objects/page/organisations/course_salary.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_salary.rb
@@ -10,6 +10,7 @@ module PageObjects
         element :course_length_two_years, '#course_course_length_twoyears'
         element :course_salary_details, '#course_salary_details'
         element :flash, '.govuk-success-summary'
+        element :error_flash, '.govuk-error-summary'
         element :warning_message, '[data-copy-course=warning]'
 
         section :copy_content, PageObjects::Section::CopyContentSection

--- a/spec/site_prism/page_objects/page/organisations/course_salary.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_salary.rb
@@ -4,16 +4,9 @@ module PageObjects
       class CourseSalary < CourseBase
         set_url '/organisations/{provider_code}/courses/{course_code}/salary'
 
-        element :title, '.govuk-heading-xl'
-        element :caption, '.govuk-caption-xl'
         element :course_length_one_year, '#course_course_length_oneyear'
         element :course_length_two_years, '#course_course_length_twoyears'
         element :course_salary_details, '#course_salary_details'
-        element :flash, '.govuk-success-summary'
-        element :error_flash, '.govuk-error-summary'
-        element :warning_message, '[data-copy-course=warning]'
-
-        section :copy_content, PageObjects::Section::CopyContentSection
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/courses.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses.rb
@@ -4,7 +4,6 @@ module PageObjects
       class Courses < PageObjects::Base
         set_url '/organisations/{provider_code}/courses'
 
-        element :title, '.govuk-heading-xl'
         sections :courses_tables, '[data-qa="courses__table-section"]' do
           element :subheading, 'h2'
           sections :rows, 'tbody tr' do


### PR DESCRIPTION
### Context

We need to display validation errors when users save course description fields.

### Changes proposed in this pull request

Renders the shared errors template at the top of the about, fees, salary, and requirements pages.

The forms are updated to each contain a hidden field, for the `page` that they correspond to, to allow the `courses#update` action to render the correct page when responding with validation errors.

4 new `patch` routes are created, one for each page. This is because on the regular `update` endpoint, the URL is `/organisations/ORG/courses/CRS`. If a user takes this URL and submits it in the same browser tab, they'll be taken to the basic details, which is confusing.

### Guidance to review

There will be a follow-up PR to implement the red highlights on the form fields.

### Screenshots

<img width="1013" alt="Screenshot 2019-06-19 at 14 31 50" src="https://user-images.githubusercontent.com/1650875/59770856-955f8a80-92a0-11e9-85e5-3442a6294c32.png">
<img width="1014" alt="Screenshot 2019-06-19 at 14 33 07" src="https://user-images.githubusercontent.com/1650875/59770858-95f82100-92a0-11e9-99d4-5317b12e43ab.png">
<img width="1025" alt="Screenshot 2019-06-19 at 14 33 26" src="https://user-images.githubusercontent.com/1650875/59770859-95f82100-92a0-11e9-86c6-56361180deaf.png">
