### PR TITLE
Show recruitment cycle in sites breadcrumbs

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,5 +1,6 @@
 class SitesController < ApplicationController
   before_action :build_provider, :initialise_errors
+  before_action :build_recruitment_cycle
   before_action :build_site, only: %i[edit update]
 
   def new
@@ -63,6 +64,15 @@ private
       .where(year: cycle_year)
       .find(params[:provider_code])
       .first
+  end
+
+  def build_recruitment_cycle
+    cycle_year = params.fetch(
+      :recruitment_cycle_year,
+      Settings.current_cycle
+    )
+
+    @recruitment_cycle = RecruitmentCycle.find(cycle_year).first
   end
 
   def site_params

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -34,4 +34,19 @@ module BreadcrumbHelper
     )
     courses_breadcrumb << [course.name_and_code, path]
   end
+
+  def sites_breadcrumb
+    path = provider_recruitment_cycle_sites_path(@provider.provider_code, @recruitment_cycle.year)
+    recruitment_cycle_breadcrumb << ["Locations", path]
+  end
+
+  def edit_site_breadcrumb
+    path = edit_provider_recruitment_cycle_site_path(@provider.provider_code, @site.recruitment_cycle_year, @site.id)
+    sites_breadcrumb << [@site_name_before_update, path]
+  end
+
+  def new_site_breadcrumb
+    path = new_provider_recruitment_cycle_site_path(@provider.provider_code)
+    sites_breadcrumb << ["Add a location", path]
+  end
 end

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -1,25 +1,5 @@
 <%= content_for :page_title, "#{@errors.any? ? "Error: " : ""}#{ @site_name_before_update }" %>
-
-<% content_for :before_content do %>
-  <nav class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <% if @has_multiple_providers then %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
-        </li>
-      <% end %>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @provider.provider_name, provider_path(code: @provider.provider_code), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to "Locations", provider_recruitment_cycle_sites_path(@provider.provider_code, '2019'), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        <%= @site_name_before_update %>
-      </li>
-    </ol>
-  </nav>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:edit_site) %>
 
 <%= render 'shared/errors' %>
 

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,22 +1,5 @@
 <%= content_for :page_title, "Locations" %>
-
-<% content_for :before_content do %>
-  <nav class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <% if @has_multiple_providers then %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
-        </li>
-      <% end %>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @provider.attributes[:provider_name], provider_path(code: @provider.attributes[:provider_code]), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        Locations
-      </li>
-    </ol>
-  </nav>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:sites) %>
 
 <h1 class="govuk-heading-xl">Locations</h1>
 

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -1,25 +1,5 @@
 <%= content_for :page_title, "#{@errors.any? ? "Error: " : ""}Add a location" %>
-
-<% content_for :before_content do %>
-  <nav class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <% if @has_multiple_providers then %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to "Organisations", providers_path, class: "govuk-breadcrumbs__link" %>
-        </li>
-      <% end %>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @provider.attributes[:provider_name], provider_path(code: @provider.attributes[:provider_code]), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to "Locations", provider_recruitment_cycle_sites_path(@provider[:provider_code]), class: "govuk-breadcrumbs__link" %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        Add a location
-      </li>
-    </ol>
-  </nav>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:new_site) %>
 
 <%= render 'shared/errors' %>
 

--- a/spec/features/sites/new_spec.rb
+++ b/spec/features/sites/new_spec.rb
@@ -6,7 +6,7 @@ feature 'Locations', type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle)
+    stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
     stub_api_v2_request(
       "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}?include=sites",
       provider.to_jsonapi(include: :sites)


### PR DESCRIPTION
### Context

- Show the full breadcrumb on locations/edit location/add location

### Changes proposed in this pull request

- Switch to using the breadcrumbs helper
- DRY up breadcrumb templates on sites pages

### Guidance to review

![Screen Shot 2019-07-17 at 16 17 07](https://user-images.githubusercontent.com/319055/61387621-58da7b00-a8ae-11e9-8c65-b65e83294a97.png)
