### PR TITLE
[1624] Abstract site form field logic into partial

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -61,4 +61,25 @@ module ViewHelper
   def beta_banner_environment_label
     Settings.environment.label
   end
+
+  # Ad-hoc, informally specified, and bug-ridden Ruby implementation of half
+  # of https://github.com/JedWatson/classnames.
+  #
+  # Example usage:
+  #   <input class="<%= cns("govuk-input", "govuk-input--width-10": is_small) %>">
+  def classnames(*args)
+    args.reduce('') do |str, arg|
+      classes =
+        if arg.is_a? Hash
+          arg.reduce([]) { |cs, (classname, condition)| cs + [condition ? classname : nil] }
+        elsif arg.is_a? String
+          [arg]
+        else
+          []
+        end
+      ([str] + classes).reject(&:blank?).join(' ')
+    end
+  end
+
+  alias_method :cns, :classnames
 end

--- a/app/views/shared/_form_field.html.erb
+++ b/app/views/shared/_form_field.html.erb
@@ -1,21 +1,9 @@
 <%
   label ||= field.to_s.humanize
-  type ||= :text_field
-  qa ||= ''
-  select_options ||= []
-  small ||= false
-  input_options = {
-    class: cns(
-      "govuk-input": type != :select,
-      "govuk-select": type == :select,
-      "govuk-input--width-10": small
-    ),
-    aria: {
-      describedby: @errors[field] ? "#{field.to_s}-error" : ''
-    },
-    data: {
-      qa: qa
-    }
+  options = {
+    class: "govuk-input",
+    aria: { describedby: @errors[field] ? "#{field.to_s}-error" : '' },
+    data: { qa: field.to_s }
   }
 %>
 
@@ -24,9 +12,5 @@
 
   <%= render "shared/error_messages", field: field %>
 
-  <% if type == :select %>
-    <%= form.send type, field, select_options, {}, input_options %>
-  <% else %>
-    <%= form.send type, field, input_options %>
-  <% end %>
+  <%= yield([field, options]) %>
 </div>

--- a/app/views/shared/_form_field.html.erb
+++ b/app/views/shared/_form_field.html.erb
@@ -1,0 +1,32 @@
+<%
+  label ||= field.to_s.humanize
+  type ||= :text_field
+  qa ||= ''
+  select_options ||= []
+  small ||= false
+  input_options = {
+    class: cns(
+      "govuk-input": type != :select,
+      "govuk-select": type == :select,
+      "govuk-input--width-10": small
+    ),
+    aria: {
+      describedby: @errors[field] ? "#{field.to_s}-error" : ''
+    },
+    data: {
+      qa: qa
+    }
+  }
+%>
+
+<div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors[field]&.any?) %>">
+  <%= form.label field, label, class: "govuk-label" %>
+
+  <%= render "shared/error_messages", field: field %>
+
+  <% if type == :select %>
+    <%= form.send type, field, select_options, {}, input_options %>
+  <% else %>
+    <%= form.send type, field, input_options %>
+  <% end %>
+</div>

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,48 +1,36 @@
-<div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:location_name]&.any? %>">
-  <%= f.label :location_name, class: "govuk-label" do %>
-    <h2 class="govuk-heading-m<%= " govuk-!-margin-bottom-0" if @errors[:location_name]&.any? %>">Name</h2>
-  <% end %>
-  <%= render "shared/error_messages", field: :location_name %>
-  <%= f.text_field :location_name, class: "govuk-input govuk-!-width-full", aria: { describedby: @errors[:location_name] ? "location_name-error" : '' }, data: { qa: 'location__name' } %>
-</div>
+<%= render "shared/form_field",
+  form: f, field: :location_name, qa: 'location__name', label: capture { %>
+    <h2 class="<%= cns("govuk-heading-m", "govuk-!-margin-bottom-0": @errors[:location_name]&.any?) %>">Name</h2>
+  <% }
+%>
 
 <h2 class="govuk-heading-m govuk-!-margin-top-8">Address</h2>
 
-<div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:address1]&.any? %>">
-  <%= f.label :address1, class: "govuk-label" do %>
+<%= render "shared/form_field",
+  form: f, field: :address1, label: capture { %>
     Building and street
     <span class="govuk-visually-hidden">line 1 of 2</span>
-  <% end %>
-  <%= render "shared/error_messages", field: :address1 %>
-  <%= f.text_field :address1, class: "govuk-input govuk-!-width-full", aria: { describedby: @errors[:address1] ? "address1-error" : '' } %>
-</div>
+  <% }
+%>
 
-<div class="govuk-form-group">
-  <%= f.label :address2, class: "govuk-label" do %>
+<%= render "shared/form_field",
+  form: f, field: :address2, label: capture { %>
     <span class="govuk-visually-hidden">line 2 of 2</span>
-  <% end %>
-  <%= f.text_field :address2, class: "govuk-input govuk-!-width-full" %>
-</div>
+  <% }
+%>
 
-<div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:address3]&.any? %>">
-  <%= f.label :address3, "Town or city", class: "govuk-label" %>
-  <%= render "shared/error_messages", field: :address3 %>
-  <%= f.text_field :address3, class: "govuk-input govuk-!-width-full", aria: { describedby: @errors[:address3] ? "address3-error" : '' } %>
-</div>
+<%= render "shared/form_field",
+  form: f, field: :address3, label: "Town or city"
+%>
 
-<div class="govuk-form-group">
-  <%= f.label :address4, "County", class: "govuk-label" %>
-  <%= f.text_field :address4, class: "govuk-input govuk-!-width-full" %>
-</div>
+<%= render "shared/form_field",
+  form: f, field: :address4, label: "County"
+%>
 
-<div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:postcode]&.any? %>">
-  <%= f.label :postcode, class: "govuk-label" %>
-  <%= render "shared/error_messages", field: :postcode %>
-  <%= f.text_field :postcode, class: "govuk-input form-control-small", aria: { describedby: @errors[:postcode] ? "postcode-error" : '' } %>
-</div>
+<%= render "shared/form_field",
+  form: f, field: :postcode, small: true
+%>
 
-<div class="govuk-form-group<%= " govuk-form-group--error" if @errors[:region_code]&.any? %>">
-  <%= f.label :region_code, "Region of UK", class: "govuk-label" %>
-  <%= render "shared/error_messages", field: :region_code %>
-  <%= f.select :region_code, Site::REGIONS, {}, class: "govuk-select", aria: { describedby: @errors[:region_code] ? "region_code-error": '' } %>
-</div>
+<%= render "shared/form_field",
+  form: f, field: :region_code, label: "Region of UK", type: :select, select_options: Site::REGIONS
+%>

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,8 +1,9 @@
 <%= render "shared/form_field",
-  form: f, field: :location_name, qa: 'location__name', label: capture { %>
+  form: f, field: :location_name, label: capture { %>
     <h2 class="<%= cns("govuk-heading-m", "govuk-!-margin-bottom-0": @errors[:location_name]&.any?) %>">Name</h2>
-  <% }
-%>
+  <% } do |field, options| %>
+  <%= f.text_field field, options %>
+<% end %>
 
 <h2 class="govuk-heading-m govuk-!-margin-top-8">Address</h2>
 
@@ -10,27 +11,33 @@
   form: f, field: :address1, label: capture { %>
     Building and street
     <span class="govuk-visually-hidden">line 1 of 2</span>
-  <% }
-%>
+  <% } do |field, options| %>
+  <%= f.text_field field, options %>
+<% end %>
 
 <%= render "shared/form_field",
   form: f, field: :address2, label: capture { %>
     <span class="govuk-visually-hidden">line 2 of 2</span>
-  <% }
-%>
+  <% } do |field, options| %>
+  <%= f.text_field field, options %>
+<% end %>
 
 <%= render "shared/form_field",
-  form: f, field: :address3, label: "Town or city"
-%>
+  form: f, field: :address3, label: "Town or city" do |field, options| %>
+  <%= f.text_field field, options.merge(class: 'govuk-input govuk-!-width-two-thirds') %>
+<% end %>
 
 <%= render "shared/form_field",
-  form: f, field: :address4, label: "County"
-%>
+  form: f, field: :address4, label: "County" do |field, options| %>
+  <%= f.text_field field, options.merge(class: 'govuk-input govuk-!-width-two-thirds') %>
+<% end %>
 
 <%= render "shared/form_field",
-  form: f, field: :postcode, small: true
-%>
+  form: f, field: :postcode do |field, options| %>
+  <%= f.text_field field, options.merge(class: 'govuk-input govuk-input--width-10') %>
+<% end %>
 
 <%= render "shared/form_field",
-  form: f, field: :region_code, label: "Region of UK", type: :select, select_options: Site::REGIONS
-%>
+  form: f, field: :region_code, label: "Region of UK" do |field, options| %>
+  <%= f.select field, Site::REGIONS, {}, options.merge(class: 'govuk-select') %>
+<% end %>

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -31,4 +31,18 @@ RSpec.feature 'View helpers', type: :helper do
       expect(helper.manage_ui_enrichment_error_url(provider_code: 'A1', course: course, field: 'about_course')).to eq("https://localhost:44364/organisation/A1/course/self/#{course.course_code}/about#AboutCourse-wrapper")
     end
   end
+
+  describe "#classnames #cns" do
+    it "returns joined classname strings" do
+      expect(helper.cns('foo', 'bar')).to eq 'foo bar'
+      expect(helper.cns('foo', bar: true)).to eq 'foo bar'
+      expect(helper.cns('foo-bar': true)).to eq 'foo-bar'
+      expect(helper.cns('foo-bar': false)).to eq ''
+      expect(helper.cns({ foo: true }, bar: true)).to eq 'foo bar'
+      expect(helper.cns(foo: true, bar: true)).to eq 'foo bar'
+      expect(helper.cns('foo', { bar: true, duck: false }, 'baz', quux: true)).to eq 'foo bar baz quux'
+      # Warning: different to reference implementation. Ignores integers.
+      expect(helper.cns(nil, false, 'bar', Object, 0, 1, { baz: nil }, '')).to eq 'bar'
+    end
+  end
 end

--- a/spec/site_prism/page_objects/page/location_page.rb
+++ b/spec/site_prism/page_objects/page/location_page.rb
@@ -5,7 +5,7 @@ module PageObjects
       set_url_matcher(%r{/organisations/.*?/locations/\d+(/edit)?$})
 
       element :title, 'h1'
-      element :name_field, 'input[data-qa="location__name"]'
+      element :name_field, 'input[data-qa="location_name"]'
       element :publish_changes, '[data-qa="location__publish-changes"]'
       element :error_summary, '.govuk-error-summary'
     end


### PR DESCRIPTION
### Context

This uses the [capture](https://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html) feature I recently discovered to create a reusable partial for the site form fields. This will be reused in the enrichment validations.

### Changes proposed in this pull request

Simplifies `site/_form` by creating a reusable `_field_with_error` partial / component.

### Guidance to review

There should already be adequate test coverage for this, this is just a refactor.

If we're happy with this pattern of doing a reusable frontend template, I would like to extend it to other parts of the frontend. In the future, we can switch to [ActionView::Component](https://github.com/rails/rails/pull/36388).