### PR TITLE
[1620] It's grade 4 not level 4

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -184,7 +184,7 @@
             </summary>
             <div class="govuk-details__text">
               <p class="govuk-body">
-                By law, all applicants need a GCSE grade of C (or level 4), or an equivalent, in English and Mathematics – and Science for Primary courses.
+                By law, all applicants need a GCSE grade of C (or grade 4), or an equivalent, in English and Mathematics – and Science for Primary courses.
               </p>
 
               <p class="govuk-body">


### PR DESCRIPTION
### Context

Content should always read 'grade 4' not 'level 4' as GCSEs are not qualification level 4. Highlighted in a show and tell.
