### PR TITLE
[1664] Retain enrichment error messages on edit

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -44,12 +44,7 @@ class CoursesController < ApplicationController
   end
 
   def about
-    if params[:display_errors].present?
-      attributes = %i[about_course interview_process how_school_placements_work]
-
-      @course.publish
-      @errors = @course.errors.messages.select { |key| attributes.include? key }
-    end
+    show_deep_linked_errors(%i[about_course interview_process how_school_placements_work])
 
     if params[:copy_from].present?
       @copied_fields = [
@@ -61,12 +56,7 @@ class CoursesController < ApplicationController
   end
 
   def requirements
-    if params[:display_errors].present?
-      attributes = %i[required_qualifications personal_qualities other_requirements]
-
-      @course.publish
-      @errors = @course.errors.messages.select { |key| attributes.include? key }
-    end
+    show_deep_linked_errors(%i[required_qualifications personal_qualities other_requirements])
 
     if params[:copy_from].present?
       @copied_fields = [
@@ -78,12 +68,7 @@ class CoursesController < ApplicationController
   end
 
   def fees
-    if params[:display_errors].present?
-      attributes = %i[course_length fee_uk_eu fee_international fee_details financial_support]
-
-      @course.publish
-      @errors = @course.errors.messages.select { |key| attributes.include? key }
-    end
+    show_deep_linked_errors(%i[course_length fee_uk_eu fee_international fee_details financial_support])
 
     if params[:copy_from].present?
       @copied_fields = [
@@ -97,12 +82,7 @@ class CoursesController < ApplicationController
   end
 
   def salary
-    if params[:display_errors].present?
-      attributes = %i[course_length salary_details]
-
-      @course.publish
-      @errors = @course.errors.messages.select { |key| attributes.include? key }
-    end
+    show_deep_linked_errors(%i[course_length salary_details])
 
     if params[:copy_from].present?
       @copied_fields = [
@@ -230,5 +210,12 @@ private
 
   def initialise_errors
     @errors = {}
+  end
+
+  def show_deep_linked_errors(attributes)
+    return if params[:display_errors].blank?
+
+    @course.publishable?
+    @errors = @course.errors.messages.select { |key| attributes.include? key }
   end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -44,6 +44,13 @@ class CoursesController < ApplicationController
   end
 
   def about
+    if params[:display_errors].present?
+      attributes = %i[about_course interview_process how_school_placements_work]
+
+      @course.publish
+      @errors = @course.errors.messages.select { |key| attributes.include? key }
+    end
+
     if params[:copy_from].present?
       @copied_fields = [
         ['About the course', 'about_course'],
@@ -54,6 +61,13 @@ class CoursesController < ApplicationController
   end
 
   def requirements
+    if params[:display_errors].present?
+      attributes = %i[required_qualifications personal_qualities other_requirements]
+
+      @course.publish
+      @errors = @course.errors.messages.select { |key| attributes.include? key }
+    end
+
     if params[:copy_from].present?
       @copied_fields = [
         ['Qualifications needed', 'required_qualifications'],
@@ -64,6 +78,13 @@ class CoursesController < ApplicationController
   end
 
   def fees
+    if params[:display_errors].present?
+      attributes = %i[course_length fee_uk_eu fee_international fee_details financial_support]
+
+      @course.publish
+      @errors = @course.errors.messages.select { |key| attributes.include? key }
+    end
+
     if params[:copy_from].present?
       @copied_fields = [
         ['Course length', 'course_length'],
@@ -76,6 +97,13 @@ class CoursesController < ApplicationController
   end
 
   def salary
+    if params[:display_errors].present?
+      attributes = %i[course_length salary_details]
+
+      @course.publish
+      @errors = @course.errors.messages.select { |key| attributes.include? key }
+    end
+
     if params[:copy_from].present?
       @copied_fields = [
         ['Course length', 'course_length'],

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -37,12 +37,12 @@ module ViewHelper
     base = "/organisations/#{provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}"
 
     {
-      'about_course' => base + '/about#about_course_wrapper',
-      'how_school_placements_work' => base + '/about#how_school_placements_work_wrapper',
-      'fee_uk_eu' => base + '/fees#fee_uk_eu_wrapper',
-      'course_length' => base + (course.has_fees? ? '/fees' : '/salary') + '#course_length_wrapper',
-      'salary_details' => base + '/salary#salary_details_wrapper',
-      'qualifications' => base + '/requirements#required_qualifications_wrapper'
+      'about_course' => base + '/about?display_errors=true#about_course_wrapper',
+      'how_school_placements_work' => base + '/about?display_errors=true#how_school_placements_work_wrapper',
+      'fee_uk_eu' => base + '/fees?display_errors=true#fee_uk_eu_wrapper',
+      'course_length' => base + (course.has_fees? ? '/fees' : '/salary') + '?display_errors=true#course_length_wrapper',
+      'salary_details' => base + '/salary?display_errors=true#salary_details_wrapper',
+      'qualifications' => base + '/requirements?display_errors=true#required_qualifications_wrapper'
     }[field]
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -11,23 +11,11 @@ class Course < Base
   self.primary_key = :course_code
 
   def publish
-    publish_url = "#{Course.site}providers/#{provider.provider_code}/courses/#{course_code}/publish"
-    post_options = {
-      body: { data: { attributes: {}, type: "course" } },
-      params: request_params.to_params
-    }
+    post_request('/publish')
+  end
 
-    self.last_result_set = self.class.requestor.__send__(
-      :request, :post, publish_url, post_options
-    )
-
-    if last_result_set.has_errors?
-      self.fill_errors # Inherited from JsonApiClient::Resource
-      false
-    else
-      self.errors.clear if self.errors
-      true
-    end
+  def publishable?
+    post_request('/publishable')
   end
 
   def full_time?
@@ -72,5 +60,28 @@ class Course < Base
 
   def has_multiple_running_sites_or_study_modes?
     running_site_statuses.length > 1 || full_time_or_part_time?
+  end
+
+private
+
+  def post_request(path)
+    base_url = "#{Course.site}#{Course.path}/%<course_code>s" % path_attributes
+
+    post_options = {
+      body: { data: { attributes: {}, type: "course" } },
+      params: request_params.to_params
+    }
+
+    self.last_result_set = self.class.requestor.__send__(
+      :request, :post, base_url + path, post_options
+    )
+
+    if last_result_set.has_errors?
+      self.fill_errors # Inherited from JsonApiClient::Resource
+      false
+    else
+      self.errors.clear if self.errors
+      true
+    end
   end
 end

--- a/spec/helpers/course_helper_spec.rb
+++ b/spec/helpers/course_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'View helpers', type: :helper do
       end
 
       it "returns correct content" do
-        expect(helper.course_summary_label('About course', :about_course)).to eq("<dt class=\"govuk-summary-list__key course-parts__fields__label--error\"><span>About course</span><a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about#about_course_wrapper\">Something about the course</a></dt>")
+        expect(helper.course_summary_label('About course', :about_course)).to eq("<dt class=\"govuk-summary-list__key course-parts__fields__label--error\"><span>About course</span><a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#about_course_wrapper\">Something about the course</a></dt>")
       end
     end
   end
@@ -46,7 +46,7 @@ RSpec.feature 'View helpers', type: :helper do
 
     it "returns correct content" do
       expect(helper.course_manage_error_link('about_course', 'Something about the course'))
-        .to eq("<a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about#about_course_wrapper\">Something about the course</a>")
+        .to eq("<a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#about_course_wrapper\">Something about the course</a>")
     end
   end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'View helpers', type: :helper do
   describe "#enrichment_error_url" do
     it "returns enrichment error URL" do
       course = Course.new(build(:course).attributes)
-      expect(helper.enrichment_error_url(provider_code: 'A1', course: course, field: 'about_course')).to eq("/organisations/A1/#{course.recruitment_cycle_year}/courses/#{course.course_code}/about#about_course_wrapper")
+      expect(helper.enrichment_error_url(provider_code: 'A1', course: course, field: 'about_course')).to eq("/organisations/A1/#{course.recruitment_cycle_year}/courses/#{course.course_code}/about?display_errors=true#about_course_wrapper")
     end
   end
 

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'Courses' do
   describe 'POST publish' do
-    let(:provider) { jsonapi(:provider) }
+    let(:provider) { jsonapi(:provider, provider_code: 'A0') }
     let(:course) { jsonapi(:course, provider: provider) }
 
     before do


### PR DESCRIPTION
### Context
> When users publish a course, they are presented with validation errors. The fields to fix these errors are nested within a different page, such as the `about` page. When users navigate to this page after receiving a `publish` error, they should still see the error so they can correct it.

### Changes proposed in this pull request
- Update validation links to navigate to the rails frontend app
- Display validation messages on the individual enrichment pages

### Guidance to review
- Try and publish an invalid course then click one of the validation message links
