### PR TITLE
[1394] Courses table for next and current cycles during rollover

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -160,6 +160,7 @@ private
     # rubocop:disable Style/MultilineBlockChain
     @courses_by_accrediting_provider = @provider
       .courses
+      .select { |course| course.recruitment_cycle_year == params[:recruitment_cycle_year] }
       .group_by { |course|
         # HOTFIX: A courses API response no included hash seems to cause issues with the
         # .accrediting_provider relationship lookup. To be investigated, for now,

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -13,7 +13,11 @@ class CourseDecorator < ApplicationDecorator
 
   def on_find(provider = object.provider)
     if object.findable?
-      h.govuk_link_to("Yes - view online", h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code))
+      if current_cycle?
+        h.govuk_link_to("Yes - view online", h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code))
+      elsif next_cycle?
+        "Yes – from October"
+      end
     else
       not_on_find
     end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -106,6 +106,14 @@ class CourseDecorator < ApplicationDecorator
     end
   end
 
+  def current_cycle?
+    course.recruitment_cycle_year.to_i == Settings.current_cycle
+  end
+
+  def next_cycle?
+    course.recruitment_cycle_year.to_i == Settings.current_cycle + 1
+  end
+
 private
 
   def status_tag_content

--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -1,0 +1,31 @@
+module RecruitmentCycleHelper
+  def rollover?
+    Settings.rollover
+  end
+
+  def current_cycle?
+    cycle_year == Settings.current_cycle
+  end
+
+  def next_cycle?
+    cycle_year == Settings.current_cycle + 1
+  end
+
+  def recruitment_cycle_title
+    year_range = "#{cycle_year} – #{cycle_year + 1}"
+
+    if current_cycle?
+      "Current cycle (#{year_range})"
+    elsif next_cycle?
+      "Next cycle (#{year_range})"
+    else
+      year_range
+    end
+  end
+
+private
+
+  def cycle_year
+    params[:recruitment_cycle_year].to_i
+  end
+end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -77,5 +77,14 @@ module ViewHelper
     end
   end
 
+  def show_legacy_courses_table?
+    # For the 2019/2020 cycle we transitioned mid-cycle
+    # In this year the course and site statuses aren't directly tied to the enrichment status
+    # A course could appear on Find without any published content
+    #
+    # This is not true for following years
+    params[:recruitment_cycle_year] && params[:recruitment_cycle_year] == '2019'
+  end
+
   alias_method :cns, :classnames
 end

--- a/app/views/courses/_course_table.html.erb
+++ b/app/views/courses/_course_table.html.erb
@@ -2,11 +2,19 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Course</th>
-      <th class="govuk-table__header">UCAS Status</th>
-      <th class="govuk-table__header">Content</th>
-      <th class="govuk-table__header">Is it on <abbr class="text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?</th>
+      <% if show_legacy_courses_table? %>
+        <th class="govuk-table__header">UCAS Status</th>
+        <th class="govuk-table__header">Content</th>
+      <% else %>
+        <th class="govuk-table__header">Status</th>
+      <% end %>
+      <th class="govuk-table__header">
+        <% if current_cycle? %>Is it<% else %>Will it be<% end %> on <abbr class="text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?
+      </th>
       <th class="govuk-table__header">Applications</th>
-      <th class="govuk-table__header">Vacancies</th>
+      <% if current_cycle? %>
+        <th class="govuk-table__header">Vacancies</th>
+      <% end %>
     </tr>
   </thead>
   <tbody class="govuk-table__body">

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -6,10 +6,12 @@
     %>
     <span class="govuk-body-s"><%= course.description %></span>
   </td>
-  <td class="govuk-table__cell" data-qa="courses-table__ucas-status">
-    <%= course.ucas_status %>
-  </td>
-  <td class="govuk-table__cell" data-qa="courses-table__content-status">
+  <% if show_legacy_courses_table? %>
+    <td class="govuk-table__cell" data-qa="courses-table__ucas-status">
+      <%= course.ucas_status %>
+    </td>
+  <% end %>
+  <td class="govuk-table__cell" data-qa="courses-table__status">
     <% unless course.not_running? %>
       <%= course.status_tag %>
     <% end %>
@@ -22,9 +24,11 @@
       <%= course.open_or_closed_for_applications %>
     <% end %>
   </td>
-  <td class="govuk-table__cell" data-qa="courses-table__vacancies">
-    <% if course.is_running? %>
-      <%= course.vacancies %>
-    <% end %>
-  </td>
+  <% if current_cycle? %>
+    <td class="govuk-table__cell" data-qa="courses-table__vacancies">
+      <% if course.is_running? %>
+        <%= course.vacancies %>
+      <% end %>
+    </td>
+  <% end %>
 </tr>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -18,8 +18,12 @@
   </nav>
 <% end %>
 
-<h1 class="govuk-heading-xl">Courses</h1>
-
+<h1 class="govuk-heading-xl">
+  <% if rollover? %>
+   <span class="govuk-caption-xl"><%= recruitment_cycle_title %></span>
+  <% end %>
+  Courses
+</h1>
 <p class="govuk-body">Use this section to:</p>
 
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Courses" %>
+<%= content_for :page_title, rollover? ? "Courses – #{recruitment_cycle_title}" : "Courses" %>
 
 <% content_for :before_content do %>
   <nav class="govuk-breadcrumbs">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     get '/locations', to: redirect('/organisations/%{provider_code}/2019/locations')
     get '/locations/:location_id/edit', to: redirect('/organisations/%{provider_code}/2019/locations/%{location_id}/edit')
     get '/locations/new', to: redirect('/organisations/%{provider_code}/2019/locations/new')
+    get '/courses', to: redirect('/organisations/%{provider_code}/2019/courses')
     get '/courses/:course_code', to: redirect('/organisations/%{provider_code}/2019/courses/%{course_code}')
     get '/courses/:course_code/locations', to: redirect('/organisations/%{provider_code}/2019/courses/%{course_code}/locations')
     get '/courses/:course_code/vacancies', to: redirect('/organisations/%{provider_code}/2019/courses/%{course_code}/vacancies')
@@ -26,7 +27,8 @@ Rails.application.routes.draw do
     get '/courses/:course_code/delete', to: redirect('/organisations/%{provider_code}/2019/courses/%{course_code}/delete')
     get '/courses/:course_code/preview', to: redirect('/organisations/%{provider_code}/2019/courses/%{course_code}/preview')
 
-    resources :recruitment_cycles, param: :year, path: '', only: :show do
+    # TODO: Extract year constraint to future proof for future cycles
+    resources :recruitment_cycles, param: :year, constraints: { year: /2019|2020/ }, path: '', only: :show do
       resources :courses, param: :code do
         get '/vacancies', on: :member, to: 'courses/vacancies#edit'
         put '/vacancies', on: :member, to: 'courses/vacancies#update'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,3 +37,4 @@ environment:
   label: 'Beta'
   selector_name: 'beta'
 rollover: true
+current_cycle: 2019

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -46,4 +46,32 @@ describe CourseDecorator do
   it "returns course length" do
     expect(course.length).to eq('1 year')
   end
+
+  context 'recruitment cycles' do
+    before do
+      allow(Settings).to receive(:current_cycle).and_return(2019)
+    end
+
+    context 'for a course in the current cycle' do
+      let(:course_jsonapi) {
+        jsonapi(:course, recruitment_cycle_year: '2019').to_resource
+      }
+
+      it 'knows which cycle it’s in' do
+        expect(course.next_cycle?).to eq(false)
+        expect(course.current_cycle?).to eq(true)
+      end
+    end
+
+    context 'for a course in the next cycle' do
+      let(:course_jsonapi) {
+        jsonapi(:course, recruitment_cycle_year: '2020').to_resource
+      }
+
+      it 'knows which cycle it’s in' do
+        expect(course.next_cycle?).to eq(true)
+        expect(course.current_cycle?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
 feature 'Index courses', type: :feature do
-  let(:course_1) { jsonapi :course, name: 'English', include_nulls: [:accrediting_provider] }
+  let(:course_1) {
+    jsonapi :course,
+            name: 'English',
+            include_nulls: [:accrediting_provider]
+  }
   let(:course_2) {
     jsonapi :course,
             name: 'Mathematics',
@@ -10,12 +14,35 @@ feature 'Index courses', type: :feature do
             has_vacancies?: true,
             include_nulls: [:accrediting_provider]
   }
-  let(:course_3) { jsonapi :course, findable?: false, name: 'Physics', content_status: "empty", include_nulls: [:accrediting_provider] }
-  let(:course_4) { jsonapi :course, findable?: false, name: 'Science', content_status: "published", include_nulls: [:accrediting_provider] }
-  let(:courses)  { [course_1, course_2, course_3, course_4] }
-  let(:provider) do
-    jsonapi(:provider, courses: courses, accredited_body?: true, provider_code: 'A123')
-  end
+  let(:course_3) {
+    jsonapi :course,
+            findable?: false,
+            name: 'Physics',
+            content_status: "empty",
+            include_nulls: [:accrediting_provider]
+  }
+  let(:course_4) {
+    jsonapi :course,
+            findable?: false,
+            name: 'Science',
+            content_status: "published",
+            include_nulls: [:accrediting_provider]
+  }
+  let(:next_cycle_course) {
+    jsonapi :course,
+            findable?: false,
+            name: 'Geoplanetary Science',
+            content_status: "published",
+            include_nulls: [:accrediting_provider],
+            recruitment_cycle_year: '2020'
+  }
+  let(:courses)  { [course_1, course_2, course_3, course_4, next_cycle_course] }
+  let(:provider) {
+    jsonapi :provider,
+            courses: courses,
+            accredited_body?: true,
+            provider_code: 'A123'
+  }
   let(:provider_response) { provider.render }
   let(:root_page) { PageObjects::Page::RootPage.new }
   let(:organisation_page) { PageObjects::Page::Organisations::OrganisationPage.new }
@@ -37,9 +64,11 @@ feature 'Index courses', type: :feature do
       organisation_page.courses.click
     end
 
-    scenario 'it shows a list of courses' do
+    scenario 'it shows a list of courses from this cycle' do
       expect(courses_page.title).to have_content('Courses')
       courses_table = courses_page.courses_tables.first
+
+      expect(courses_table).not_to have_content('Geoplanetary Science')
       expect(courses_table.rows.size).to eq(4)
 
       first_row = courses_table.rows.first
@@ -113,8 +142,10 @@ feature 'Index courses', type: :feature do
       organisation_page.courses.click
     end
 
-    scenario "it shows a list of courses" do
+    scenario "it shows a list of courses from this cycle" do
       expect(courses_page.title).to have_content('Courses')
+
+      expect(courses_page).not_to have_content('Geoplanetary Science')
       expect(courses_page.courses_tables.size).to eq(4)
 
       expect(courses_page.courses_tables.first).to_not have_subheading

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -28,15 +28,22 @@ feature 'Index courses', type: :feature do
             content_status: "published",
             include_nulls: [:accrediting_provider]
   }
-  let(:next_cycle_course) {
+  let(:next_cycle_course_1) {
     jsonapi :course,
-            findable?: false,
+            findable?: true,
             name: 'Geoplanetary Science',
             content_status: "published",
-            include_nulls: [:accrediting_provider],
             recruitment_cycle_year: '2020'
   }
-  let(:courses)  { [course_1, course_2, course_3, course_4, next_cycle_course] }
+  let(:next_cycle_course_2) {
+    jsonapi :course,
+            findable?: false,
+            name: 'Time travel',
+            content_status: "draft",
+            ucas_status: "new",
+            recruitment_cycle_year: '2020'
+  }
+  let(:courses)  { [course_1, course_2, course_3, course_4, next_cycle_course_1, next_cycle_course_2] }
   let(:provider) {
     jsonapi :provider,
             courses: courses,
@@ -48,20 +55,25 @@ feature 'Index courses', type: :feature do
   let(:organisation_page) { PageObjects::Page::Organisations::OrganisationPage.new }
   let(:courses_page) { PageObjects::Page::Organisations::Courses.new }
 
+  before do
+    allow(Settings).to receive(:current_cycle).and_return(2019)
+    user = build(:user)
+    stub_omniauth(user: user)
+    stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
+    stub_api_v2_request("/providers/A123", provider_response)
+    stub_api_v2_request(
+      "/providers/A123?include=courses.accrediting_provider",
+      provider_response
+    )
+  end
+
   context "without accrediting providers" do
     before do
-      allow(Settings).to receive(:rollover).and_return(false)
-      user = build(:user)
-      stub_omniauth(user: user)
-      stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
-      stub_api_v2_request("/providers/A123", provider_response)
-      stub_api_v2_request(
-        "/providers/A123?include=courses.accrediting_provider",
-        provider_response
-      )
-      root_page.load
-      expect(organisation_page).to be_displayed(provider_code: 'A123')
-      organisation_page.courses.click
+      courses_page.load(recruitment_cycle_year: '2019', provider_code: provider.provider_code)
+    end
+
+    scenario "it indicates if a course is on Find" do
+      expect(courses_page.courses_tables.first).to have_content('Is it on Find?')
     end
 
     scenario 'it shows a list of courses from this cycle' do
@@ -74,8 +86,8 @@ feature 'Index courses', type: :feature do
       first_row = courses_table.rows.first
       expect(first_row.name).to           have_content course_1.attributes[:name]
       expect(first_row.ucas_status).to    have_content 'Running'
-      expect(first_row.content_status).to have_content 'Published'
-      expect(first_row.is_it_on_find).to  have_content 'Yes - view online'
+      expect(first_row.status).to         have_content 'Published'
+      expect(first_row.on_find).to        have_content 'Yes - view online'
       expect(first_row.applications).to   have_content 'Closed'
       expect(first_row.vacancies).to      have_content 'No (Edit)'
       expect(first_row.find_link['href']).to eq(
@@ -87,7 +99,7 @@ feature 'Index courses', type: :feature do
 
       second_row = courses_table.rows.second
       expect(second_row.name).to          have_content course_2.attributes[:name]
-      expect(second_row.is_it_on_find).to have_content('Yes - view online')
+      expect(second_row.on_find).to       have_content('Yes - view online')
       expect(second_row.applications).to  have_content 'Open'
       expect(second_row.vacancies).to     have_content 'Yes (Edit)'
       expect(second_row.find_link['href']).to eql(
@@ -96,15 +108,15 @@ feature 'Index courses', type: :feature do
 
       third_row = courses_table.rows.third
       expect(third_row.name).to           have_content course_3.attributes[:name]
-      expect(third_row.content_status).to have_content 'Empty'
-      expect(third_row.is_it_on_find).to  have_content 'No'
+      expect(third_row.status).to         have_content 'Empty'
+      expect(third_row.on_find).to        have_content 'No'
       expect(third_row.applications).to   have_content ''
       expect(third_row.vacancies).to      have_content ''
 
       fourth_row = courses_table.rows.fourth
       expect(fourth_row.name).to           have_content course_4.attributes[:name]
-      expect(fourth_row.content_status).to have_content ''
-      expect(fourth_row.is_it_on_find).to  have_content 'No'
+      expect(fourth_row.status).to         have_content ''
+      expect(fourth_row.on_find).to        have_content 'No'
       expect(fourth_row.applications).to   have_content ''
       expect(fourth_row.vacancies).to      have_content ''
     end
@@ -128,27 +140,21 @@ feature 'Index courses', type: :feature do
     let(:course_4) { jsonapi :course, accrediting_provider: provider_3 }
 
     before do
-      allow(Settings).to receive(:rollover).and_return(false)
-      user = build(:user)
-      stub_omniauth(user: user)
-      stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
-      stub_api_v2_request("/providers/A123", provider_response)
-      stub_api_v2_request(
-        "/providers/A123?include=courses.accrediting_provider",
-        provider_response
-      )
-      root_page.load
-      expect(organisation_page).to be_displayed(provider_code: 'A123')
-      organisation_page.courses.click
+      courses_page.load(recruitment_cycle_year: '2019', provider_code: provider.provider_code)
     end
 
     scenario "it shows a list of courses from this cycle" do
       expect(courses_page.title).to have_content('Courses')
-
       expect(courses_page).not_to have_content('Geoplanetary Science')
+      expect(courses_page).to have_content('English')
       expect(courses_page.courses_tables.size).to eq(4)
+    end
 
+    scenario "it puts courses without an accredited body first" do
       expect(courses_page.courses_tables.first).to_not have_subheading
+    end
+
+    scenario "it orders accredited bodies alphabetically" do
       expect(courses_page.courses_tables.second.subheading).to have_content('Accredited body Aacme Scitt')
       expect(courses_page.courses_tables.third.subheading).to have_content('Accredited body e-Qualitas')
       expect(courses_page.courses_tables.fourth.subheading).to have_content('Accredited body Zacme Scitt')
@@ -191,6 +197,78 @@ feature 'Index courses', type: :feature do
     scenario "it shows a list of courses" do
       expect(courses_page.title).to have_content('Courses')
       expect(courses_page.courses_tables.size).to eq(4)
+    end
+  end
+
+  describe 'courses in the next cycle' do
+    before do
+      courses_page.load(recruitment_cycle_year: '2020', provider_code: provider.provider_code)
+    end
+
+    scenario "it indicates if a course will be on Find" do
+      expect(courses_page.courses_tables.first).to have_content('Will it be on Find?')
+    end
+
+    scenario "it shows a list of courses from the next cycle" do
+      expect(courses_page).to be_displayed
+
+      courses_table = courses_page.courses_tables.first
+      expect(courses_table.rows.size).to eq(2)
+
+      first_row = courses_table.rows.first
+      expect(first_row.name).to           have_content next_cycle_course_1.attributes[:name]
+      expect(first_row.status).to         have_content 'Published'
+      expect(first_row.on_find).to        have_content 'Yes – from October'
+      expect(first_row.applications).to   have_content 'Closed'
+
+      second_row = courses_table.rows.second
+      expect(second_row.name).to                have_content next_cycle_course_2.attributes[:name]
+      expect(second_row.status).to              have_content 'Draft'
+      expect(second_row.on_find).to             have_content('No – still in draft')
+      expect(second_row.applications.text).to   be_empty
+    end
+
+    scenario "it hides vacancies, UCAS status and Find links" do
+      courses_table = courses_page.courses_tables.first
+
+      first_row = courses_table.rows.first
+      expect(first_row).not_to have_ucas_status
+      expect(first_row).not_to have_find_link
+      expect(first_row).not_to have_vacancies
+
+      second_row = courses_table.rows.second
+      expect(second_row).not_to have_ucas_status
+      expect(second_row).not_to have_find_link
+      expect(second_row).not_to have_vacancies
+    end
+  end
+
+  describe 'courses in the 2019 cycle' do
+    before do
+      allow(Settings).to receive(:current_cycle).and_return(2020)
+      courses_page.load(recruitment_cycle_year: '2019', provider_code: provider.provider_code)
+    end
+
+    scenario "shows the UCAS status when it’s not the current cycle" do
+      courses_table = courses_page.courses_tables.first
+
+      expect(courses_table).to have_content('UCAS Status')
+      expect(courses_table).to have_content('Content')
+
+      first_row = courses_table.rows.first
+      expect(first_row.ucas_status).to    have_content 'Running'
+      expect(first_row.status).to         have_content 'Published'
+    end
+  end
+
+  describe 'during rollover' do
+    before do
+      allow(Settings).to receive(:rollover).and_return(true)
+      courses_page.load(recruitment_cycle_year: '2019', provider_code: provider.provider_code)
+    end
+
+    scenario "shows a caption above the page title" do
+      expect(courses_page.caption).to have_content('Current cycle (2019 – 2020)')
     end
   end
 end

--- a/spec/helpers/recruitment_cycle_helper_spec.rb
+++ b/spec/helpers/recruitment_cycle_helper_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'Recruitment cycle helpers', type: :helper do
+  context "viewing a page in the current cycle" do
+    before do
+      allow(Settings).to receive(:current_cycle).and_return(2019)
+      allow(helper).to receive(:params).and_return(recruitment_cycle_year: "2019")
+    end
+
+    it "knows it’s the current cycle" do
+      expect(helper.current_cycle?).to eq(true)
+      expect(helper.next_cycle?).to eq(false)
+    end
+
+    it "has the right title" do
+      expect(helper.recruitment_cycle_title).to eq("Current cycle (2019 – 2020)")
+    end
+  end
+
+  context "viewing a page in the next cycle" do
+    before do
+      allow(Settings).to receive(:current_cycle).and_return(2019)
+      allow(helper).to receive(:params).and_return(recruitment_cycle_year: "2020")
+    end
+
+    it "knows it’s the next cycle" do
+      expect(helper.current_cycle?).to eq(false)
+      expect(helper.next_cycle?).to eq(true)
+    end
+
+    it "has the right title" do
+      expect(helper.recruitment_cycle_title).to eq("Next cycle (2020 – 2021)")
+    end
+  end
+
+  context "viewing a page in a previous cycle" do
+    before do
+      allow(Settings).to receive(:current_cycle).and_return(2020)
+      allow(helper).to receive(:params).and_return(recruitment_cycle_year: "2019")
+    end
+
+    it "knows it’s not the current cycle or the next cycle" do
+      expect(helper.current_cycle?).to eq(false)
+      expect(helper.next_cycle?).to eq(false)
+    end
+
+    it "just shows the years as the title" do
+      expect(helper.recruitment_cycle_title).to eq("2019 – 2020")
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses.rb
@@ -5,6 +5,7 @@ module PageObjects
         set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses'
 
         element :flash, '.govuk-success-summary'
+        element :caption, '.govuk-caption-xl'
 
         sections :courses_tables, '[data-qa="courses__table-section"]' do
           element :subheading, 'h2'
@@ -12,8 +13,8 @@ module PageObjects
             element :name, '[data-qa="courses-table__course"]'
             element :link, 'td.course-table__course-name a'
             element :ucas_status, '[data-qa="courses-table__ucas-status"]'
-            element :content_status, '[data-qa="courses-table__content-status"]'
-            element :is_it_on_find, '[data-qa="courses-table__findable"]'
+            element :status, '[data-qa="courses-table__status"]'
+            element :on_find, '[data-qa="courses-table__findable"]'
             element :find_link, '[data-qa="courses-table__findable"] a'
             element :applications, '[data-qa="courses-table__applications"]'
             element :vacancies, '[data-qa="courses-table__vacancies"]'


### PR DESCRIPTION
### Context



https://bat-design-history.herokuapp.com/publish-teacher-training/publishing-during-rollover

### Changes proposed in this pull request
- Filter courses by recruitment_cycle_year
- During a rollover period, indicate if the courses shown are for the current or next cycle
- Add helpers to determine which cycle is being shown
- Show a slightly different table for the next cycle
- Show a simplified courses table for all cycles after 2019

What's intentionally missing from this PR:
- Breadcrumbs
- A link to a different "Add course" Google form
- Handling of the "Applications" column (depends on what we intend to do with rolled over courses)
- Handling of the courses page when the current cycle becomes a previous cycle

### Guidance to review
- Modify some local courses to be in the next recruitment cycle in backend, for example:
```ruby
next_cycle = RecruitmentCycle.all[1]
courses[0..3].each { |c| c.recruitment_cycle = next_cycle; c.save }
```
- Change `2019` to `2020` in the URL

### Screenshots

#### Next cycle
![Screen Shot 2019-07-05 at 14 52 58](https://user-images.githubusercontent.com/319055/60726995-c5f82300-9f34-11e9-8d08-cc98e92cd531.png)

(note: The draft course here shouldn't say it'll be on Find, this is because the copied course has a UCAS status of running, which needs to be reset to new)

#### Current cycle during rollover
![Screen Shot 2019-07-05 at 14 46 36](https://user-images.githubusercontent.com/319055/60726996-c5f82300-9f34-11e9-9ce7-a4cb17907ab5.png)

#### Current cycle before we enable rollover
![Screen Shot 2019-07-05 at 14 53 48](https://user-images.githubusercontent.com/319055/60726994-c5f82300-9f34-11e9-8e85-29660060644c.png)