### PR TITLE
[1738] Fix link style

### DIFF
--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -20,7 +20,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @provider.rolled_over? %>
-      <h2 class="govuk-heading-m"><%= govuk_link_to "Current cycle (2019 – 2020)", provider_recruitment_cycle_path(@provider.provider_code, '2019'), data: { qa: 'provider__courses__current_cycle' } %></h2>
+      <h2 class="govuk-heading-m"><%= link_to "Current cycle (2019 – 2020)", provider_recruitment_cycle_path(@provider.provider_code, '2019'), data: { qa: 'provider__courses__current_cycle' }, class: "govuk-link" %></h2>
       <p class="govuk-body">Use this section to:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
         <li>write about your organisation</li>


### PR DESCRIPTION
### Context

Link didn't have the `.govuk-link` styling.

### Changes proposed in this pull request

Switch `govuk_link_to` helper to `.govuk-link` as `data: {}` is replacing HTML options in helper.
