### PR TITLE
[1748] Record the form error messages to GA

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -37,7 +37,7 @@
       <ul class="govuk-list govuk-error-summary__list">
         <% @errors.each do |id, messages| %>
           <% messages.each do |message| %>
-            <li>
+            <li data-error-message="<%= message %>">
               <a href="<%= enrichment_error_url(
                 provider_code: @provider.provider_code,
                 course: @course,

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -38,7 +38,19 @@ if (typeof ga === "function") {
   );
 
   if ($formErrorSummary) {
+    const $formErrorMessages = $formErrorSummary.querySelectorAll(
+      "[data-error-message]"
+    );
+
     triggerFormAnalytics("form", "form-publish", "form-error");
+
+    $formErrorMessages.forEach(function($errorMessage) {
+      triggerFormAnalytics(
+        "form",
+        "form-error-message",
+        $errorMessage.getAttribute("data-error-message")
+      );
+    });
   } else if ($formSuccessSummary) {
     triggerFormAnalytics("form", "form-publish", "form-success");
   }


### PR DESCRIPTION
### Context

Send form errors to GA.

### Changes proposed in this pull request

Add `data-error-message` data attribute to error message `li` rather than targeting the inner text of the `li a`
