### PR TITLE
Fix edit course locations cancel link

### DIFF
--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -105,7 +105,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -86,7 +86,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -58,7 +58,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -41,7 +41,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link" %>
+        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -53,7 +53,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link" %>
+      <%= link_to 'Cancel changes', details_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link" %>
     </p>
   </div>
 </div>

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -53,7 +53,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= link_to 'Cancel changes', details_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link" %>
+      <%= link_to 'Cancel changes', details_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
     </p>
   </div>
 </div>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -32,7 +32,7 @@
       <% else %>
         <%= form.submit "Reopen applications", class: "govuk-button" %>
       <% end %>
-      <p class="govuk-body"><%= govuk_link_to "Cancel changes", provider_recruitment_cycle_courses_path(params[:provider_code]) %></p>
+      <p class="govuk-body"><%= link_to "Cancel changes", provider_recruitment_cycle_courses_path(params[:provider_code]), class: "govuk-link govuk-link--no-visited-state" %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -34,7 +34,7 @@
       <%= f.submit "Save and publish changes", class: "govuk-button", data: { qa: 'location__publish-changes' } %>
     <% end %>
     <p class="govuk-body">
-      <%= link_to "Cancel changes", provider_recruitment_cycle_sites_path(@provider.provider_code), class: "govuk-link" %>
+      <%= link_to "Cancel changes", provider_recruitment_cycle_sites_path(@provider.provider_code), class: "govuk-link govuk-link--no-visited-state" %>
     </p>
   </div>
 </div>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -35,7 +35,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'location__publish-changes' } %>
     <% end %>
     <p class="govuk-body">
-      <%= link_to "Cancel changes", provider_recruitment_cycle_sites_path(@provider[:provider_code]), class: "govuk-link" %>
+      <%= link_to "Cancel changes", provider_recruitment_cycle_sites_path(@provider[:provider_code]), class: "govuk-link govuk-link--no-visited-state" %>
     </p>
   </div>
 </div>

--- a/spec/features/courses/sites/edit_spec.rb
+++ b/spec/features/courses/sites/edit_spec.rb
@@ -40,7 +40,7 @@ feature 'Edit course sites', type: :feature do
 
   scenario 'viewing the edit locations page' do
     expect(page).to have_link('Back', href: provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code))
-    expect(page).to have_link('Cancel changes', href: provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code))
+    expect(page).to have_link('Cancel changes', href: details_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code))
     expect(locations_page.title).to have_content('Locations')
     expect(locations_page.caption).to have_content(
       "#{course.name} (#{course.course_code})"


### PR DESCRIPTION
### Context

Cancel changes should take you back to where you came from – editing course locations is accessed from the details tab.

### Changes proposed in this pull request

- Change cancel link destination
- Add `govuk-link--no-visited-state` to cancel links