### PR TITLE
[1671] Course fee improvements

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,8 +6,8 @@ class Course < Base
   custom_endpoint :sync_with_search_and_compare, on: :member, request_method: :post
   custom_endpoint :publish, on: :member, request_method: :post
 
-  property :fee_international, type: :integer
-  property :fee_uk_eu, type: :integer
+  property :fee_international, type: :string
+  property :fee_uk_eu, type: :string
 
   self.primary_key = :course_code
 

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -30,7 +30,7 @@
           <div class="govuk-currency-input">
             <div class="govuk-currency-input__inner">
               <span class="govuk-currency-input__inner__unit">£</span>
-              <%= f.number_field field, options.merge(
+              <%= f.text_field field, options.merge(
                 class: 'govuk-currency-input__inner__input govuk-input govuk-input--width-10',
                 value: number_with_precision(course.fee_uk_eu, precision: 2, strip_insignificant_zeros: true)
               ) %>
@@ -46,7 +46,7 @@
           <div class="govuk-currency-input">
             <div class="govuk-currency-input__inner">
               <span class="govuk-currency-input__inner__unit">£</span>
-              <%= f.number_field field, options.merge(
+              <%= f.text_field field, options.merge(
                 class: 'govuk-currency-input__inner__input govuk-input govuk-input--width-10',
                 value: number_with_precision(course.fee_international, precision: 2, strip_insignificant_zeros: true)
               ) %>


### PR DESCRIPTION
### Context

Users are currently unable to save the empty string value on the course fee fields.

### Changes proposed in this pull request

#### Mark fee attributes on course as strings

This prevents `json_api_client` from typecasting a valid value of '' (empty string) to `0`, which are two separate values in our system. It also removes some weird behaviour, like how `9,000.00` is cast to `9`.

We should revisit our own (or rather, now lack of any) casting and validations to make sure we're doing as much work as we can so that users don't constantly bump into "X is not a number" type errors when they type reasonable values like `£9,000.00`.

#### Use text_fields instead of number_fields

[The Design System encourages using input type='text' for currency values](https://design-system.service.gov.uk/components/text-input/). While it is not explicitly stated, it is because type='number' introduces potential accessibility issues.

### Guidance to review

No tests as it feels like those would be testing the web platform and `json_api_client` respectively.