### PR TITLE
Only list new or running sites on course preview

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -86,6 +86,10 @@ class CourseDecorator < ApplicationDecorator
     object.sites.sort_by(&:location_name)
   end
 
+  def preview_site_statuses
+    site_statuses.select(&:new_or_running?).sort_by { |status| status.site.location_name }
+  end
+
   def has_site?(site)
     object.sites.include?(site)
   end

--- a/app/views/courses/preview/_apply.html.erb
+++ b/app/views/courses/preview/_apply.html.erb
@@ -25,7 +25,7 @@
   <h3 class="govuk-heading-m">Choose a training location</h3>
   <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>
 
-  <table class="govuk-table">
+  <table class="govuk-table" data-qa="course__choose_a_training_location">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Location</th>
@@ -34,7 +34,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% course.site_statuses.each do |site_status| %>
+      <% course.preview_site_statuses.each do |site_status| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
             <strong><%= site_status.site.location_name %></strong>

--- a/spec/site_prism/page_objects/page/organisations/course_preview.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_preview.rb
@@ -35,6 +35,7 @@ module PageObjects
         element :contact_address, '[data-qa=provider__address]'
         element :course_advice, '#section-advice'
         element :course_apply, '#section-apply'
+        element :choose_a_training_location_table, '[data-qa=course__choose_a_training_location]'
       end
     end
   end


### PR DESCRIPTION
### Context

Whereas on live we want to show only running sites, on preview the course might not be live – when in this state all sites will be in status "new".

### Changes proposed in this pull request

- Restrict sites to just those that are new or running
- Add feature spec to check which sites and their vacancies are shown in preview
- Sites that are new or running but have no vacancies still show, but the vacancies column says "No"
- Adds sorting of sites

### Guidance to review

- Test with a new course
- Test with a running course
