### PR TITLE
[1692] Allow providers to edit their UCAS equivalency settings

### DIFF
--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -1,0 +1,42 @@
+module Courses
+  class EntryRequirementsController < ApplicationController
+    decorates_assigned :course
+    before_action :build_course
+
+    def edit; end
+
+    def update
+      if @course.update(course_params)
+        flash[:success] = 'Your changes have been saved'
+        redirect_to(
+          details_provider_recruitment_cycle_course_path(
+            @course.provider_code,
+            @course.recruitment_cycle_year,
+            @course.course_code
+          )
+        )
+      else
+        @errors = @course.errors.messages
+        render :edit
+      end
+    end
+
+  private
+
+    def course_params
+      params.require(:course).permit(
+        :maths,
+        :english,
+        :science
+      )
+    end
+
+    def build_course
+      @course = Course
+        .where(recruitment_cycle_year: params[:recruitment_cycle_year])
+        .where(provider_code: params[:provider_code])
+        .find(params[:code])
+        .first
+    end
+  end
+end

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -180,9 +180,6 @@
           <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'Science', gcse_subject_code: course.science } %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to entry_requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_entry_requirements_link" } do %>
-            Change<span class="govuk-visually-hidden"> entry requirements</span>
-          <% end %>
         </dd>
       </div>
     </dl>

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -170,42 +170,19 @@
         </dd>
         <dd class="govuk-summary-list__actions"></dd>
       </div>
-    </dl>
-
-    <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           UCAS Apply: GCSE requirements for applicants
         </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__entry_requirements">
+        <dd class="govuk-summary-list__value govuk-!-padding-right-0" data-qa="course__entry_requirements">
           <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'Maths', gcse_subject_code: course.maths } %>
           <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'English', gcse_subject_code: course.english } %>
           <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'Science', gcse_subject_code: course.science } %>
-
-          <details class="govuk-details">
-            <summary class="govuk-details__summary">
-              <span class="govuk-details__summary-text">More about these <span class="govuk-visually-hidden">UCAS GCSE </span>codes</span>
-            </summary>
-            <div class="govuk-details__text">
-              <p class="govuk-body">
-                By law, all applicants need a GCSE grade of C (or grade 4), or an equivalent, in English and Mathematics – and Science for Primary courses.
-              </p>
-
-              <p class="govuk-body">
-                Candidates may still be taking a GCSE when they apply. Alternatively, they can take an equivalency test to demonstrate they have the required skills to start a course.
-              </p>
-
-              <p class="govuk-body">
-                The code determines how flexible you are towards those candidates:
-              </p>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>1: Must have (least flexible)</li>
-                <li>2: Taking</li>
-                <li>3: Equivalence test (recommended)</li>
-                <li>No code (for when there is no legal requirement)</li>
-              </ul>
-            </div>
-          </details>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to entry_requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_entry_requirements_link" } do %>
+            Change<span class="govuk-visually-hidden"> entry requirements</span>
+          <% end %>
         </dd>
       </div>
     </dl>

--- a/app/views/courses/_entry_requirements.html.erb
+++ b/app/views/courses/_entry_requirements.html.erb
@@ -1,22 +1,37 @@
 <% case gcse_subject_code %>
 <% when 'must_have_qualification_at_application_time' %>
-  <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-bottom-0">
-    <%= gcse_subject %> GCSE (Code 1 – ‘Must have’)
-  </h3>
-  <p class="govuk-body govuk-hint">UCAS will block applications from candidates who haven’t gained their <%= gcse_subject %> GCSE yet or who need to take an equivalency test.</p>
+  <details class="govuk-details govuk-!-margin-bottom-2">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text"><%= gcse_subject %> GCSE: Must have</span>
+    </summary>
+    <div class="govuk-details__text">
+      <p class="govuk-body">
+        UCAS will block applications from candidates who haven’t gained their <%= gcse_subject %> GCSE yet or who need to take an equivalency test.
+      </p>
+    </div>
+  </details>
 <% when 'expect_to_achieve_before_training_begins' %>
-  <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-bottom-0">
-    <%= gcse_subject %> GCSE (Code 2 – ‘Taking’)
-  </h3>
-  <p class="govuk-body govuk-hint">You will consider candidates with a pending <%= gcse_subject %> GCSE. But UCAS will block applications from someone who needs to take an equivalency test.</p>
+  <details class="govuk-details govuk-!-margin-bottom-2">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text"><%= gcse_subject %> GCSE: Taking</span>
+    </summary>
+    <div class="govuk-details__text">
+      <p class="govuk-body">
+        You will consider candidates with a pending <%= gcse_subject %> GCSE. But UCAS will block applications from someone who needs to take an equivalency test.
+      </p>
+    </div>
+  </details>
 <% when 'equivalence_test' %>
-  <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-bottom-0">
-    <%= gcse_subject %> GCSE (Code 3 – ‘Equivalence test’)
-  </h3>
-  <p class="govuk-body govuk-hint">You will consider candidates who need to take an equivalency test as well as those with a pending <%= gcse_subject %> GCSE.</p>
+  <details class="govuk-details govuk-!-margin-bottom-2">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text"><%= gcse_subject %> GCSE: Equivalence test</span>
+    </summary>
+    <div class="govuk-details__text">
+      <p class="govuk-body">
+        You will consider candidates who need to take an equivalency test as well as those with a pending <%= gcse_subject %> GCSE.
+      </p>
+    </div>
+  </details>
 <% else %>
-  <h3 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-bottom-0">
-    <%= gcse_subject %> GCSE (No code)
-  </h3>
-  <p class="govuk-body govuk-hint">You have no <%= gcse_subject %> GCSE requirement.</p>
+  <p class="govuk-body"><%= gcse_subject %> GCSE: No requirement</p>
 <% end %>

--- a/app/views/courses/entry_requirements/_subject_choices.html.erb
+++ b/app/views/courses/entry_requirements/_subject_choices.html.erb
@@ -18,7 +18,7 @@
             'You will consider candidates with a pending GCSE. But UCAS will block applications from someone who needs to take an equivalency test.'
           ],
           [
-            '3: Equivalence test (recommended)',
+            '3: Equivalence test',
             'equivalence_test',
             'You will consider candidates who need to take an equivalency test as well as those with a pending GCSE.'
           ],

--- a/app/views/courses/entry_requirements/_subject_choices.html.erb
+++ b/app/views/courses/entry_requirements/_subject_choices.html.erb
@@ -1,0 +1,54 @@
+<div class="govuk-form-group govuk-!-margin-bottom-8" data-qa="course__<%= subject %>_requirements">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      <h2 class="govuk-fieldset__heading">
+        <%= subject.to_s.titleize %> GCSE
+      </h2>
+    </legend>
+    <div class="govuk-radios govuk-radios--conditional">
+      <% [
+          [
+            '1. Must have (least flexible)',
+            'must_have_qualification_at_application_time',
+            'UCAS will block applications from candidates who haven’t gained their GCSE yet or who need to take an equivalency test.'
+          ],
+          [
+            '2: Taking',
+            'expect_to_achieve_before_training_begins',
+            'You will consider candidates with a pending GCSE. But UCAS will block applications from someone who needs to take an equivalency test.'
+          ],
+          [
+            '3: Equivalence test (recommended)',
+            'equivalence_test',
+            'You will consider candidates who need to take an equivalency test as well as those with a pending GCSE.'
+          ],
+          [
+            'No GCSE requirement',
+            'not_required'
+          ]
+        ].each do |label, value, guidance|
+      %>
+        <div class="govuk-radios__item">
+          <%= form.radio_button subject,
+                value,
+                class: 'govuk-radios__input',
+                data: {
+                  'aria-describedby': "#{subject}-#{value}-help"
+                },
+                checked: course.send(subject) == value
+          %>
+          <%= form.label subject,
+                label,
+                value: value,
+                class: 'govuk-label govuk-radios__label'
+          %>
+          <% if guidance %>
+            <span id="<%= "#{subject}-#{value}-help" %>" class="govuk-hint govuk-radios__hint">
+              <%= guidance %>
+            </span>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/courses/entry_requirements/edit.html.erb
+++ b/app/views/courses/entry_requirements/edit.html.erb
@@ -5,10 +5,13 @@
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl">GCSE requirements for applicants</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">UCAS Apply</span>
+      GCSE requirements for&nbsp;applicants
+    </h1>
+
     <p class="govuk-body">
       By law, all applicants need GCSE grade C/grade 4, or an equivalent, in English and Mathematics – plus Science for Primary courses.
     </p>
@@ -29,7 +32,10 @@
       <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :english } %>
       <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :science } %>
 
-      <%= form.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <p class="govuk-body">Changes will appear on UCAS Apply within 2 hours.</p>
+
+      <%= form.submit "Save changes", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
         <%= link_to 'Cancel changes',

--- a/app/views/courses/entry_requirements/edit.html.erb
+++ b/app/views/courses/entry_requirements/edit.html.erb
@@ -1,0 +1,41 @@
+<%= content_for :page_title, "GCSE requirements for applicants – #{course.name_and_code}" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<h1 class="govuk-heading-xl">GCSE requirements for applicants</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      By law, all applicants need GCSE grade C/grade 4, or an equivalent, in English and Mathematics – plus Science for Primary courses.
+    </p>
+
+    <p class="govuk-body">
+      Candidates may still be taking a GCSE when they apply. Alternatively, they can take an equivalency test to demonstrate they have the required skills to start a course.
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-8">
+      The codes you pick determine how flexible you are towards those candidates.
+    </p>
+
+    <%= form_for @course,
+          url: entry_requirements_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+          method: :put do |form| %>
+
+      <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :maths } %>
+      <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :english } %>
+      <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :science } %>
+
+      <%= form.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes',
+          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,9 @@ Rails.application.routes.draw do
         get '/locations', on: :member, to: 'courses/sites#edit'
         put '/locations', on: :member, to: 'courses/sites#update'
         post '/publish', on: :member, to: 'courses#publish'
+
+        get '/entry-requirements', on: :member, to: 'courses/entry_requirements#edit'
+        put '/entry-requirements', on: :member, to: 'courses/entry_requirements#update'
       end
 
       resources :sites, path: 'locations', on: :member, except: %i[destroy show]

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -34,6 +34,19 @@ feature 'Edit course entry requirements', type: :feature do
       )
     end
 
+    scenario 'can cancel changes' do
+      click_on 'Cancel changes'
+      expect(course_details_page).to be_displayed
+    end
+
+    scenario 'can navigate to the edit screen and back again' do
+      course_details_page.load_with_course(course)
+      click_on 'Change entry requirements'
+      expect(entry_requirements_page).to be_displayed
+      click_on 'Back'
+      expect(course_details_page).to be_displayed
+    end
+
     scenario 'presents a choice for each subject' do
       expect(entry_requirements_page).to have_maths_requirements
       expect(entry_requirements_page).to have_english_requirements

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+feature 'Edit course entry requirements', type: :feature do
+  let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+  let(:entry_requirements_page) { PageObjects::Page::Organisations::CourseEntryRequirements.new }
+  let(:course_details_page) { PageObjects::Page::Organisations::CourseDetails.new }
+  let(:provider) { build(:provider) }
+
+  before do
+    stub_omniauth
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}",
+      current_recruitment_cycle.to_jsonapi
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
+      build(:provider).to_jsonapi(include: %i[courses accrediting_provider])
+    )
+
+    stub_course_request
+    stub_course_details_tab
+    entry_requirements_page.load_with_course(course)
+  end
+
+  context 'any course' do
+    let(:course) do
+      build(
+        :course,
+        provider: provider,
+        maths: 'must_have_qualification_at_application_time',
+        english: 'expect_to_achieve_before_training_begins',
+        science: 'equivalence_test'
+      )
+    end
+
+    scenario 'presents a choice for each subject' do
+      expect(entry_requirements_page).to have_maths_requirements
+      expect(entry_requirements_page).to have_english_requirements
+      expect(entry_requirements_page).to have_science_requirements
+
+      %w[
+        maths_requirements
+        english_requirements
+        science_requirements
+      ].each do |subject|
+        expect(entry_requirements_page.send(subject)).to have_field('1. Must have (least flexible)')
+        expect(entry_requirements_page.send(subject)).to have_field('2: Taking')
+        expect(entry_requirements_page.send(subject)).to have_field('3: Equivalence test (recommended)')
+        expect(entry_requirements_page.send(subject)).to have_field('No GCSE requirement')
+      end
+    end
+
+    scenario 'has the correct value selected' do
+      expect(entry_requirements_page).to have_maths_requirements
+      expect(entry_requirements_page).to have_english_requirements
+      expect(entry_requirements_page).to have_science_requirements
+
+      [
+        ['maths_requirements', '1. Must have (least flexible)'],
+        ['english_requirements', '2: Taking'],
+        ['science_requirements', '3: Equivalence test (recommended)']
+      ].each do |subject, field_name|
+        expect(entry_requirements_page.send(subject)).to have_field(field_name, checked: true)
+      end
+    end
+
+    scenario 'can be updated' do
+      update_course_stub = stub_api_v2_request(
+        "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+        "/providers/#{provider.provider_code}" \
+        "/courses/#{course.course_code}",
+        course.to_jsonapi,
+        :patch, 200
+      )
+
+      choose('course_maths_expect_to_achieve_before_training_begins')
+      choose('course_english_expect_to_achieve_before_training_begins')
+      choose('course_science_expect_to_achieve_before_training_begins')
+      click_on 'Save'
+
+      expect(course_details_page).to be_displayed
+      expect(course_details_page.flash).to have_content('Your changes have been saved')
+      expect(update_course_stub).to have_been_requested
+    end
+  end
+
+  def stub_course_request
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}/courses" \
+      "/#{course.course_code}",
+      course.to_jsonapi
+    )
+  end
+
+  def stub_course_details_tab
+    stub_api_v2_request(
+      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
+      "/courses/#{course.course_code}" \
+      "?include=sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites])
+    )
+  end
+end

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -59,7 +59,7 @@ feature 'Edit course entry requirements', type: :feature do
       ].each do |subject|
         expect(entry_requirements_page.send(subject)).to have_field('1. Must have (least flexible)')
         expect(entry_requirements_page.send(subject)).to have_field('2: Taking')
-        expect(entry_requirements_page.send(subject)).to have_field('3: Equivalence test (recommended)')
+        expect(entry_requirements_page.send(subject)).to have_field('3: Equivalence test')
         expect(entry_requirements_page.send(subject)).to have_field('No GCSE requirement')
       end
     end
@@ -72,7 +72,7 @@ feature 'Edit course entry requirements', type: :feature do
       [
         ['maths_requirements', '1. Must have (least flexible)'],
         ['english_requirements', '2: Taking'],
-        ['science_requirements', '3: Equivalence test (recommended)']
+        ['science_requirements', '3: Equivalence test']
       ].each do |subject, field_name|
         expect(entry_requirements_page.send(subject)).to have_field(field_name, checked: true)
       end

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -40,6 +40,7 @@ feature 'Edit course entry requirements', type: :feature do
     end
 
     scenario 'can navigate to the edit screen and back again' do
+      pending('Disabled until we put Change link in')
       course_details_page.load_with_course(course)
       click_on 'Change entry requirements'
       expect(entry_requirements_page).to be_displayed

--- a/spec/site_prism/page_objects/page/organisations/course_entry_requirements.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_entry_requirements.rb
@@ -1,0 +1,13 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseEntryRequirements < CourseBase
+        set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/entry-requirements'
+
+        element :maths_requirements,   '[data-qa="course__maths_requirements"]'
+        element :english_requirements, '[data-qa="course__english_requirements"]'
+        element :science_requirements, '[data-qa="course__science_requirements"]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We are allowing users to edit the UCAS equivalencies for Maths; English and Science. Providers are regularly contacting us through support to edit the equivalencies, often for individual candidates they are wanting to apply.

This is an MVP version of the design to allow us to ship editing sooner:
https://bat-design-history.herokuapp.com/publish-teacher-training/minimum-requirements-read-only-mvp

### Changes proposed in this pull request

- Add controller, view and tests for editing entry requirements
- Link to the edit form from the basic details tab
- Depends on https://github.com/DFE-Digital/manage-courses-backend/pull/623 being merged and shipped

PR excludes:
- Validation if no code is provided, this is being handled separately
- Logic around specific requirements of Secondary/Primary/FE courses

### Screenshots

![Screen Shot 2019-07-19 at 12 06 49](https://user-images.githubusercontent.com/319055/61533464-e3dd8180-aa24-11e9-8e4c-d616631ccd8e.png)
![Screen Shot 2019-07-19 at 12 06 56](https://user-images.githubusercontent.com/319055/61533465-e3dd8180-aa24-11e9-81d0-a5d06dd277c5.png)

![localhost_3000_organisations_1CS_2019_courses_2DGY_entry-requirements (2)](https://user-images.githubusercontent.com/319055/61533530-0ff90280-aa25-11e9-9b73-ee2b91398058.png)

