### PR TITLE
[1800] Extend course content status for rollover

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -130,6 +130,8 @@ private
       'Draft'
     when 'published_with_unpublished_changes'
       'Published&nbsp;*'
+    when 'rolled_over'
+      'Rolled over'
     end
   end
 
@@ -143,6 +145,8 @@ private
       'phase-tag--draft'
     when 'published_with_unpublished_changes'
       'phase-tag--published'
+    when 'rolled_over'
+      'phase-tag--no-content'
     end
   end
 

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -184,6 +184,24 @@ feature 'Course show', type: :feature do
     end
   end
 
+  context 'when the course has been rolled over' do
+    let(:course) {
+      build :course,
+            findable?: false,
+            content_status: 'rolled_over',
+            ucas_status: 'new',
+            has_vacancies?: true,
+            open_for_applications?: false,
+            provider: provider
+    }
+
+    scenario 'it displays a status panel' do
+      expect(course_page).to have_status_panel
+      expect(course_page.is_findable).to have_content('No')
+      expect(course_page.status_tag).to have_content('Rolled over')
+    end
+  end
+
   context 'when the course is not running' do
     let(:course) {
       build :course,


### PR DESCRIPTION
### Context
Rollover

### Changes proposed in this pull request
Display new `rolled over` status for users

### Guidance to review
# After
![localhost_3000_organisations_2C4_2020_courses_2XNM(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/61451808-31d58500-a952-11e9-8a90-94adcab9e748.png)

