### PR TITLE
[1298] 404 if site not found

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -43,7 +43,12 @@ private
 
   def build_site
     @site = @provider.sites.find { |site| site.id == params[:id] }
-    @site_name_before_update = @site.location_name.dup
+
+    if @site
+      @site_name_before_update = @site.location_name.dup
+    else
+      render file: 'errors/not_found', status: :not_found
+    end
   end
 
   def build_provider

--- a/spec/features/sites/edit_spec.rb
+++ b/spec/features/sites/edit_spec.rb
@@ -12,6 +12,20 @@ feature 'Edit locations', type: :feature do
   let(:locations_page) { PageObjects::Page::LocationsPage.new }
   let(:location_page) { PageObjects::Page::LocationPage.new }
 
+  describe "when visiting a site that doesn’t exist" do
+    before do
+      stub_omniauth
+      stub_api_v2_request("/providers/#{provider_code}?include=sites", provider)
+    end
+
+    scenario 'it 404s' do
+      visit edit_provider_site_path(provider_code, 'not_a_site')
+      expect(location_page).not_to be_displayed
+      expect(page.status_code).to eq(404)
+      expect(page.body).to have_content('Page not found')
+    end
+  end
+
   describe "without errors" do
     before do
       stub_omniauth


### PR DESCRIPTION
We shouldn't throw a 500 if the provider doesn't have the specified site ID.

### Context

When editing a site it throws a 500 if you mess with an edit location URL and put in a bad ID.

Because it can’t find a site you get:
```undefined method 'location_name' for nil:NilClass```

For example, a bad URL: `/organisations/135/locations/1000000000000/edit`

### Changes proposed in this pull request

- Stop the 500
- Show a 404
