### PR TITLE
Remove "link for this course" message

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -29,12 +29,6 @@
     <h2 class="govuk-success-summary__title" id="success-summary-title">
       <%= @published %>
     </h2>
-    <div class="govuk-error-summary__body">
-      <p class="govuk-body">
-        The link for this course is:
-        <%= govuk_link_to search_ui_course_page_url(provider_code: @provider.provider_code, course_code: @course.course_code) %>
-      </p>
-    </div>
   </div>
 <% end %>
 

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -262,7 +262,6 @@ feature 'Course show', type: :feature do
 
           expect(course_page).to be_displayed
           expect(course_page.success_summary).to have_content("Your course has been published.")
-          expect(course_page.success_summary).to have_content("The link for this course is: https://localhost:5000/course/#{provider.provider_code}/#{course.course_code}")
         end
       end
 


### PR DESCRIPTION
### Context

This message incorrectly shows for all saved changes, not just publishing.

This means it shows when editing an unpublished draft, or when editing a course in the new cycle, which is confusing.

As a quick fix, remove the message.

### Before
![Screen Shot 2019-07-18 at 16 42 15](https://user-images.githubusercontent.com/319055/61471668-0adf7900-a97b-11e9-9f40-5d782be5521d.png)

### After
![Screen Shot 2019-07-18 at 16 41 53](https://user-images.githubusercontent.com/319055/61471670-0ca93c80-a97b-11e9-893d-cb87e39ef664.png)


