### PR TITLE
[1796] Don't show publish button on rolled over courses

### DIFF
--- a/app/views/courses/_status_panel.html.erb
+++ b/app/views/courses/_status_panel.html.erb
@@ -3,7 +3,9 @@
   <div class="govuk-!-margin-bottom-6" data-qa="course__content-status">
     <%= course.status_tag %>
   </div>
-  <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Is it on Find?</h3>
+  <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
+    <% if @recruitment_cycle.current? %>Is it<% else %>Will it be<% end %> on <abbr class="app-text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?
+  </h3>
   <p class="govuk-body" data-qa="course__is_findable">
     <%= course.on_find %>
   </p>

--- a/app/views/courses/status_panel/_unpublished.html.erb
+++ b/app/views/courses/status_panel/_unpublished.html.erb
@@ -9,8 +9,12 @@
 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
 
 <h4 class="govuk-heading-m">Publish</h4>
-<p class="govuk-body">Publish your changes.</p>
-<p class="govuk-body">You can make changes to this course after publishing it.</p>
-<%= form_for course, url: publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :post do |f| %>
-  <%= f.submit "Publish", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: 'course__publish' } %>
+<% if @recruitment_cycle.current? %>
+  <p class="govuk-body">Publish your changes.</p>
+  <p class="govuk-body">You can make changes to this course after publishing it.</p>
+  <%= form_for course, url: publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :post do |f| %>
+    <%= f.submit "Publish", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: 'course__publish' } %>
+  <% end %>
+<% else %>
+  <p class="govuk-body">You will be able to publish your courses in September before the next cycle opens.</p>
 <% end %>


### PR DESCRIPTION
Publishing will trigger a sync to `Find` which will currently fail on the server. Until we fix this, we should display some content instead.

Paired with @fofr.

### After

![Screenshot 2019-07-18 at 11 15 27](https://user-images.githubusercontent.com/1650875/61449790-94785200-a94d-11e9-958b-f3f20f073843.png)
