### PR TITLE
Update error page design to match design system

### DIFF
--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">You are not permitted to see this page</h1>
     <p class="govuk-body">This page is restricted to certain users only.</p>
     <p class="govuk-body">
-      <%= bat_contact_mail_to "Contact us by email to request access to your organisation", subject: "Publish teacher training courses access request" %>
+      Contact us by email to request access to your organisation: <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses access request" %>
     </p>
   </div>
 </div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,11 +1,11 @@
-<%= content_for :page_title, "Sorry, something went wrong" %>
+<%= content_for :page_title, "Sorry, there is a problem with the service" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sorry, something went wrong</h1>
-    <p class="govuk-body">Sorry, we're experiencing technical difficulties.</p>
+    <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+    <p class="govuk-body">Try again later.</p>
     <p class="govuk-body">
-      <%= bat_contact_mail_to "Contact the Becoming a Teacher team" %> if you continue to see this error.
+      If you continue to see this error contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Problem with the service" %>
     </p>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -3,9 +3,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Page not found</h1>
-    <p class="govuk-body">If you entered a web address please check it was correct.</p>
     <p class="govuk-body">
-      <%= bat_contact_mail_to "Contact the Becoming a Teacher team" %> if you believe you are seeing this message in error.
+      If you typed the web address, check it is correct.
+    </p>
+    <p class="govuk-body">
+      If you pasted the web address, check you copied the entire address.
+    </p>
+    <p class="govuk-body">
+      If the web address is correct or you selected a link or button and you need to speak to someone about this problem, contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Page not found" %>
     </p>
   </div>
 </div>


### PR DESCRIPTION
### Context
Update our error page designs to match content in the design system.

Based on:
https://design-system.service.gov.uk/patterns/problem-with-the-service-pages/
https://design-system.service.gov.uk/patterns/page-not-found-pages/

Also makes sure that the support email address is displayed so it can be copied if needed.

## 404
![Screen Shot 2019-06-25 at 15 36 22](https://user-images.githubusercontent.com/319055/60107783-63966a00-975f-11e9-9335-a243eb5e3163.png)

## 500
![Screen Shot 2019-06-25 at 15 36 09](https://user-images.githubusercontent.com/319055/60107784-63966a00-975f-11e9-8411-3740c17984bd.png)

## 401
![Screen Shot 2019-06-25 at 15 35 54](https://user-images.githubusercontent.com/319055/60107786-63966a00-975f-11e9-845c-4652f51dc936.png)
