### PR TITLE
DRY up breadcrumbs with a helper and partial

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -1,0 +1,37 @@
+module BreadcrumbHelper
+  def render_breadcrumbs(type)
+    render partial: "shared/breadcrumbs", locals: { items: send("#{type}_breadcrumb") }
+  end
+
+  def organisations_breadcrumb
+    @has_multiple_providers ? [["Organisations", providers_path]] : []
+  end
+
+  def provider_breadcrumb
+    path = provider_path(code: @provider.provider_code)
+    organisations_breadcrumb << [@provider.provider_name, path]
+  end
+
+  def recruitment_cycle_breadcrumb
+    if @provider.rolled_over?
+      path = provider_recruitment_cycle_path(@provider.provider_code, @recruitment_cycle.year)
+      provider_breadcrumb << [@recruitment_cycle.title, path]
+    else
+      provider_breadcrumb
+    end
+  end
+
+  def courses_breadcrumb
+    path = provider_recruitment_cycle_courses_path(@provider.provider_code)
+    recruitment_cycle_breadcrumb << ["Courses", path]
+  end
+
+  def course_breadcrumb
+    path = provider_recruitment_cycle_course_path(
+      @provider.provider_code,
+      course.recruitment_cycle_year,
+      course.course_code
+    )
+    courses_breadcrumb << [course.name_and_code, path]
+  end
+end

--- a/app/views/courses/details.html.erb
+++ b/app/views/courses/details.html.erb
@@ -1,32 +1,5 @@
 <%= content_for :page_title, "#{course.name_and_code} - Courses" %>
-
-<% content_for :before_content do %>
-  <nav class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <% if @has_multiple_providers then %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
-        </li>
-      <% end %>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @provider.provider_name, provider_path(code: @provider.provider_code), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <% if @provider.rolled_over? %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to @recruitment_cycle.title,
-                      provider_recruitment_cycle_path(@provider.provider_code, @recruitment_cycle.year),
-                      class: "govuk-breadcrumbs__link" %>
-        </li>
-      <% end %>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to "Courses", provider_recruitment_cycle_courses_path(@provider.provider_code), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        <%= course.name %> (<%= course.course_code %>)
-      </li>
-    </ol>
-  </nav>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:course) %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.description %></span>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,29 +1,5 @@
 <%= content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
-
-<% content_for :before_content do %>
-  <nav class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <% if @has_multiple_providers then %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
-        </li>
-      <% end %>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @provider[:provider_name], provider_path(code: @provider[:provider_code]), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <% if @provider.rolled_over? %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to @recruitment_cycle.title,
-                      provider_recruitment_cycle_path(@provider.provider_code, @recruitment_cycle.year),
-                      class: "govuk-breadcrumbs__link" %>
-        </li>
-      <% end %>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        Courses
-      </li>
-    </ol>
-  </nav>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:courses) %>
 
 <h1 class="govuk-heading-xl">
   <% if @provider.rolled_over? %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,32 +1,5 @@
 <%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}#{course.name_and_code} - Courses" %>
-
-<% content_for :before_content do %>
-  <nav class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <% if @has_multiple_providers then %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
-        </li>
-      <% end %>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @provider.provider_name, provider_path(code: @provider.provider_code), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <% if @provider.rolled_over? %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to @recruitment_cycle.title,
-                      provider_recruitment_cycle_path(@provider.provider_code, @recruitment_cycle.year),
-                      class: "govuk-breadcrumbs__link" %>
-        </li>
-      <% end %>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to "Courses", provider_recruitment_cycle_courses_path(@provider.provider_code), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        <%= course.name %> (<%= course.course_code %>)
-      </li>
-    </ol>
-  </nav>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:course) %>
 
 <% if @errors.present? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary" data-ga-event-form="error">

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -1,18 +1,6 @@
 <%= content_for :page_title, @provider.provider_name %>
-
-<% if @has_multiple_providers then %>
-  <% content_for :before_content do %>
-    <nav class="govuk-breadcrumbs">
-      <ol class="govuk-breadcrumbs__list">
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
-        </li>
-        <li class="govuk-breadcrumbs__list-item" aria-current="page">
-          <%= @provider.provider_name %>
-        </li>
-      </ol>
-    </nav>
-  <% end %>
+<% if @has_multiple_providers %>
+  <%= content_for :before_content, render_breadcrumbs(:provider) %>
 <% end %>
 
 <h1 class="govuk-heading-xl"><%= @provider.provider_name %></h1>

--- a/app/views/recruitment_cycles/show.html.erb
+++ b/app/views/recruitment_cycles/show.html.erb
@@ -1,22 +1,5 @@
 <%= content_for :page_title, @recruitment_cycle.title %>
-
-<% content_for :before_content do %>
-  <nav class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <% if @has_multiple_providers then %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
-        </li>
-      <% end %>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @provider.provider_name, provider_path(@provider.provider_code), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        <%= @recruitment_cycle.title %>
-      </li>
-    </ol>
-  </nav>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:recruitment_cycle) %>
 
 <h1 class="govuk-heading-xl">
   <%= @recruitment_cycle.title %>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,15 @@
+<% items ||= [] %>
+<% if items.any? %>
+  <nav class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <% items[0...-1].each do |text, path| %>
+        <li class="govuk-breadcrumbs__list-item">
+          <%= link_to text, path, class: "govuk-breadcrumbs__link" %>
+        </li>
+      <% end %>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <%= items.last.first %>
+      </li>
+    </ol>
+  </nav>
+<% end %>


### PR DESCRIPTION
* DRY up our breadcrumbs with a partial
* Keep breadcrumb logic in one place

Example usage:
```erb
<%= content_for :before_content, render_breadcrumbs(:courses) %>
```