### PR TITLE
[1758] Add URLs and entries for next cycle course forms

### DIFF
--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -1,6 +1,6 @@
 module ProviderHelper
-  def add_course_url(email, provider, current)
-    cycle_key = current ? 'current_cycle' : 'next_cycle'
+  def add_course_url(email, provider, is_current_cycle:)
+    cycle_key = is_current_cycle ? 'current_cycle' : 'next_cycle'
 
     if provider.accredited_body?
       google_form_url_for(Settings.google_forms[cycle_key].new_course_for_accredited_bodies, email, provider)
@@ -9,8 +9,8 @@ module ProviderHelper
     end
   end
 
-  def add_course_link(email, provider, current)
-    link_to "Add a new course", add_course_url(email, provider, current), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank"
+  def add_course_link(email, provider, is_current_cycle:)
+    link_to "Add a new course", add_course_url(email, provider, is_current_cycle: is_current_cycle), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank"
   end
 
   def google_form_url_for(settings, email, provider)

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -1,14 +1,16 @@
 module ProviderHelper
-  def add_course_url(email, provider)
+  def add_course_url(email, provider, current)
+    cycle_key = current ? 'current_cycle' : 'next_cycle'
+
     if provider.accredited_body?
-      google_form_url_for(Settings.google_forms.new_course_for_accredited_bodies, email, provider)
+      google_form_url_for(Settings.google_forms[cycle_key].new_course_for_accredited_bodies, email, provider)
     else
-      google_form_url_for(Settings.google_forms.new_course_for_unaccredited_bodies, email, provider)
+      google_form_url_for(Settings.google_forms[cycle_key].new_course_for_unaccredited_bodies, email, provider)
     end
   end
 
-  def add_course_link(email, provider)
-    link_to "Add a new course", add_course_url(email, provider), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank"
+  def add_course_link(email, provider, current)
+    link_to "Add a new course", add_course_url(email, provider, current), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank"
   end
 
   def google_form_url_for(settings, email, provider)

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -41,7 +41,7 @@
 </ul>
 
 <% if @provider.courses.count > 10 %>
-  <%= add_course_link(current_user['info']['email'], @provider) %>
+  <%= add_course_link(current_user['info']['email'], @provider, @recruitment_cycle.current?) %>
   <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your course details.</p>
 <% end %>
 
@@ -62,5 +62,5 @@
   </section>
 <% end %>
 
-<%= add_course_link(current_user['info']['email'], @provider) %>
+<%= add_course_link(current_user['info']['email'], @provider, @recruitment_cycle.current?) %>
 <p class="govuk-body-s">You’ll be taken to a Google Form to fill in your course details.</p>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -41,7 +41,7 @@
 </ul>
 
 <% if @provider.courses.count > 10 %>
-  <%= add_course_link(current_user['info']['email'], @provider, @recruitment_cycle.current?) %>
+  <%= add_course_link(current_user['info']['email'], @provider, is_current_cycle: @recruitment_cycle.current?) %>
   <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your course details.</p>
 <% end %>
 
@@ -62,5 +62,5 @@
   </section>
 <% end %>
 
-<%= add_course_link(current_user['info']['email'], @provider, @recruitment_cycle.current?) %>
+<%= add_course_link(current_user['info']['email'], @provider, is_current_cycle: @recruitment_cycle.current?) %>
 <p class="govuk-body-s">You’ll be taken to a Google Form to fill in your course details.</p>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,14 +23,24 @@ search_ui:
   # URL of the C# search ui app (search-and-compare-ui)
   base_url: https://localhost:5000
 google_forms:
-  new_course_for_accredited_bodies:
-    url: https://docs.google.com/forms/d/e/1FAIpQLSd4k5wSjrVyFu-FW4ZaSsrbK0AwTpjmzfyTdfa_qdXLZ313HQ/viewform?usp=pp_url
-    email_entry: entry.957076544
-    provider_code_entry: entry.1735563938
-  new_course_for_unaccredited_bodies:
-    url: https://docs.google.com/forms/d/e/1FAIpQLSeatJO2ZuqM-fnRJxEo6IIF0hZIU63JGnx0sDXO6Ulax7U_bA/viewform?usp=pp_url
-    email_entry: entry.1033530353
-    provider_code_entry: entry.158771972
+  current_cycle:
+    new_course_for_accredited_bodies:
+      url: https://docs.google.com/forms/d/e/1FAIpQLSd4k5wSjrVyFu-FW4ZaSsrbK0AwTpjmzfyTdfa_qdXLZ313HQ/viewform?usp=pp_url
+      email_entry: entry.957076544
+      provider_code_entry: entry.1735563938
+    new_course_for_unaccredited_bodies:
+      url: https://docs.google.com/forms/d/e/1FAIpQLSeatJO2ZuqM-fnRJxEo6IIF0hZIU63JGnx0sDXO6Ulax7U_bA/viewform?usp=pp_url
+      email_entry: entry.1033530353
+      provider_code_entry: entry.158771972
+  next_cycle:
+    new_course_for_accredited_bodies:
+      url: https://docs.google.com/forms/d/e/1FAIpQLScckkzOwt93FTZGgZCBRA6spAnSO06UKewD5N6P3moBhIpKiA/viewform?usp=pp_url
+      email_entry: entry.957076544
+      provider_code_entry: entry.1735563938
+    new_course_for_unaccredited_bodies:
+      url: https://docs.google.com/forms/d/e/1FAIpQLSeD1BwS11lYm4PJ8WZMRIU5U02h0z-T5WlC0aqycc1CHV-e0A/viewform?usp=pp_url
+      email_entry: entry.1033530353
+      provider_code_entry: entry.158771972
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk
 environment:

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -130,7 +130,7 @@ feature 'Index courses', type: :feature do
     end
 
     scenario "it shows 'add a new course' link" do
-      expect(courses_page).to have_link_to_add_a_course_for_accredited_bodies
+      expect(courses_page).to have_link_to_add_a_course_for_accredited_bodies_current_cycle
     end
   end
 
@@ -169,7 +169,7 @@ feature 'Index courses', type: :feature do
     end
 
     scenario "it shows 'add a new course' link" do
-      expect(courses_page).to have_link_to_add_a_course_for_unaccredited_bodies
+      expect(courses_page).to have_link_to_add_a_course_for_unaccredited_bodies_current_cycle
     end
   end
 
@@ -185,6 +185,7 @@ feature 'Index courses', type: :feature do
 
       expect(courses_page).to be_displayed
       expect(courses_page.caption).to have_content('Current cycle')
+      expect(courses_page).to have_link_to_add_a_course_for_accredited_bodies_current_cycle
     end
 
     scenario "can navigate to a courses page via the next cycle" do
@@ -194,6 +195,7 @@ feature 'Index courses', type: :feature do
 
       expect(courses_page).to be_displayed
       expect(courses_page.caption).to have_content('Next cycle')
+      expect(courses_page).to have_link_to_add_a_course_for_accredited_bodies_next_cycle
     end
 
     describe "courses in the current cycle" do

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -7,7 +7,7 @@ feature 'View helpers', type: :helper do
 
   describe "#add_course_link" do
     it "builds a link" do
-      expect(helper.add_course_link(email, provider)).to eq("<a class=\"govuk-button govuk-!-margin-bottom-2\" rel=\"noopener noreferrer\" target=\"_blank\" href=\"#{CGI::escapeHTML(helper.add_course_url(email, provider))}\">Add a new course</a>")
+      expect(helper.add_course_link(email, provider, true)).to eq("<a class=\"govuk-button govuk-!-margin-bottom-2\" rel=\"noopener noreferrer\" target=\"_blank\" href=\"#{CGI::escapeHTML(helper.add_course_url(email, provider, true))}\">Add a new course</a>")
     end
   end
 
@@ -15,20 +15,32 @@ feature 'View helpers', type: :helper do
     describe "for accredited bodies" do
       let(:provider) { jsonapi(:provider, accredited_body?: true).to_resource }
 
-      it "returns correct google form" do
-        expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.new_course_for_accredited_bodies.url)
-        expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
-        expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
+      it "returns correct google form for the current cycle" do
+        expect(helper.add_course_url(email, provider, true)).to start_with(Settings.google_forms.current_cycle.new_course_for_accredited_bodies.url)
+        expect(helper.add_course_url(email, provider, true)).to include(html_escaped_version_of_email)
+        expect(helper.add_course_url(email, provider, true)).to include(provider.attributes[:provider_code])
+      end
+
+      it "returns correct google form for the next cycle" do
+        expect(helper.add_course_url(email, provider, false)).to start_with(Settings.google_forms.next_cycle.new_course_for_accredited_bodies.url)
+        expect(helper.add_course_url(email, provider, false)).to include(html_escaped_version_of_email)
+        expect(helper.add_course_url(email, provider, false)).to include(provider.attributes[:provider_code])
       end
     end
 
     describe "for non-accredited bodies" do
       let(:provider) { jsonapi(:provider, accredited_body?: false).to_resource }
 
-      it "returns correct google form" do
-        expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.new_course_for_unaccredited_bodies.url)
-        expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
-        expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
+      it "returns correct google form for the current cycle" do
+        expect(helper.add_course_url(email, provider, true)).to start_with(Settings.google_forms.current_cycle.new_course_for_unaccredited_bodies.url)
+        expect(helper.add_course_url(email, provider, true)).to include(html_escaped_version_of_email)
+        expect(helper.add_course_url(email, provider, true)).to include(provider.attributes[:provider_code])
+      end
+
+      it "returns correct google form for the next cycle" do
+        expect(helper.add_course_url(email, provider, false)).to start_with(Settings.google_forms.next_cycle.new_course_for_unaccredited_bodies.url)
+        expect(helper.add_course_url(email, provider, false)).to include(html_escaped_version_of_email)
+        expect(helper.add_course_url(email, provider, false)).to include(provider.attributes[:provider_code])
       end
     end
   end

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -7,7 +7,7 @@ feature 'View helpers', type: :helper do
 
   describe "#add_course_link" do
     it "builds a link" do
-      expect(helper.add_course_link(email, provider, true)).to eq("<a class=\"govuk-button govuk-!-margin-bottom-2\" rel=\"noopener noreferrer\" target=\"_blank\" href=\"#{CGI::escapeHTML(helper.add_course_url(email, provider, true))}\">Add a new course</a>")
+      expect(helper.add_course_link(email, provider, is_current_cycle: true)).to eq("<a class=\"govuk-button govuk-!-margin-bottom-2\" rel=\"noopener noreferrer\" target=\"_blank\" href=\"#{CGI::escapeHTML(helper.add_course_url(email, provider, is_current_cycle: true))}\">Add a new course</a>")
     end
   end
 
@@ -16,15 +16,15 @@ feature 'View helpers', type: :helper do
       let(:provider) { jsonapi(:provider, accredited_body?: true).to_resource }
 
       it "returns correct google form for the current cycle" do
-        expect(helper.add_course_url(email, provider, true)).to start_with(Settings.google_forms.current_cycle.new_course_for_accredited_bodies.url)
-        expect(helper.add_course_url(email, provider, true)).to include(html_escaped_version_of_email)
-        expect(helper.add_course_url(email, provider, true)).to include(provider.attributes[:provider_code])
+        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to start_with(Settings.google_forms.current_cycle.new_course_for_accredited_bodies.url)
+        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to include(html_escaped_version_of_email)
+        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to include(provider.attributes[:provider_code])
       end
 
       it "returns correct google form for the next cycle" do
-        expect(helper.add_course_url(email, provider, false)).to start_with(Settings.google_forms.next_cycle.new_course_for_accredited_bodies.url)
-        expect(helper.add_course_url(email, provider, false)).to include(html_escaped_version_of_email)
-        expect(helper.add_course_url(email, provider, false)).to include(provider.attributes[:provider_code])
+        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to start_with(Settings.google_forms.next_cycle.new_course_for_accredited_bodies.url)
+        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to include(html_escaped_version_of_email)
+        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to include(provider.attributes[:provider_code])
       end
     end
 
@@ -32,15 +32,15 @@ feature 'View helpers', type: :helper do
       let(:provider) { jsonapi(:provider, accredited_body?: false).to_resource }
 
       it "returns correct google form for the current cycle" do
-        expect(helper.add_course_url(email, provider, true)).to start_with(Settings.google_forms.current_cycle.new_course_for_unaccredited_bodies.url)
-        expect(helper.add_course_url(email, provider, true)).to include(html_escaped_version_of_email)
-        expect(helper.add_course_url(email, provider, true)).to include(provider.attributes[:provider_code])
+        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to start_with(Settings.google_forms.current_cycle.new_course_for_unaccredited_bodies.url)
+        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to include(html_escaped_version_of_email)
+        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to include(provider.attributes[:provider_code])
       end
 
       it "returns correct google form for the next cycle" do
-        expect(helper.add_course_url(email, provider, false)).to start_with(Settings.google_forms.next_cycle.new_course_for_unaccredited_bodies.url)
-        expect(helper.add_course_url(email, provider, false)).to include(html_escaped_version_of_email)
-        expect(helper.add_course_url(email, provider, false)).to include(provider.attributes[:provider_code])
+        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to start_with(Settings.google_forms.next_cycle.new_course_for_unaccredited_bodies.url)
+        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to include(html_escaped_version_of_email)
+        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to include(provider.attributes[:provider_code])
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/courses.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses.rb
@@ -21,10 +21,16 @@ module PageObjects
           end
         end
 
-        element :link_to_add_a_course_for_unaccredited_bodies, "a[href^=\"#{Settings.google_forms.new_course_for_unaccredited_bodies.url.gsub('?', '\?')}\"]",
+        element :link_to_add_a_course_for_unaccredited_bodies_current_cycle, "a[href^=\"#{Settings.google_forms.current_cycle.new_course_for_unaccredited_bodies.url.gsub('?', '\?')}\"]",
                 text: "Add a new course"
 
-        element :link_to_add_a_course_for_accredited_bodies, "a[href^=\"#{Settings.google_forms.new_course_for_accredited_bodies.url.gsub('?', '\?')}\"]",
+        element :link_to_add_a_course_for_accredited_bodies_current_cycle, "a[href^=\"#{Settings.google_forms.current_cycle.new_course_for_accredited_bodies.url.gsub('?', '\?')}\"]",
+                text: "Add a new course"
+
+        element :link_to_add_a_course_for_unaccredited_bodies_next_cycle, "a[href^=\"#{Settings.google_forms.next_cycle.new_course_for_unaccredited_bodies.url.gsub('?', '\?')}\"]",
+                text: "Add a new course"
+
+        element :link_to_add_a_course_for_accredited_bodies_next_cycle, "a[href^=\"#{Settings.google_forms.next_cycle.new_course_for_accredited_bodies.url.gsub('?', '\?')}\"]",
                 text: "Add a new course"
       end
     end


### PR DESCRIPTION
### Context

Now the new forms are set up, add links to them and pre-fill the correct fields.
Link to the right form based on current or next cycle and accredited or unaccredited providers.