### PR TITLE
[1712] Add fee details to preview

### DIFF
--- a/app/views/courses/preview/_fees.html.erb
+++ b/app/views/courses/preview/_fees.html.erb
@@ -29,6 +29,12 @@
         </tbody>
       </table>
     </div>
+
+    <% if course.fee_details.present? %>
+      <div data-qa="course__fee_details">
+        <%= markdown(course.fee_details) %>
+      </div>
+    <% end %>
   <% else %>
     <p class="missing-section">Please add details for this section.</p>
   <% end %>

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -11,6 +11,7 @@ feature 'Preview course', type: :feature do
             start_date: '2019-09-01T00:00:00Z',
             fee_uk_eu: '9250.0',
             fee_international: '9250.0',
+            fee_details: 'Optional fee details',
             has_scholarship_and_bursary?: true,
             scholarship_amount: '20000',
             bursary_amount: '22000',
@@ -117,6 +118,10 @@ feature 'Preview course', type: :feature do
 
     expect(preview_course_page.international_fees).to have_content(
       '£9,250'
+    )
+
+    expect(preview_course_page.fee_details).to have_content(
+      decorated_course.fee_details
     )
 
     expect(preview_course_page).to_not have_salary_details

--- a/spec/site_prism/page_objects/page/organisations/course_preview.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_preview.rb
@@ -19,6 +19,7 @@ module PageObjects
         element :school_placements, '#section-schools'
         element :uk_fees, '[data-qa=course__uk_fees]'
         element :eu_fees, '[data-qa=course__eu_fees]'
+        element :fee_details, '[data-qa=course__fee_details]'
         element :international_fees, '[data-qa=course__international_fees]'
         element :salary_details, '#section-salary'
         element :scholarship_amount, '[data-qa=course__scholarship_amount]'


### PR DESCRIPTION
This was missing from the new preview page.

### Context

The new course preview did not include the fee details section.

C#: https://github.com/DFE-Digital/search-and-compare-ui/blob/master/shared/Views/Shared/Components/CourseDetails/_Fees.cshtml#L53-L56

### Changes proposed in this pull request

| Before | After |
|-|-|
|![Screen Shot 2019-07-02 at 11 53 42](https://user-images.githubusercontent.com/319055/60507482-2a5e7c80-9cc0-11e9-9429-7cefc5a99f30.png)|![Screen Shot 2019-07-02 at 11 53 27](https://user-images.githubusercontent.com/319055/60507483-2cc0d680-9cc0-11e9-976d-57543b32fa89.png)|

### Guidance to review

- Add some fee details to a course
- Preview it
