### PR TITLE
 Make sure tests past irrespective of rollover setting

### DIFF
--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -53,6 +53,7 @@ feature 'Index courses', type: :feature do
   let(:provider_response) { provider.render }
   let(:root_page) { PageObjects::Page::RootPage.new }
   let(:organisation_page) { PageObjects::Page::Organisations::OrganisationPage.new }
+  let(:recruitment_cycle_page) { PageObjects::Page::Organisations::RecruitmentCycle.new }
   let(:courses_page) { PageObjects::Page::Organisations::Courses.new }
 
   before do
@@ -66,6 +67,12 @@ feature 'Index courses', type: :feature do
       "/providers/A123?include=courses.accrediting_provider",
       provider_response
     )
+  end
+
+  scenario "can navigate to a courses page" do
+    root_page.load
+    organisation_page.courses.click
+    expect(courses_page).to be_displayed
   end
 
   context "without accrediting providers" do
@@ -169,6 +176,24 @@ feature 'Index courses', type: :feature do
   context "during rollover" do
     before do
       allow(Settings).to receive(:rollover).and_return(true)
+    end
+
+    scenario "can navigate to a courses page via the current cycle" do
+      root_page.load
+      organisation_page.current_cycle.click
+      recruitment_cycle_page.courses_link.click
+
+      expect(courses_page).to be_displayed
+      expect(courses_page.caption).to have_content('Current cycle')
+    end
+
+    scenario "can navigate to a courses page via the next cycle" do
+      root_page.load
+      organisation_page.next_cycle.click
+      recruitment_cycle_page.courses_link.click
+
+      expect(courses_page).to be_displayed
+      expect(courses_page.caption).to have_content('Next cycle')
     end
 
     describe "courses in the current cycle" do

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -165,39 +165,11 @@ feature 'Index courses', type: :feature do
     end
   end
 
-  context "rollover" do
-    let(:provider) do
-      jsonapi(:provider, courses: courses, accredited_body?: false, provider_code: 'A123')
-    end
-    let(:provider_response) { provider.render }
-    let(:provider_1) { jsonapi :provider, id: "1", provider_name: "Zacme Scitt" }
-    let(:provider_2) { jsonapi :provider, id: "2", provider_name: "Aacme Scitt" }
-    let(:provider_3) { jsonapi :provider, id: "3", provider_name: "e-Qualitas" }
-
-    let(:course_2) { jsonapi :course, accrediting_provider: provider_1 }
-    let(:course_3) { jsonapi :course, accrediting_provider: provider_2 }
-    let(:course_4) { jsonapi :course, accrediting_provider: provider_3 }
-
+  context "during rollover" do
     before do
       allow(Settings).to receive(:rollover).and_return(true)
-      user = build(:user)
-      stub_omniauth(user: user)
-      stub_api_v2_request('/providers', jsonapi(:providers_response, data: [provider_response[:data]]))
-      stub_api_v2_request("/providers/A123", provider_response)
-      stub_api_v2_request(
-        "/providers/A123?include=courses.accrediting_provider",
-        provider_response
-      )
-      root_page.load
-      expect(organisation_page).to be_displayed(provider_code: 'A123')
-      organisation_page.current_cycle.click
-      organisation_page.courses.click
     end
 
-    scenario "it shows a list of courses" do
-      expect(courses_page.title).to have_content('Courses')
-      expect(courses_page.courses_tables.size).to eq(4)
-    end
   end
 
   describe 'courses in the next cycle' do


### PR DESCRIPTION
### Context

Failing specs found by changing rollover to false and running test suite.

### Changes proposed in this pull request

- Correctly set expected rollover setting for each spec context.
- Remove some unnecessary test setup in courses/index_spec rollover context

### Guidance to review

- Best reviewed commit by commit
- Hide whitespace as some code blocks moved into new contexts