### PR TITLE
[1699][1479] Hide the "Applications open" line on basic details

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -117,15 +117,19 @@
         </div>
       <% end %>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Applications open
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__application_status">
-          <%= course.open_or_closed_for_applications %>
-        </dd>
-        <dd class="govuk-summary-list__actions"></dd>
-      </div>
+      <%#
+        FIXME: This was showing the wrong information and isn't easily corrected
+        https://trello.com/c/l0t1Oun3/
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Applications open
+          </dt>
+          <dd class="govuk-summary-list__value" data-qa="course__application_status">
+          </dd>
+          <dd class="govuk-summary-list__actions"></dd>
+        </div>
+      #%>
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/spec/features/courses/details_spec.rb
+++ b/spec/features/courses/details_spec.rb
@@ -81,9 +81,6 @@ feature 'Course details', type: :feature do
     expect(course_details_page.accredited_body).to have_content(
       provider.provider_name
     )
-    expect(course_details_page.application_status).to have_content(
-      'Open'
-    )
     expect(course_details_page.is_send).to have_content(
       'No'
     )


### PR DESCRIPTION
### Context

This was showing if applications were open or closed, rather than the date applications opened.

The date applications opened isn't easily available.

Rather than risk showing the wrong information, comment out the section until a bug fix is in place for
https://trello.com/c/l0t1Oun3/