### PR TITLE
[1698] Fix up sites on preview page

### DIFF
--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -40,7 +40,7 @@ feature 'Preview course', type: :feature do
   before do
     stub_omniauth
     stub_api_v2_request(
-      "/providers/AO/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
+      "/providers/AO/courses/#{course.course_code}?include=site_statuses.site,provider.sites,accrediting_provider",
       course_response
     )
   end


### PR DESCRIPTION
### Context
Preview page

### Changes proposed in this pull request
Include `site_statuses` on the course#preview page because we need to get the `has_vacancies?` method from each site_status

### Guidance to review
Example - https://localhost:3000/organisations/1CS/courses/2DHM/preview