### PR TITLE
[1484] Make accredited body sorting case insensitive

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -161,7 +161,7 @@ private
           @provider.provider_name
         end
       }
-      .sort_by { |accrediting_provider, _| accrediting_provider }
+      .sort_by { |accrediting_provider, _| accrediting_provider.downcase }
       .map { |provider_name, courses|
       [provider_name, courses.sort_by { |course| [course.name, course.course_code] }
                              .map(&:decorate)]

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -91,9 +91,11 @@ feature 'Index courses', type: :feature do
     let(:provider_response) { provider.render }
     let(:provider_1) { jsonapi :provider, id: "1", provider_name: "Zacme Scitt" }
     let(:provider_2) { jsonapi :provider, id: "2", provider_name: "Aacme Scitt" }
+    let(:provider_3) { jsonapi :provider, id: "3", provider_name: "e-Qualitas" }
 
     let(:course_2) { jsonapi :course, accrediting_provider: provider_1 }
     let(:course_3) { jsonapi :course, accrediting_provider: provider_2 }
+    let(:course_4) { jsonapi :course, accrediting_provider: provider_3 }
 
     before do
       user = build(:user)
@@ -111,11 +113,12 @@ feature 'Index courses', type: :feature do
 
     scenario "it shows a list of courses" do
       expect(courses_page.title).to have_content('Courses')
-      expect(courses_page.courses_tables.size).to eq(3)
+      expect(courses_page.courses_tables.size).to eq(4)
 
       expect(courses_page.courses_tables.first).to_not have_subheading
       expect(courses_page.courses_tables.second.subheading).to have_content('Accredited body Aacme Scitt')
-      expect(courses_page.courses_tables.third.subheading).to have_content('Accredited body Zacme Scitt')
+      expect(courses_page.courses_tables.third.subheading).to have_content('Accredited body e-Qualitas')
+      expect(courses_page.courses_tables.fourth.subheading).to have_content('Accredited body Zacme Scitt')
     end
 
     scenario "it shows 'add a new course' link" do


### PR DESCRIPTION
### Context

A couple of providers begin with a lowercase letter, eg e-Qualitas. Courses associated with this accredited body were appearing in a block at the bottom of the page instead of the expected alphabetical position.

| Before | After |
|-|-|
| ![Screen Shot 2019-06-25 at 16 16 52](https://user-images.githubusercontent.com/319055/60110848-aeff4700-9764-11e9-834f-7716db5f43a4.png) | ![Screen Shot 2019-06-25 at 16 16 08](https://user-images.githubusercontent.com/319055/60110846-aeff4700-9764-11e9-91a1-349c1aac7248.png) |

