### PR TITLE
[1678] Added back button to parent page on guidance

### DIFF
--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -1,5 +1,9 @@
 <%= content_for :page_title, "Guidance" %>
 
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(:back) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Guidance for Publish teacher training courses</h1>

--- a/app/views/pages/new_features.html.erb
+++ b/app/views/pages/new_features.html.erb
@@ -10,24 +10,32 @@
     <h2 class="govuk-heading-l">Recently released</h2>
     <p class="govuk-body">You can now:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>change locations assigned to a course (<a href="https://www.youtube.com/watch?v=W_zhfemKiYM" class="govuk-link">Watch a video<span class="govuk-visually-hidden">of the assigning locations feature</span></a>)</li>
       <li>edit course vacancies (<a href="https://www.youtube.com/watch?v=nxmtXGy1cCY" class="govuk-link">Watch a video<span class="govuk-visually-hidden">of the edit vacancies feature</span></a>)</li>
-      <li>add a new location</li>
-      <li>edit a location name and address</li>
-      <li>request a new course using a Google Form</li>
+      <li>edit a location name and address (<a href="https://www.youtube.com/watch?v=W_zhfemKiYM" class="govuk-link">Watch a video<span class="govuk-visually-hidden">of the assigning locations feature</span></a>)</li>
+      <li>add a new location (<a href="https://www.youtube.com/watch?v=W_zhfemKiYM" class="govuk-link">Watch a video<span class="govuk-visually-hidden">of the assigning locations feature</span></a>)</li>
+      <li>assign locations to a course (<a href="https://www.youtube.com/watch?v=W_zhfemKiYM" class="govuk-link">Watch a video<span class="govuk-visually-hidden">of the assigning locations feature</span></a>)</li>
+      <li>request a new course using a Google Form </li>
     </ul>
 
-    <h2 class="govuk-heading-l">May to June 2019</h2>
-    <p class="govuk-body">You’ll be able to:</p>
+    <h2 class="govuk-heading-l">July 2019</h2>
+    <p class="govuk-body">In July we’ll roll over your courses. Once we’ve done this, you’ll be able to:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>edit the UCAS Apply eligibility requirements for a course</li>
+      <li>view your courses for the next cycle (2020 – 2021)</li>
+      <li>edit their detailed descriptions (the content in 'About this course') and locations</li>
+      <li>view their basic details</li>
     </ul>
 
-    <h2 class="govuk-heading-l">July to September 2019</h2>
-    <p class="govuk-body">You’ll be able to:</p>
+    <h2 class="govuk-heading-l">August to September 2019</h2>
+    <p class="govuk-body">You’ll be able to edit all the basic details of your courses, including:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>rollover and prepare your courses for the next cycle</li>
-      <li>edit all aspects of a course</li>
+      <li>the UCAS Apply eligibility requirements</li>
+      <li>the course outcomes</li>
+      <li>the age range</li>
+    </ul>
+
+    <p class="govuk-body">You’ll also be able to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>edit all additional course content</li>
       <li>add a new course</li>
     </ul>
   </div>


### PR DESCRIPTION
### Context

Add back button to parent page from guidance page

### Changes proposed in this pull request

Added a generic back button that will return the user to the parent page.

### Guidance to review

Is this worth turning this into a partial and repeating on multiple pages? Such as cookies, terms etc.
