### PR TITLE
[1654] Enable rollover across all environments

### DIFF
--- a/config/settings/new_prod.yml
+++ b/config/settings/new_prod.yml
@@ -10,6 +10,5 @@ manage_ui:
 search_ui:
   base_url: https://bat-prod-sacui-as.azurewebsites.net
 environment:
-  label: 'Beta'
-  selector_name: 'Beta'
-rollover: false
+  label: "Beta"
+  selector_name: "Beta"

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -10,6 +10,5 @@ manage_ui:
 search_ui:
   base_url: https://find-postgraduate-teacher-training.education.gov.uk
 environment:
-  label: 'Beta'
-  selector_name: 'beta'
-rollover: false
+  label: "Beta"
+  selector_name: "beta"

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -12,4 +12,3 @@ search_ui:
 environment:
   label: "QA"
   selector_name: "qa"
-rollover: true

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -10,6 +10,5 @@ manage_ui:
 search_ui:
   base_url: https://bat-staging-search-and-compare-ui-app.azurewebsites.net
 environment:
-  label: 'Staging'
-  selector_name: 'staging'
-rollover: false
+  label: "Staging"
+  selector_name: "staging"


### PR DESCRIPTION
### Context
Allow providers to see the current AND next cycle

### Changes proposed in this pull request
Remove overrides and leave the default 'true' for all environments

### Guidance to review
You should be able to see "cycles" when selecting a provider
> My prettier config is double quotes