### PR TITLE
[1669] Iterate vacancies design for single site/single study mode courses

### DIFF
--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -8,6 +8,39 @@ module Courses
     def edit; end
 
     def update
+      unless params[:change_vacancies_confirmation]
+        error_message = if @course.has_vacancies?
+                          "Please confirm there are no vacancies to close applications"
+                        else
+                          "Please confirm there are vacancies to reopen applications"
+                        end
+        @errors = { change_vacancies_confirmation: [error_message] }
+        return render(:edit)
+      end
+
+      @course.has_multiple_running_sites_or_study_modes? ? update_vacancies_for_multiple_sites : update_vacancies_for_a_single_site
+      @course.sync_with_search_and_compare(provider_code: params[:provider_code])
+      flash[:success] = 'Course vacancies published'
+      redirect_to provider_courses_path(params[:provider_code])
+    end
+
+  private
+
+    def update_vacancies_for_a_single_site
+      case params[:change_vacancies_confirmation]
+      when 'no_vacancies_confirmation'
+        vac_status = 'no_vacancies'
+      when 'has_vacancies_confirmation'
+        vac_status = @course.full_time? ? "full_time_vacancies" : "part_time_vacancies"
+      end
+
+      @site_statuses.each do |site_status|
+        site_status.vac_status = vac_status
+        site_status.save
+      end
+    end
+
+    def update_vacancies_for_multiple_sites
       params.dig(:course, :site_status_attributes)
         &.values&.each do |vacancy_status|
           site_status = find_site_status vacancy_status[:id]
@@ -23,21 +56,14 @@ module Courses
                                    end
           site_status.save
         end
-
-      @course.sync_with_search_and_compare(provider_code: params[:provider_code])
-
-      flash[:success] = 'Course vacancies published'
-      redirect_to provider_courses_path(params[:provider_code])
     end
-
-  private
 
     def build_course
       @course = Course.includes(site_statuses: [:site]).where(provider_code: params[:provider_code]).find(params[:code]).first
     end
 
     def build_site_statuses
-      @site_statuses = @course.site_statuses.select(&:running?)
+      @site_statuses = @course.running_site_statuses
     end
 
     def find_site_status(id)

--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -9,12 +9,7 @@ module Courses
 
     def update
       unless params[:change_vacancies_confirmation]
-        error_message = if @course.has_vacancies?
-                          "Please confirm there are no vacancies to close applications"
-                        else
-                          "Please confirm there are vacancies to reopen applications"
-                        end
-        @errors = { change_vacancies_confirmation: [error_message] }
+        set_missing_confirmation_error
         return render(:edit)
       end
 
@@ -25,6 +20,16 @@ module Courses
     end
 
   private
+
+    def set_missing_confirmation_error
+      error_message = if @course.has_vacancies?
+                        "Please confirm there are no vacancies to close applications"
+                      else
+                        "Please confirm there are vacancies to reopen applications"
+                      end
+
+      @errors = { change_vacancies_confirmation: [error_message] }
+    end
 
     def update_vacancies_for_a_single_site
       case params[:change_vacancies_confirmation]

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -46,4 +46,12 @@ class Course < Base
   def is_published?
     content_status == 'published'
   end
+
+  def running_site_statuses
+    site_statuses.select(&:running?)
+  end
+
+  def has_multiple_running_sites_or_study_modes?
+    running_site_statuses.length > 1 || full_time_or_part_time?
+  end
 end

--- a/app/views/courses/vacancies/_multiple_sites.html.erb
+++ b/app/views/courses/vacancies/_multiple_sites.html.erb
@@ -21,10 +21,10 @@
       <fieldset class="govuk-fieldset" aria-describedby="has_vacancies_true_hint">
         <div class="govuk-checkboxes">
           <%= f.fields_for :site_status, @site_statuses.sort_by { |status| status.site.location_name } do |sf| %>
-            <% if @course.study_mode == 'full_time_or_part_time' %>
+            <% if @course.full_time_or_part_time? %>
               <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :part_time, show_study_mode: true } %>
               <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :full_time, show_study_mode: true } %>
-            <% elsif @course.study_mode == 'full_time' || @course.study_mode == 'part_time' %>
+            <% elsif @course.full_time? || @course.part_time? %>
               <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: @course.study_mode } %>
             <% end %>
           <% end %>

--- a/app/views/courses/vacancies/_multiple_sites.html.erb
+++ b/app/views/courses/vacancies/_multiple_sites.html.erb
@@ -1,0 +1,35 @@
+<div class="govuk-radios govuk-!-margin-bottom-7" data-module="radios">
+  <div class="govuk-radios__item">
+    <%= f.radio_button :has_vacancies, 'false', class: 'govuk-radios__input', checked: !@course.has_vacancies? %>
+    <%= f.label :has_vacancies_false, 'There are no vacancies', class: "govuk-label govuk-radios__label govuk-!-font-weight-bold" %>
+    <span id="has_vacancies_false" class="govuk-hint govuk-radios__hint">
+      Close this course to new applications.
+      <br>
+      You can reopen a course later.
+    </span>
+  </div>
+  <div class="govuk-radios__divider">or</div>
+  <div class="govuk-radios__item">
+    <%= f.radio_button :has_vacancies, 'true', class: 'govuk-radios__input', checked: @course.has_vacancies?, "aria-controls" => "has_vacancies_true_conditional" %>
+    <%= f.label :has_vacancies_true, 'There are some vacancies', class: "govuk-label govuk-radios__label govuk-!-font-weight-bold" %>
+    <span id="has_vacancies_true_hint" class="govuk-hint govuk-radios__hint">
+      Pick the locations with vacancies
+    </span>
+  </div>
+  <div class="govuk-radios__conditional <%= 'govuk-radios__conditional--hidden' if !@course.has_vacancies? %>" id="has_vacancies_true_conditional">
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset" aria-describedby="has_vacancies_true_hint">
+        <div class="govuk-checkboxes">
+          <%= f.fields_for :site_status, @site_statuses.sort_by { |status| status.site.location_name } do |sf| %>
+            <% if @course.study_mode == 'full_time_or_part_time' %>
+              <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :part_time, show_study_mode: true } %>
+              <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :full_time, show_study_mode: true } %>
+            <% elsif @course.study_mode == 'full_time' || @course.study_mode == 'part_time' %>
+              <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: @course.study_mode } %>
+            <% end %>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+</div>

--- a/app/views/courses/vacancies/_multiple_sites.html.erb
+++ b/app/views/courses/vacancies/_multiple_sites.html.erb
@@ -1,35 +1,38 @@
-<div class="govuk-radios govuk-!-margin-bottom-7" data-module="radios">
-  <div class="govuk-radios__item">
-    <%= f.radio_button :has_vacancies, 'false', class: 'govuk-radios__input', checked: !@course.has_vacancies? %>
-    <%= f.label :has_vacancies_false, 'There are no vacancies', class: "govuk-label govuk-radios__label govuk-!-font-weight-bold" %>
-    <span id="has_vacancies_false" class="govuk-hint govuk-radios__hint">
-      Close this course to new applications.
-      <br>
-      You can reopen a course later.
-    </span>
-  </div>
-  <div class="govuk-radios__divider">or</div>
-  <div class="govuk-radios__item">
-    <%= f.radio_button :has_vacancies, 'true', class: 'govuk-radios__input', checked: @course.has_vacancies?, "aria-controls" => "has_vacancies_true_conditional" %>
-    <%= f.label :has_vacancies_true, 'There are some vacancies', class: "govuk-label govuk-radios__label govuk-!-font-weight-bold" %>
-    <span id="has_vacancies_true_hint" class="govuk-hint govuk-radios__hint">
-      Pick the locations with vacancies
-    </span>
-  </div>
-  <div class="govuk-radios__conditional <%= 'govuk-radios__conditional--hidden' if !@course.has_vacancies? %>" id="has_vacancies_true_conditional">
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset" aria-describedby="has_vacancies_true_hint">
-        <div class="govuk-checkboxes">
-          <%= f.fields_for :site_status, @site_statuses.sort_by { |status| status.site.location_name } do |sf| %>
-            <% if @course.full_time_or_part_time? %>
-              <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :part_time, show_study_mode: true } %>
-              <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :full_time, show_study_mode: true } %>
-            <% elsif @course.full_time? || @course.part_time? %>
-              <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: @course.study_mode } %>
+<div class="govuk-form-group">
+  <%= hidden_field_tag('change_vacancies_confirmation', true) %>
+  <div class="govuk-radios govuk-!-margin-bottom-7" data-module="radios">
+    <div class="govuk-radios__item">
+      <%= f.radio_button :has_vacancies, 'false', class: 'govuk-radios__input', checked: !@course.has_vacancies? %>
+      <%= f.label :has_vacancies_false, 'There are no vacancies', class: "govuk-label govuk-radios__label govuk-!-font-weight-bold" %>
+      <span id="has_vacancies_false" class="govuk-hint govuk-radios__hint">
+        Close this course to new applications.
+        <br>
+        You can reopen a course later.
+      </span>
+    </div>
+    <div class="govuk-radios__divider">or</div>
+    <div class="govuk-radios__item">
+      <%= f.radio_button :has_vacancies, 'true', class: 'govuk-radios__input', checked: @course.has_vacancies?, "aria-controls" => "has_vacancies_true_conditional" %>
+      <%= f.label :has_vacancies_true, 'There are some vacancies', class: "govuk-label govuk-radios__label govuk-!-font-weight-bold" %>
+      <span id="has_vacancies_true_hint" class="govuk-hint govuk-radios__hint">
+        Pick the locations with vacancies
+      </span>
+    </div>
+    <div class="govuk-radios__conditional <%= 'govuk-radios__conditional--hidden' if !@course.has_vacancies? %>" id="has_vacancies_true_conditional">
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="has_vacancies_true_hint">
+          <div class="govuk-checkboxes">
+            <%= f.fields_for :site_status, @site_statuses.sort_by { |status| status.site.location_name } do |sf| %>
+              <% if @course.full_time_or_part_time? %>
+                <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :part_time, show_study_mode: true } %>
+                <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :full_time, show_study_mode: true } %>
+              <% elsif @course.full_time? || @course.part_time? %>
+                <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: @course.study_mode } %>
+              <% end %>
             <% end %>
-          <% end %>
-        </div>
-      </fieldset>
+          </div>
+        </fieldset>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/courses/vacancies/_single_site.html.erb
+++ b/app/views/courses/vacancies/_single_site.html.erb
@@ -1,0 +1,22 @@
+<div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:change_vacancies_confirmation]&.any?) %>">
+  <% if @errors && @errors[:change_vacancies_confirmation]&.any? %>
+    <span id="change_vacancies_confirmation-error" class="govuk-error-message">
+      <% @errors[:change_vacancies_confirmation].each do |error| %>
+        <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
+      <% end %>
+    </span>
+  <% end %>
+  <div class="govuk-checkboxes">
+    <div class="govuk-checkboxes__item">
+      <% if @course.has_vacancies? %>
+        <%= check_box_tag('change_vacancies_confirmation', 'no_vacancies_confirmation', false, class: 'govuk-checkboxes__input') %>
+        <%= label_tag('change_vacancies_confirmation', "I confirm there are no vacancies", class: 'govuk-label govuk-label--s govuk-checkboxes__label') %>
+        <span class="govuk-hint govuk-checkboxes__hint">Close this course to new applications.<br />You can reopen a course later.</span>
+      <% else %>
+        <%= check_box_tag('change_vacancies_confirmation', 'has_vacancies_confirmation', false, class: 'govuk-checkboxes__input') %>
+        <%= label_tag('change_vacancies_confirmation', "I confirm there are vacancies", class: 'govuk-label govuk-label--s govuk-checkboxes__label') %>
+        <span class="govuk-hint govuk-checkboxes__hint">Reopen this course to new applications.</span>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @course, url: vacancies_provider_course_path(params[:provider_code], @course.course_code), method: :put do |f| %>
       <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset" aria-describedby="how-contacted-conditional-hint">
+        <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-7">
             <h1 class="govuk-fieldset__heading">
               <span class="govuk-caption-xl"><%= @course.name %>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Vacancies" %>
+<%= content_for :page_title, "Edit vacancies for #{@course.name} (#{@course.course_code})" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_courses_path(params[:provider_code])) %>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @course, url: vacancies_provider_course_path(params[:provider_code], @course.course_code), method: :put do |f| %>
+    <%= form_for @course, url: vacancies_provider_course_path(params[:provider_code], @course.course_code), method: :put do |form| %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-7">
@@ -16,44 +16,10 @@
               Edit vacancies
             </h1>
           </legend>
-          <div class="govuk-radios govuk-!-margin-bottom-7" data-module="radios">
-            <div class="govuk-radios__item">
-              <%= f.radio_button :has_vacancies, 'false', class: 'govuk-radios__input', checked: !@course.has_vacancies? %>
-              <%= f.label :has_vacancies_false, 'There are no vacancies', class: "govuk-label govuk-radios__label govuk-!-font-weight-bold" %>
-              <span id="has_vacancies_false" class="govuk-hint govuk-radios__hint">
-                Close this course to new applications.
-                <br>
-                You can reopen a course later.
-              </span>
-            </div>
-            <div class="govuk-radios__divider">or</div>
-            <div class="govuk-radios__item">
-              <%= f.radio_button :has_vacancies, 'true', class: 'govuk-radios__input', checked: @course.has_vacancies?, "aria-controls" => "has_vacancies_true_conditional" %>
-              <%= f.label :has_vacancies_true, 'There are some vacancies', class: "govuk-label govuk-radios__label govuk-!-font-weight-bold" %>
-              <span id="has_vacancies_true_hint" class="govuk-hint govuk-radios__hint">
-                Pick the locations with vacancies
-              </span>
-            </div>
-            <div class="govuk-radios__conditional <%= 'govuk-radios__conditional--hidden' if !@course.has_vacancies? %>" id="has_vacancies_true_conditional">
-              <div class="govuk-form-group">
-                <fieldset class="govuk-fieldset" aria-describedby="has_vacancies_true_hint">
-                  <div class="govuk-checkboxes">
-                    <%= f.fields_for :site_status, @site_statuses.sort_by { |status| status.site.location_name } do |sf| %>
-                      <% if @course.study_mode == 'full_time_or_part_time' %>
-                        <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :part_time, show_study_mode: true } %>
-                        <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: :full_time, show_study_mode: true } %>
-                      <% elsif @course.study_mode == 'full_time' || @course.study_mode == 'part_time' %>
-                        <%= render partial: 'courses/vacancies/site_status_checkbox', locals: { f: sf, course: @course, study_mode: @course.study_mode } %>
-                      <% end %>
-                    <% end %>
-                  </div>
-                </fieldset>
-              </div>
-            </div>
-          </div>
+          <%= render partial: 'courses/vacancies/multiple_sites', locals: { f: form } %>
         </fieldset>
         <p class="govuk-body">Changes will appear on Find straight away. UCAS Apply will be updated within 2 hours.</p>
-        <%= f.submit "Publish changes", class: "govuk-button" %>
+        <%= form.submit "Publish changes", class: "govuk-button" %>
         <p class="govuk-body"><%= govuk_link_to "Cancel changes", provider_courses_path(params[:provider_code]) %></p>
       </div>
     <% end %>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -4,24 +4,35 @@
   <%= govuk_back_link_to(provider_courses_path(params[:provider_code])) %>
 <% end %>
 
+<%= render 'shared/errors', error_summary_title: 'We couldn’t edit the vacancies for this course' %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @course, url: vacancies_provider_course_path(params[:provider_code], @course.course_code), method: :put do |form| %>
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-7">
-            <h1 class="govuk-fieldset__heading">
-              <span class="govuk-caption-xl"><%= @course.name %>
-                (<%= @course.course_code %>)</span>
-              Edit vacancies
-            </h1>
-          </legend>
-          <%= render partial: 'courses/vacancies/multiple_sites', locals: { f: form } %>
-        </fieldset>
-        <p class="govuk-body">Changes will appear on Find straight away. UCAS Apply will be updated within 2 hours.</p>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-7">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl"><%= @course.name %>
+              (<%= @course.course_code %>)</span>
+            Edit vacancies
+          </h1>
+        </legend>
+        <% if @course.has_multiple_running_sites_or_study_modes? %>
+          <%= render partial: "courses/vacancies/multiple_sites", locals: { f: form } %>
+        <% else %>
+          <%= render partial: 'courses/vacancies/single_site', locals: { f: form } %>
+        <% end %>
+      </fieldset>
+      <p class="govuk-body">Changes will appear on Find straight away. UCAS Apply will be updated within 2 hours.</p>
+
+      <% if @course.has_multiple_running_sites_or_study_modes? %>
         <%= form.submit "Publish changes", class: "govuk-button" %>
-        <p class="govuk-body"><%= govuk_link_to "Cancel changes", provider_courses_path(params[:provider_code]) %></p>
-      </div>
+      <% elsif @course.has_vacancies? %>
+        <%= form.submit "Close applications", class: "govuk-button govuk-button--warning" %>
+      <% else %>
+        <%= form.submit "Reopen applications", class: "govuk-button" %>
+      <% end %>
+      <p class="govuk-body"><%= govuk_link_to "Cancel changes", provider_courses_path(params[:provider_code]) %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,7 +1,8 @@
-<% if @errors.any? %>
+<% error_summary_title ||= 'You’ll need to correct some information.' %>
+<% if @errors && @errors.any? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
-      You’ll need to correct some information.
+      <%= error_summary_title %>
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -86,6 +86,31 @@ feature 'Edit course vacancies', type: :feature do
     end
   end
 
+  context 'A full time or part time course with one site' do
+    let(:course) do
+      jsonapi(
+        :course,
+        :with_full_time_or_part_time_vacancy,
+        course_code: course_code,
+        site_statuses: [
+          jsonapi_site_status('Uni full and part time 1', :full_time_and_part_time, 'running'),
+        ]
+      )
+    end
+
+    scenario 'presents a radio button choice and shows both study modes for the site' do
+      expect(course_vacancies_page).to have_vacancies_radio_choice
+      expect(course_vacancies_page.vacancies_radio_has_some_vacancies).to be_checked
+
+      [
+        ["Uni full and part time 1 (Full time)", true],
+        ["Uni full and part time 1 (Part time)", true]
+      ].each do |name, checked|
+        expect(course_vacancies_page.vacancies_running_sites_checkboxes).to have_field(name, checked: checked)
+      end
+    end
+  end
+
   context 'A full time or part time course with multiple running sites' do
     let(:course) do
       jsonapi(

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -1,175 +1,184 @@
 require 'rails_helper'
 
 feature 'Edit course vacancies', type: :feature do
-  let(:course) do
-    jsonapi(
-      :course,
-      :with_full_time_or_part_time_vacancy,
-      site_statuses: [site_status],
-      provider: jsonapi(:provider)
-    ).render
-  end
-  let(:course_without_full_time_vacancy) do
-    jsonapi(
-      :course,
-      :with_full_time_or_part_time_vacancy,
-      course_code:   course_attributes[:course_code],
-      site_statuses: [
-        jsonapi(:site_status, :part_time, id: site_status.id, site: site)
-      ]
-    ).render
-  end
-  let(:course_attributes) { course[:data][:attributes] }
-  let(:site) { jsonapi(:site) }
-  let(:site_status) do
-    jsonapi(:site_status, :full_time_and_part_time, site: site)
-  end
-  let(:edit_vacancies_path) do
-    "/organisations/AO/courses/#{course_attributes[:course_code]}/vacancies"
-  end
+  let(:course_vacancies_page) { PageObjects::Page::Organisations::CourseVacancies.new }
+  let(:courses_page) { PageObjects::Page::Organisations::Courses.new }
+  let(:course_code) { 'X104' }
+
   let!(:sync_courses_request_stub) do
     stub_request(
       :post,
       "http://localhost:3001/api/v2/providers/AO/courses/" \
-        "#{course_attributes[:course_code]}/sync_with_search_and_compare"
+        "#{course_code}/sync_with_search_and_compare"
     ).to_return(status: 201, body: "")
   end
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/providers/AO?include=courses.accrediting_provider",
-      jsonapi(:provider).render
-    )
-    stub_api_v2_request(
-      "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site",
-      course
-    )
-
-    visit edit_vacancies_path
+    stub_api_v2_request("/providers/AO?include=courses.accrediting_provider", jsonapi(:provider).render)
+    stub_request(:patch, %r{\Ahttp://localhost:3001/api/v2/site_statuses/\d+})
+    stub_course_request(course)
+    course_vacancies_page.load_with_course(course)
   end
 
-  scenario 'viewing the edit vacancies page' do
-    expect(page).to have_link('Back', href: provider_courses_path('AO'))
-    expect(page).to have_link('Cancel changes', href: provider_courses_path('AO'))
-    expect(find('h1')).to have_content('Edit vacancies')
-    expect(find('.govuk-caption-xl')).to have_content(
-      "#{course_attributes[:name]} (#{course_attributes[:course_code]})"
-    )
+  context 'A full time course with multiple running sites' do
+    let(:course) do
+      jsonapi(
+        :course,
+        :with_full_time_vacancy,
+        course_code: course_code,
+        site_statuses: [
+          jsonapi_site_status('Running Uni 1', :full_time, 'running'),
+          jsonapi_site_status('Running Uni 2', :full_time, 'running'),
+          jsonapi_site_status('Not running Uni', :full_time, 'suspended')
+        ]
+      )
+    end
+
+    scenario 'shows the edit vacancies page' do
+      expect(course_vacancies_page).to have_link('Back', href: provider_courses_path('AO'))
+      expect(course_vacancies_page).to have_link('Cancel changes', href: provider_courses_path('AO'))
+      expect(course_vacancies_page.title).to have_content('Edit vacancies')
+      expect(course_vacancies_page.caption).to have_content(
+        "#{course.name} (#{course.course_code})"
+      )
+    end
+
+    scenario 'only render site statuses that are running' do
+      expect(course_vacancies_page).to have_vacancies_radio_choice
+      expect(course_vacancies_page.vacancies_radio_has_some_vacancies).to be_checked
+
+      [
+        ["Running Uni 1", true],
+        ["Running Uni 2", true]
+      ].each do |name, checked|
+        expect(course_vacancies_page.vacancies_running_sites_checkboxes).to have_field(name, checked: checked)
+      end
+
+      expect(course_vacancies_page.vacancies_running_sites_checkboxes).not_to have_field("Not running Uni")
+    end
   end
 
-  context 'site_statuses#running' do
+  context 'A full time course with multiple running sites but no vacancies' do
+    let(:course) do
+      jsonapi(
+        :course,
+        :full_time,
+        course_code: course_code,
+        site_statuses: [
+          jsonapi_site_status('Running Uni 1', :no_vacancies, 'running'),
+          jsonapi_site_status('Running Uni 2', :no_vacancies, 'running')
+        ]
+      )
+    end
+
+    scenario 'shows course as having no vacancies' do
+      expect(course_vacancies_page).to have_vacancies_radio_choice
+      expect(course_vacancies_page.vacancies_radio_no_vacancies).to be_checked
+      expect(course_vacancies_page.vacancies_radio_has_some_vacancies).not_to be_checked
+
+      [
+        ["Running Uni 1", false],
+        ["Running Uni 2", false]
+      ].each do |name, checked|
+        expect(course_vacancies_page.vacancies_running_sites_checkboxes).to have_field(name, checked: checked)
+      end
+    end
+  end
+
+  context 'A full time or part time course with multiple running sites' do
     let(:course) do
       jsonapi(
         :course,
         :with_full_time_or_part_time_vacancy,
-        site_statuses: [running_site_status, non_running_site_status]
-      ).render
+        course_code: course_code,
+        site_statuses: [
+          jsonapi_site_status('Uni 1', :full_time, 'running'),
+          jsonapi_site_status('Uni 2', :part_time, 'running'),
+          jsonapi_site_status('Uni 3', :full_time_and_part_time, 'running'),
+          jsonapi_site_status('Not running Uni', :full_time, 'suspended')
+        ]
+      )
     end
 
-    let(:site_running) { jsonapi(:site, location_name: 'Big Uni') }
-    let(:site_not_running) { jsonapi(:site, location_name: 'Small Uni') }
+    scenario 'shows both study modes for each site' do
+      expect(course_vacancies_page).to have_vacancies_radio_choice
+      expect(course_vacancies_page.vacancies_radio_has_some_vacancies).to be_checked
 
-    let(:running_site_status) do
-      jsonapi(:site_status, :full_time_and_part_time, site: site_running, status: 'running')
-    end
-    let(:non_running_site_status) do
-      jsonapi(:site_status, :full_time_and_part_time, site: site_not_running, status: 'suspended')
-    end
-
-    scenario 'only render site_statuses that are running' do
-      expect(page).to have_field("Big Uni (Full time)")
-      expect(page).to_not have_field("Small Uni (Full time)")
+      [
+        ["Uni 1 (Full time)", true],
+        ["Uni 1 (Part time)", false],
+        ["Uni 2 (Full time)", false],
+        ["Uni 2 (Part time)", true],
+        ["Uni 3 (Full time)", true],
+        ["Uni 3 (Part time)", true]
+      ].each do |name, checked|
+        expect(course_vacancies_page.vacancies_running_sites_checkboxes).to have_field(name, checked: checked)
+      end
     end
   end
 
-  context 'removing vacancies' do
-    let(:course_without_vacancies) do
+  context 'Removing vacancies for a course' do
+    let(:course) do
       jsonapi(
         :course,
-        :full_time_or_part_time,
-        course_code:   course_attributes[:course_code],
+        :with_full_time_or_part_time_vacancy,
+        course_code: course_code,
         site_statuses: [
-          jsonapi(:site_status, :no_vacancies, id: site_status.id, site: site)
+          jsonapi_site_status('Uni 1', :full_time, 'running')
         ]
-      ).render
-    end
-
-    before do
-      stub_request(
-        :patch,
-        "http://localhost:3001/api/v2/site_statuses/#{site_status.id}"
       )
     end
 
     scenario 'removing a full time vacancy' do
-      uncheck(
-        "#{site.attributes[:location_name]} (Full time)",
-        allow_label_click: true
-      )
-
-      stub_api_v2_request(
-        "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site",
-        course_without_full_time_vacancy
-      )
-
-      click_on 'Publish changes'
-
-      expect(page.find('.govuk-success-summary')).to have_content(
-        'Course vacancies published'
-      )
-      expect(find('h1')).to have_content('Courses')
-      expect(sync_courses_request_stub).to have_been_requested
+      expect(course_vacancies_page.vacancies_radio_has_some_vacancies).to be_checked
+      uncheck("Uni 1 (Full time)")
+      publish_changes
     end
 
     scenario 'removing all vacancies' do
+      expect(course_vacancies_page.vacancies_radio_has_some_vacancies).to be_checked
+
       choose 'There are no vacancies'
+      expect(course_vacancies_page.vacancies_radio_no_vacancies).to be_checked
 
-      stub_api_v2_request(
-        "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site",
-        course_without_vacancies
-      )
-
-      click_on 'Publish changes'
-
-      expect(page.find('.govuk-success-summary')).to have_content(
-        'Course vacancies published'
-      )
-      expect(find('h1')).to have_content('Courses')
-      expect(sync_courses_request_stub).to have_been_requested
+      publish_changes
     end
   end
 
-  context 'adding vacancies' do
-    before do
-      stub_api_v2_request(
-        "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site",
-        course_without_full_time_vacancy
-      )
-      stub_request(
-        :patch,
-        "http://localhost:3001/api/v2/site_statuses/#{site_status.id}"
+  context 'Adding vacancies for a course' do
+    let(:course) do
+      jsonapi(
+        :course,
+        :with_full_time_or_part_time_vacancy,
+        course_code: course_code,
+        site_statuses: [
+          jsonapi_site_status('Uni 1', :full_time, 'running')
+        ]
       )
     end
 
     scenario 'adding a part time vacancy' do
-      check(
-        "#{site.attributes[:location_name]} (Full time)",
-        allow_label_click: true
-      )
-
-      stub_api_v2_request(
-        "/providers/AO/courses/#{course_attributes[:course_code]}?include=site_statuses.site",
-        course
-      )
-
-      click_on 'Publish changes'
-
-      expect(page.find('.govuk-success-summary')).to have_content(
-        'Course vacancies published'
-      )
-      expect(find('h1')).to have_content('Courses')
-      expect(sync_courses_request_stub).to have_been_requested
+      check("Uni 1 (Part time)")
+      publish_changes
     end
+  end
+
+  def publish_changes
+    click_on 'Publish changes'
+    expect(courses_page).to be_displayed
+    expect(courses_page.flash).to have_content('Course vacancies published')
+    expect(sync_courses_request_stub).to have_been_requested
+  end
+
+  def jsonapi_site_status(name, study_mode, status)
+    jsonapi(:site_status, study_mode, site: jsonapi(:site, location_name: name), status: status)
+  end
+
+  def stub_course_request(course)
+    stub_api_v2_request(
+      "/providers/AO/courses/#{course.course_code}?include=site_statuses.site",
+      course.render
+    )
   end
 end

--- a/spec/requests/courses/vacancies/edit_spec.rb
+++ b/spec/requests/courses/vacancies/edit_spec.rb
@@ -6,14 +6,14 @@ describe 'Edit vacancies' do
       jsonapi(
         :course,
         :with_full_time_or_part_time_vacancy,
-        site_statuses: [site_status]
+        site_statuses: [site_status, site_status_2]
       ).render
     end
     let(:course_code) { course[:data][:attributes][:course_code] }
     let(:site) { jsonapi(:site) }
-    let(:site_status) do
-      jsonapi(:site_status, :full_time_and_part_time, site: site)
-    end
+    let(:site_status) { jsonapi(:site_status, :full_time_and_part_time, site: site) }
+    let(:site_status_2) { jsonapi(:site_status, :full_time_and_part_time, site: site) }
+
     let(:edit_vacancies_path) do
       "/organisations/AO/courses/#{course_code}/vacancies"
     end
@@ -32,13 +32,13 @@ describe 'Edit vacancies' do
       expect(response.body).to include('Edit vacancies')
     end
 
-    describe 'rendering vacancies checkboxes' do
+    describe 'rendering vacancies checkboxes for a course with multiple running sites' do
       context 'with a full time and part time course' do
         let(:course) do
           jsonapi(
             :course,
             :with_full_time_or_part_time_vacancy,
-            site_statuses: [site_status]
+            site_statuses: [site_status, site_status_2]
           ).render
         end
 
@@ -57,7 +57,7 @@ describe 'Edit vacancies' do
           jsonapi(
             :course,
             :with_full_time_vacancy,
-            site_statuses: [site_status]
+            site_statuses: [site_status, site_status_2]
           ).render
         end
 
@@ -65,7 +65,7 @@ describe 'Edit vacancies' do
           expect(response.body).to include(
             site.attributes[:location_name]
           )
-          expect(response.body).to_not include(
+          expect(response.body).not_to include(
             "#{site.attributes[:location_name]} (Full time)"
           )
           expect(response.body).not_to include(
@@ -79,7 +79,7 @@ describe 'Edit vacancies' do
           jsonapi(
             :course,
             :with_part_time_vacancy,
-            site_statuses: [site_status]
+            site_statuses: [site_status, site_status_2]
           ).render
         end
 
@@ -90,7 +90,7 @@ describe 'Edit vacancies' do
           expect(response.body).not_to include(
             "#{site.attributes[:location_name]} (Full time)"
           )
-          expect(response.body).to_not include(
+          expect(response.body).not_to include(
             "#{site.attributes[:location_name]} (Part time)"
           )
         end

--- a/spec/site_prism/page_objects/page/organisations/course_vacancies.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_vacancies.rb
@@ -1,0 +1,16 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseVacancies < CourseBase
+        set_url '/organisations/{provider_code}/courses/{course_code}/vacancies'
+
+        element :title, 'h1.govuk-fieldset__heading'
+
+        element :vacancies_radio_choice, '.govuk-radios'
+        element :vacancies_radio_no_vacancies, '#course_has_vacancies_false.govuk-radios__input'
+        element :vacancies_radio_has_some_vacancies, '#course_has_vacancies_true.govuk-radios__input'
+        element :vacancies_running_sites_checkboxes, '.govuk-radios__conditional .govuk-checkboxes'
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/course_vacancies.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_vacancies.rb
@@ -10,6 +10,9 @@ module PageObjects
         element :vacancies_radio_no_vacancies, '#course_has_vacancies_false.govuk-radios__input'
         element :vacancies_radio_has_some_vacancies, '#course_has_vacancies_true.govuk-radios__input'
         element :vacancies_running_sites_checkboxes, '.govuk-radios__conditional .govuk-checkboxes'
+
+        element :confirm_no_vacancies_checkbox, '#change_vacancies_confirmation[value="no_vacancies_confirmation"]'
+        element :confirm_has_vacancies_checkbox, '#change_vacancies_confirmation[value="has_vacancies_confirmation"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/courses.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses.rb
@@ -4,6 +4,8 @@ module PageObjects
       class Courses < PageObjects::Base
         set_url '/organisations/{provider_code}/courses'
 
+        element :flash, '.govuk-success-summary'
+
         sections :courses_tables, '[data-qa="courses__table-section"]' do
           element :subheading, 'h2'
           sections :rows, 'tbody tr' do


### PR DESCRIPTION
### Context

Update the code to match the design:
https://bat-design-history.herokuapp.com/publish-teacher-training/vacancies-iteration-14-jan

We built the complex version of vacancies when we launched the feature, but we didn't return to it to create the simpler toggle. The toggle should be used when there is only 1 site and the course has one study mode.

### Changes proposed in this pull request

- Add check for if course is single site/single study mode
- Show a checkbox for toggling vacancies
- Use different update logic and template for single site/single study mode
- Refactor vacancies tests to:
   - use SitePrism
   - be explicit about the study mode and number of sites when testing a course

### Guidance to review

| State | No error | With error |
|--|--|--|
| With vacancies |![Screen Shot 2019-06-21 at 14 05 45](https://user-images.githubusercontent.com/319055/59924513-c6b99100-942d-11e9-9583-293b83933f9c.png)|![Screen Shot 2019-06-21 at 14 05 53](https://user-images.githubusercontent.com/319055/59924511-c6b99100-942d-11e9-8beb-cf00632485e6.png)|
| No vacancies |![Screen Shot 2019-06-21 at 14 06 13](https://user-images.githubusercontent.com/319055/59924510-c6b99100-942d-11e9-9148-09f5e169870c.png) |![Screen Shot 2019-06-21 at 14 06 17](https://user-images.githubusercontent.com/319055/59924507-c6b99100-942d-11e9-9513-436b61d29c67.png)|
