### PR TITLE
[1387] Add rollover screen

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,4 +12,6 @@ class PagesController < ApplicationController
   def new_features; end
 
   def transition_info; end
+
+  def rollover; end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,7 +26,7 @@ class SessionsController < ApplicationController
 
     if user.state == 'new'
       redirect_to transition_info_path
-    elsif user.state == 'transitioned'
+    elsif Settings.rollover && user.state == 'transitioned'
       redirect_to rollover_path
     else
       redirect_to session[:redirect_back_to] || root_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,6 +26,8 @@ class SessionsController < ApplicationController
 
     if user.state == 'new'
       redirect_to transition_info_path
+    elsif user.state == 'transitioned'
+      redirect_to rollover_path
     else
       redirect_to session[:redirect_back_to] || root_path
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,14 +1,24 @@
 class UsersController < ApplicationController
   def accept_transition_info
-    User.member(current_user['user_id']).accept_transition_screen
-    redirect_to providers_path
+    accept_screen('accept_transition_screen', rollover_path)
+  end
+
+  def accept_rollover
+    accept_screen('accept_rollover_screen', providers_path)
+  end
+
+private
+
+  def accept_screen(method, path)
+    User.member(current_user['user_id']).send(method)
+    redirect_to path
   rescue JsonApiClient::Errors::ClientError, JsonApiClient::Errors::ServerError => e
     e.env.body.delete("traces")
     Raven.extra_context(e.env)
 
     if e.is_a? JsonApiClient::Errors::ClientError
       Raven.capture_exception(e)
-      redirect_to providers_path
+      redirect_to path
     else
       raise e
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def accept_transition_info
-    accept_screen('accept_transition_screen', rollover_path)
+    accept_screen('accept_transition_screen', Settings.rollover ? rollover_path : providers_path)
   end
 
   def accept_rollover

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < Base
   custom_endpoint :accept_transition_screen, on: :member, request_method: :patch
+  custom_endpoint :accept_rollover_screen, on: :member, request_method: :patch
 
   def self.member(id)
     new(id: id)

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -1,0 +1,19 @@
+<%= content_for :page_title, "Begin preparing for the next cycle" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Begin preparing for the next cycle</h1>
+    <p class="govuk-body">All your courses, locations and details have been rolled over from the current cycle. You can now update them for the next recruitment cycle (2020 – 2021).</p>
+    <p class="govuk-body">You can:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>prepare your course descriptions</li>
+      <li>request new courses for the next cycle</li>
+      <li>delete courses you’re no longer running</li>
+    </ul>
+
+    <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>
+      <%= f.submit "Continue", class: "govuk-button", data: { qa: 'rollover__continue' } %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,8 @@ Rails.application.routes.draw do
   get "/new-features", to: "pages#new_features", as: :new_features
   get "/transition-info", to: "pages#transition_info", as: :transition_info
   patch '/accept-transition-info', to: 'users#accept_transition_info'
+  get "/rollover", to: "pages#rollover", as: :rollover
+  patch '/accept-rollover', to: 'users#accept_rollover'
 
   match '/404', to: 'errors#not_found', via: :all
   match '/403', to: 'errors#forbidden', via: :all

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,3 +36,4 @@ service_support:
 environment:
   label: 'Beta'
   selector_name: 'beta'
+rollover: true

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -12,3 +12,4 @@ search_ui:
 environment:
   label: 'Beta'
   selector_name: 'beta'
+rollover: false

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -12,3 +12,4 @@ search_ui:
 environment:
   label: 'Staging'
   selector_name: 'staging'
+rollover: false

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -22,9 +22,9 @@ describe UsersController, type: :controller do
         stub_api_v2_request("/users/#{user.id}/accept_transition_screen", {}, :patch, 200)
       end
 
-      it "redirects to providers index" do
+      it "redirects to the rollover screen" do
         get :accept_transition_info
-        expect(response).to redirect_to(providers_path)
+        expect(response).to redirect_to(rollover_path)
       end
     end
 
@@ -35,6 +35,31 @@ describe UsersController, type: :controller do
 
       it "redirects to providers index" do
         get :accept_transition_info
+        expect(Raven).to have_received(:capture_exception).with(instance_of(JsonApiClient::Errors::ClientError))
+        expect(response).to redirect_to(rollover_path)
+      end
+    end
+  end
+
+  describe 'GET #accept_rollover' do
+    context "with working request" do
+      before do
+        stub_api_v2_request("/users/#{user.id}/accept_rollover_screen", {}, :patch, 200)
+      end
+
+      it "redirects to providers index" do
+        get :accept_rollover
+        expect(response).to redirect_to(providers_path)
+      end
+    end
+
+    context "with client error" do
+      before do
+        stub_api_v2_request("/users/#{user.id}/accept_rollover_screen", {}, :patch, 400)
+      end
+
+      it "redirects to providers index" do
+        get :accept_rollover
         expect(Raven).to have_received(:capture_exception).with(instance_of(JsonApiClient::Errors::ClientError))
         expect(response).to redirect_to(providers_path)
       end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -6,11 +6,15 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name  { Faker::Name.last_name }
     email      { Faker::Internet.safe_email("#{first_name} #{last_name}") }
-    state      { 'transitioned' }
+    state      { 'rolled_over' }
     accept_terms_date_utc { Time.current }
 
     trait :new do
       state { 'new' }
+    end
+
+    trait :transitioned do
+      state { 'transitioned' }
     end
   end
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'Sign in', type: :feature do
   let(:transition_info_page) { PageObjects::Page::TransitionInfo.new }
+  let(:rollover_page)        { PageObjects::Page::Rollover.new }
   let(:organisations_page)   { PageObjects::Page::OrganisationsPage.new }
   let(:root_page)            { PageObjects::Page::RootPage.new }
 
@@ -31,6 +32,24 @@ feature 'Sign in', type: :feature do
 
     expect(transition_info_page.title).to have_content('Important new features')
     transition_info_page.continue.click
+
+    expect(rollover_page).to be_displayed
+    expect(request).to have_been_made
+  end
+
+  scenario 'new user accepts the rollover page' do
+    user = build :user, :transitioned
+
+    stub_omniauth(user: user)
+    stub_api_v2_request('/providers', jsonapi(:providers_response))
+    request = stub_api_v2_request "/users/#{user.id}/accept_rollover_screen", user.to_jsonapi, :patch
+
+    visit '/signin'
+
+    expect(rollover_page).to be_displayed
+
+    expect(rollover_page.title).to have_content('Begin preparing for the next cycle')
+    rollover_page.continue.click
 
     expect(organisations_page).to be_displayed
     expect(request).to have_been_made

--- a/spec/site_prism/page_objects/page/rollover.rb
+++ b/spec/site_prism/page_objects/page/rollover.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module Page
+    class Rollover < PageObjects::Base
+      set_url '/rollover'
+
+      element :title, 'h1'
+      element :continue, '[data-qa=rollover__continue]'
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Show rollover screen to transitioned users
- Continue showing transition screen to users who haven't seen it yet, they'll see this first (still about 60 per week seeing it)
- Only show the rollover screen once per user
- Introduce a new "rolled_over" state

Goes with https://github.com/DFE-Digital/manage-courses-backend/pull/577

![Screen Shot 2019-07-04 at 15 09 57](https://user-images.githubusercontent.com/319055/60672668-dc877700-9e6d-11e9-962e-627e2dad8a94.png)

### Guidance to review

We probably want to disable the redirect to the rollover screen until we are ready for it. What's the best way to do that?