### PR TITLE
Fix styles on video links

### DIFF
--- a/app/views/pages/new_features.html.erb
+++ b/app/views/pages/new_features.html.erb
@@ -10,8 +10,8 @@
     <h2 class="govuk-heading-l">Recently released</h2>
     <p class="govuk-body">You can now:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>change locations assigned to a course (<a href="https://www.youtube.com/watch?v=W_zhfemKiYM">Watch a video<span class="govuk-visually-hidden">of the assigning locations feature</span></a>)</li>
-      <li>edit course vacancies (<a href="https://www.youtube.com/watch?v=nxmtXGy1cCY">Watch a video<span class="govuk-visually-hidden">of the edit vacancies feature</span></a>)</li>
+      <li>change locations assigned to a course (<a href="https://www.youtube.com/watch?v=W_zhfemKiYM" class="govuk-link">Watch a video<span class="govuk-visually-hidden">of the assigning locations feature</span></a>)</li>
+      <li>edit course vacancies (<a href="https://www.youtube.com/watch?v=nxmtXGy1cCY" class="govuk-link">Watch a video<span class="govuk-visually-hidden">of the edit vacancies feature</span></a>)</li>
       <li>add a new location</li>
       <li>edit a location name and address</li>
       <li>request a new course using a Google Form</li>


### PR DESCRIPTION
Add missing `govuk-link` classes

## Before

![Screen Shot 2019-06-24 at 15 56 16](https://user-images.githubusercontent.com/319055/60029207-9e819a80-9698-11e9-81fb-c077674f69a2.png)
