### PR TITLE
Fix success summary and enrichment back links

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -98,7 +98,7 @@ class CoursesController < ApplicationController
         ]
       }.to_h
     else
-      flash[:success] = "Your course has been published. The link for this course is: #{Settings.search_ui.base_url}/course/#{@provider.provider_code}/#{@course.course_code}"
+      flash[:success] = "Your course has been published."
     end
 
     redirect_to description_provider_course_path(@provider.provider_code, @course.course_code)

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "About this course – #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>
+  <%= govuk_back_link_to(description_provider_course_path(@provider.provider_code, course.course_code)) %>
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Course length and fees - #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>
+  <%= govuk_back_link_to(description_provider_course_path(@provider.provider_code, course.course_code)) %>
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Requirements and eligibility – #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>
+  <%= govuk_back_link_to(description_provider_course_path(@provider.provider_code, course.course_code)) %>
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Course length and salary - #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_course_path(@provider.provider_code, course.course_code)) %>
+  <%= govuk_back_link_to(description_provider_course_path(@provider.provider_code, course.course_code)) %>
 <% end %>
 
 <%= render partial: 'courses/copy_content_warning',

--- a/spec/features/courses/description_spec.rb
+++ b/spec/features/courses/description_spec.rb
@@ -212,7 +212,8 @@ feature 'Course description', type: :feature do
           course_page.publish.click
 
           expect(course_page).to be_displayed
-          expect(course_page.success_summary).to have_content("Your course has been published. The link for this course is: https://localhost:5000/course/#{provider.provider_code}/#{course.course_code}")
+          expect(course_page.success_summary).to have_content("Your course has been published.")
+          expect(course_page.success_summary).to have_content("The link for this course is: https://localhost:5000/course/#{provider.provider_code}/#{course.course_code}")
         end
       end
 


### PR DESCRIPTION
### Context

- Back links on enrichment pages linked to the Basic details tab rather than the Description tab
- The success summary on publishing duplicated the publish message

### Before
![Screen Shot 2019-06-20 at 12 08 36](https://user-images.githubusercontent.com/319055/59845645-c4840380-9355-11e9-97d3-fafa72b27880.png)