### PR TITLE
[1748] Record form errors/success on publish

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -29,7 +29,7 @@
 <% end %>
 
 <% if @errors.present? %>
-  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
       You’ll need to correct some information.
     </h2>
@@ -52,7 +52,7 @@
 <% end %>
 
 <% if @published.present? %>
-  <div class="govuk-success-summary" aria-labelledby="success-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+  <div class="govuk-success-summary" aria-labelledby="success-summary-title" role="alert" tabindex="-1" data-module="error-summary" data-ga-event-form="success">
     <h2 class="govuk-success-summary__title" id="success-summary-title">
       <%= @published %>
     </h2>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -2,6 +2,7 @@ import "../stylesheets/application.scss";
 import { initAll } from "govuk-frontend";
 import CookieMessage from "scripts/cookie-banner";
 import FormCheckLeave from "scripts/form-check-leave";
+import { triggerFormAnalytics } from "scripts/form-error-tracking";
 
 initAll();
 
@@ -26,4 +27,19 @@ if ($copyWarningMessage) {
   window.onbeforeunload = function() {
     return "You have unsaved changes, are you sure you want to leave?";
   };
+}
+
+if (typeof ga === "function") {
+  const $formErrorSummary = document.querySelector(
+    '[data-ga-event-form="error"]'
+  );
+  const $formSuccessSummary = document.querySelector(
+    '[data-ga-event-form="success"]'
+  );
+
+  if ($formErrorSummary) {
+    triggerFormAnalytics("form", "form-publish", "form-error");
+  } else if ($formSuccessSummary) {
+    triggerFormAnalytics("form", "form-publish", "form-success");
+  }
 }

--- a/app/webpacker/scripts/form-error-tracking.js
+++ b/app/webpacker/scripts/form-error-tracking.js
@@ -1,0 +1,7 @@
+export function triggerFormAnalytics(category, action, label) {
+  ga("send", "event", {
+    eventCategory: category,
+    eventAction: action,
+    eventLabel: label
+  });
+}


### PR DESCRIPTION
### Context

Record form errors/success on publish and send to Google Analytics.

### Changes proposed in this pull request

Added the `data-ga-event-form` to error element and pass in values "error" or "success"