### PR TITLE
Updated base_url to use service domain in new_staging.yml

### DIFF
--- a/config/settings/new_staging.yml
+++ b/config/settings/new_staging.yml
@@ -2,13 +2,13 @@ dfe_signin:
   issuer: https://signin-test-oidc-as.azurewebsites.net
   profile: https://signin-test-pfl-as.azurewebsites.net
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
-  base_url: https://bat-stg-mcfe-as.azurewebsites.net
+  base_url: https://www2.staging.publish-teacher-training-courses.service.gov.uk
 manage_backend:
-  base_url: https://bat-stg-mcbe-as.azurewebsites.net
+  base_url: https://api2.staging.publish-teacher-training-courses.service.gov.uk
 manage_ui:
-  base_url: https://bat-stg-mcui-as.azurewebsites.net
+  base_url: https://www.staging.publish-teacher-training-courses.service.gov.uk
 search_ui:
-  base_url: https://bat-stg-sacui-as.azurewebsites.net
+  base_url: https://www.staging.find-postgraduate-teacher-training.service.gov.uk
 environment:
   label: 'Staging'
   selector_name: 'staging'


### PR DESCRIPTION
### Context
Update new staging environment to use non-Azure domains

### Changes proposed in this pull request
Change base_url value in New_staging.yml file from default azure web app .azurewebsites.net urls to service domains

### Guidance to review
base_url updated in new_staging.yml file only.  New staging service domain urls are as follows:
mcapi: https://api.staging.publish-teacher-training-courses.service.gov.uk
mcbe: https://api2.staging.publish-teacher-training-courses.service.gov.uk
mcfe: https://www2.staging.publish-teacher-training-courses.service.gov.uk
mcspt: https://support.staging.publish-teacher-training-courses.service.gov.uk
mcui: https://www.staging.publish-teacher-training-courses.service.gov.uk
sacapi: https://api.staging.find-postgraduate-teacher-training.service.gov.uk
sacui: https://www.staging.find-postgraduate-teacher-training.service.gov.uk
