### PR TITLE
Fix Google Analytics link colour

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -22,7 +22,7 @@
             <%= link_to "Cookies", cookies_path, class: "govuk-footer__link" %>
           </li>
           <li class="govuk-footer__inline-list-item">
-            <%= link_to "Privacy Policy", privacy_path, class: "govuk-footer__link" %>
+            <%= link_to "Privacy policy", privacy_path, class: "govuk-footer__link" %>
           </li>
           <li class="govuk-footer__inline-list-item">
             <%= link_to "Terms and conditions", terms_path, class: "govuk-footer__link" %>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -62,7 +62,7 @@
       </table>
     </div>
 
-    <p class="govuk-body">You can opt out of <a href="https://tools.google.com/dlpage/gaoptout" rel="external">Google Analytics</a>.</p>
+    <p class="govuk-body">You can opt out of <a href="https://tools.google.com/dlpage/gaoptout" rel="external" class="govuk-link">Google Analytics</a>.</p>
 
     <h3 class="govuk-heading-m">Our introductory message</h3>
 


### PR DESCRIPTION
Add the missing `govuk-link` class so the text renders in the right colour.
