### PR TITLE
[1678] Added back link to guidance page

### DIFF
--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -1,5 +1,13 @@
 <%= content_for :page_title, "Guidance" %>
 
+<% content_for :before_content do %>
+  <% if request.referrer.present? %>
+    <%= govuk_back_link_to(:back) %>
+  <% else %>
+    <%= govuk_back_link_to(providers_path) %>
+  <% end %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Guidance for Publish teacher training courses</h1>


### PR DESCRIPTION
### Context

Add a button to return to the referrer page so that the page no longer feels like a dead end.

### Changes proposed in this pull request

Button to return back to the page the user came from no matter where they are.

### Guidance to review

Should this become a component/partial that we can reuse on other pages? Such as cookies, terms etc.