### PR TITLE
[1664] Handle publish errors better

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -90,16 +90,10 @@ class CoursesController < ApplicationController
   def preview; end
 
   def publish
-    errors = @course.publish(provider_code: @provider.provider_code).errors
-    if errors.present?
-      flash[:error_summary] = errors.map { |error|
-        [
-          error[:title].last(error[:title].length - 'Invalid '.length),
-          error[:detail]
-        ]
-      }.to_h
-    else
+    if @course.publish
       flash[:success] = "Your course has been published."
+    else
+      flash[:error_summary] = @course.errors.messages
     end
 
     redirect_to provider_course_path(@provider.provider_code, @course.course_code)

--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -5,15 +5,17 @@ module CourseHelper
                 href: enrichment_error_url(
                   provider_code: @provider.provider_code,
                   course: @course,
-                  field: field
+                  field: field.to_s
                 )
   end
 
   def course_summary_label(key, field)
     if @errors&.key? field
-      error = @errors[field]
       content_tag :dt, class: 'govuk-summary-list__key course-parts__fields__label--error' do
-        content_tag(:span, key) + course_manage_error_link(field, error)
+        [
+          content_tag(:span, key),
+          *@errors[field].map { |error| course_manage_error_link(field, error) }
+        ].reduce(:+)
       end
     else
       content_tag :dt, key, class: 'govuk-summary-list__key'

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,16 +10,24 @@ class Course < Base
 
   self.primary_key = :course_code
 
-  def publish(provider_code:)
-    publish_url = "#{Course.site}providers/#{provider_code}/courses/#{course_code}/publish"
-    self.class.requestor.__send__(:request, :post, publish_url,
-                                  body: {
-                                    data: {
-                                      attributes: {},
-                                      type: "course"
-                                    }
-                                  },
-                                  params: request_params.to_params)
+  def publish
+    publish_url = "#{Course.site}providers/#{provider.provider_code}/courses/#{course_code}/publish"
+    post_options = {
+      body: { data: { attributes: {}, type: "course" } },
+      params: request_params.to_params
+    }
+
+    self.last_result_set = self.class.requestor.__send__(
+      :request, :post, publish_url, post_options
+    )
+
+    if last_result_set.has_errors?
+      self.fill_errors # Inherited from JsonApiClient::Resource
+      false
+    else
+      self.errors.clear if self.errors
+      true
+    end
   end
 
   def full_time?

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -28,14 +28,16 @@
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
-        <% @errors.each do |field, error| %>
-          <li>
-            <a href="<%= enrichment_error_url(
-              provider_code: @provider.provider_code,
-              course: @course,
-              field: field
-            ) %>"><%= error %></a>
-          </li>
+        <% @errors.each do |id, messages| %>
+          <% messages.each do |message| %>
+            <li>
+              <a href="<%= enrichment_error_url(
+                provider_code: @provider.provider_code,
+                course: @course,
+                field: id
+              ) %>"><%= message %></a>
+            </li>
+          <% end %>
         <% end %>
       </ul>
     </div>

--- a/spec/factories/errors.rb
+++ b/spec/factories/errors.rb
@@ -29,7 +29,8 @@ FactoryBot.define do
         [
           {
             title: "Invalid about_course",
-            detail: "About course can't be blank"
+            detail: "About course can't be blank",
+            source: { pointer: "/data/atributes/about_course" }
           }
         ]
       }

--- a/spec/helpers/course_helper_spec.rb
+++ b/spec/helpers/course_helper_spec.rb
@@ -10,11 +10,11 @@ RSpec.feature 'View helpers', type: :helper do
       before do
         @provider = Provider.new(build(:provider).attributes)
         @course = Course.new(build(:course).attributes)
-        @errors = { 'about_course' => 'Something about the course' }
+        @errors = { about_course: ['Something about the course'] }
       end
 
       it "returns correct content" do
-        expect(helper.course_summary_label('About course', "about_course")).to eq("<dt class=\"govuk-summary-list__key course-parts__fields__label--error\"><span>About course</span><a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/courses/#{@course.course_code}/about#about_course_wrapper\">Something about the course</a></dt>")
+        expect(helper.course_summary_label('About course', :about_course)).to eq("<dt class=\"govuk-summary-list__key course-parts__fields__label--error\"><span>About course</span><a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/courses/#{@course.course_code}/about#about_course_wrapper\">Something about the course</a></dt>")
       end
     end
   end

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -42,7 +42,7 @@ describe 'Courses' do
       end
 
       it 'redirects to the course description page' do
-        expect(flash[:error_summary]).to eq("about_course" => "About course can't be blank")
+        expect(flash[:error_summary]).to eq(about_course: ["About course can't be blank"])
         expect(response).to redirect_to(provider_course_path(provider_code: provider.provider_code, code: course.course_code))
       end
     end


### PR DESCRIPTION
### Context

Making validation errors consistent across the course.

### Changes proposed in this pull request

This makes the `@course.publish` method behave more similarly to `.save`, where it automatically populates `@course.errors` with the correct hash of errors. This is only possible now that the backend gives us back `pointer`s on the error object returned from `publish`.

There will be follow-up work to change this from using a flash to doing a `render` instead.

### Guidance to review

This will break if it's deployed without https://github.com/DFE-Digital/manage-courses-backend/pull/572. We should deploy backend end to end first.