### PR TITLE
[1667] Don't prefill other course length if 1/2 years

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -67,6 +67,10 @@ class CourseDecorator < ApplicationDecorator
     end
   end
 
+  def other_course_length?
+    %w[OneYear TwoYears].exclude?(course.course_length)
+  end
+
   def ucas_status
     case object.ucas_status
     when 'running'

--- a/app/views/courses/_course_length.html.erb
+++ b/app/views/courses/_course_length.html.erb
@@ -27,7 +27,7 @@
       </div>
       <div class="govuk-radios__conditional" id="other-container">
         <div class="form-group">
-          <%= f.label 'course_length_other_length', 'Course Length', class: 'govuk-label govuk-label--s', for: 'course_length_other_length' %>
+          <%= f.label 'course_length_other_length', 'Course length', class: 'govuk-label govuk-label--s' %>
           <%= f.text_field 'course_length_other_length', value: course.course_length, class: 'govuk-input',
             aria: { describedby: @errors[:course_length] ? "course_length-error" : '' } %>
         </div>

--- a/app/views/courses/_course_length.html.erb
+++ b/app/views/courses/_course_length.html.erb
@@ -9,27 +9,29 @@
     <div class="govuk-radios" data-module="radios">
       <div class="govuk-radios__item">
         <%= f.radio_button :course_length, 'OneYear', class: 'govuk-radios__input',
-          checked: (course.course_length == 'OneYear' && course.course_length != 'Other'),
+          checked: course.course_length == 'OneYear',
           aria: { describedby: @errors[:course_length] ? "course_length-error" : '' } %>
         <%= f.label :course_length, '1 year', value: 'OneYear', class: 'govuk-label govuk-radios__label', for: "course_course_length_oneyear" %>
       </div>
       <div class="govuk-radios__item">
         <%= f.radio_button :course_length, 'TwoYears', class: 'govuk-radios__input',
-          checked: (course.course_length == 'TwoYears' && course.course_length != 'Other'),
+          checked: course.course_length == 'TwoYears',
           aria: { describedby: @errors[:course_length] ? "course_length-error" : '' } %>
         <%= f.label :course_length, 'Up to 2 years', value: 'TwoYears', class: 'govuk-label govuk-radios__label', for: "course_course_length_twoyears" %>
       </div>
       <div class="govuk-radios__item">
         <%= f.radio_button :course_length, 'Other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" },
-          checked: !(course.course_length == 'OneYear' || course.course_length == 'TwoYears'),
+          checked: course.other_course_length?,
           aria: { describedby: @errors[:course_length] ? "course_length-error" : '' } %>
         <%= f.label :course_length, 'Other', value: 'Other', class: 'govuk-label govuk-radios__label', for: "course_course_length_other" %>
       </div>
       <div class="govuk-radios__conditional" id="other-container">
         <div class="form-group">
           <%= f.label 'course_length_other_length', 'Course length', class: 'govuk-label govuk-label--s' %>
-          <%= f.text_field 'course_length_other_length', value: course.course_length, class: 'govuk-input',
-            aria: { describedby: @errors[:course_length] ? "course_length-error" : '' } %>
+          <%= f.text_field 'course_length_other_length',
+                value: course.other_course_length? ? course.course_length : '',
+                class: 'govuk-input govuk-input--width-20',
+                aria: { describedby: @errors[:course_length] ? "course_length-error" : '' } %>
         </div>
       </div>
     </div>

--- a/app/views/courses/_course_length.html.erb
+++ b/app/views/courses/_course_length.html.erb
@@ -11,19 +11,19 @@
         <%= f.radio_button :course_length, 'OneYear', class: 'govuk-radios__input',
           checked: course.course_length == 'OneYear',
           aria: { describedby: @errors[:course_length] ? "course_length-error" : '' } %>
-        <%= f.label :course_length, '1 year', value: 'OneYear', class: 'govuk-label govuk-radios__label', for: "course_course_length_oneyear" %>
+        <%= f.label :course_length, '1 year', value: 'OneYear', class: 'govuk-label govuk-radios__label' %>
       </div>
       <div class="govuk-radios__item">
         <%= f.radio_button :course_length, 'TwoYears', class: 'govuk-radios__input',
           checked: course.course_length == 'TwoYears',
           aria: { describedby: @errors[:course_length] ? "course_length-error" : '' } %>
-        <%= f.label :course_length, 'Up to 2 years', value: 'TwoYears', class: 'govuk-label govuk-radios__label', for: "course_course_length_twoyears" %>
+        <%= f.label :course_length, 'Up to 2 years', value: 'TwoYears', class: 'govuk-label govuk-radios__label' %>
       </div>
       <div class="govuk-radios__item">
         <%= f.radio_button :course_length, 'Other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" },
           checked: course.other_course_length?,
           aria: { describedby: @errors[:course_length] ? "course_length-error" : '' } %>
-        <%= f.label :course_length, 'Other', value: 'Other', class: 'govuk-label govuk-radios__label', for: "course_course_length_other" %>
+        <%= f.label :course_length, 'Other', value: 'Other', class: 'govuk-label govuk-radios__label' %>
       </div>
       <div class="govuk-radios__conditional" id="other-container">
         <div class="form-group">

--- a/spec/features/courses/fees_spec.rb
+++ b/spec/features/courses/fees_spec.rb
@@ -37,6 +37,8 @@ feature 'Course fees', type: :feature do
     )
     expect(course_fees_page.course_length_one_year).not_to be_checked
     expect(course_fees_page.course_length_two_years).to be_checked
+    expect(course_fees_page.course_length_other_length.value).to eq('')
+
     expect(course_fees_page.course_fees_uk_eu.value).to have_content(
       course_1.fee_uk_eu
     )

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -43,6 +43,7 @@ feature 'Course salary', type: :feature do
     )
     expect(course_salary_page.course_length_one_year).to be_checked
     expect(course_salary_page.course_length_two_years).to_not be_checked
+    expect(course_salary_page.course_length_other_length.value).to eq('')
     expect(course_salary_page.course_salary_details.value).to eq(
       course.salary_details
     )

--- a/spec/site_prism/page_objects/page/organisations/course_salary.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_salary.rb
@@ -6,6 +6,7 @@ module PageObjects
 
         element :course_length_one_year, '#course_course_length_oneyear'
         element :course_length_two_years, '#course_course_length_twoyears'
+        element :course_length_other_length, '#course_course_length_other_length'
         element :course_salary_details, '#course_salary_details'
       end
     end


### PR DESCRIPTION
### Context

Fixes:
![Screen Shot 2019-06-14 at 10 55 11](https://user-images.githubusercontent.com/319055/59932342-dbeaeb80-943e-11e9-8e85-7e30a0343ce4.png)

### Changes proposed in this pull request

- Associate label with form field correctly
- Don't prefill field with OneYear or TwoYear special values
- Tweak casing of label and input width
