### PR TITLE
[1795] A new_status for a site on a course should be allowed to assign vacancies

### DIFF
--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -13,7 +13,7 @@ module Courses
         return render(:edit)
       end
 
-      @course.has_multiple_running_sites_or_study_modes? ? update_vacancies_for_multiple_sites : update_vacancies_for_a_single_site
+      @course.has_multiple_new_or_running_sites_or_study_modes? ? update_vacancies_for_multiple_sites : update_vacancies_for_a_single_site
       @course.sync_with_search_and_compare(provider_code: @course.provider_code, recruitment_cycle_year: params[:recruitment_cycle_year])
       flash[:success] = 'Course vacancies published'
       redirect_to provider_recruitment_cycle_courses_path(params[:provider_code], params[:recruitment_cycle_year])
@@ -74,7 +74,7 @@ module Courses
     end
 
     def build_site_statuses
-      @site_statuses = @course.running_site_statuses
+      @site_statuses = @course.new_or_running_site_statuses
     end
 
     def find_site_status(id)

--- a/app/helpers/vacancy_helper.rb
+++ b/app/helpers/vacancy_helper.rb
@@ -1,5 +1,7 @@
 module VacancyHelper
   def vacancy_available_for_course_site_status?(course, site_status, vacancy_study_mode = nil)
+    return false if site_status.new?
+
     case course.study_mode
     when 'full_time'
       site_status.full_time_vacancies?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -55,12 +55,12 @@ class Course < Base
     content_status == 'published'
   end
 
-  def running_site_statuses
-    site_statuses.select(&:running?)
+  def new_or_running_site_statuses
+    site_statuses.select(&:new_or_running?)
   end
 
-  def has_multiple_running_sites_or_study_modes?
-    running_site_statuses.length > 1 || full_time_or_part_time?
+  def has_multiple_new_or_running_sites_or_study_modes?
+    new_or_running_site_statuses.length > 1 || full_time_or_part_time?
   end
 
 private

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -15,6 +15,10 @@ class SiteStatus < Base
     status == 'running'
   end
 
+  def new?
+    status == 'new_status'
+  end
+
   def new_or_running?
     status.in?(%w[running new_status])
   end

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -17,7 +17,7 @@
             Edit vacancies
           </h1>
         </legend>
-        <% if @course.has_multiple_running_sites_or_study_modes? %>
+        <% if @course.has_multiple_new_or_running_sites_or_study_modes? %>
           <%= render partial: "courses/vacancies/multiple_sites", locals: { f: form } %>
         <% else %>
           <%= render partial: 'courses/vacancies/single_site', locals: { f: form } %>
@@ -25,7 +25,7 @@
       </fieldset>
       <p class="govuk-body">Changes will appear on Find straight away. UCAS Apply will be updated within 2 hours.</p>
 
-      <% if @course.has_multiple_running_sites_or_study_modes? %>
+      <% if @course.has_multiple_new_or_running_sites_or_study_modes? %>
         <%= form.submit "Publish changes", class: "govuk-button" %>
       <% elsif @course.has_vacancies? %>
         <%= form.submit "Close applications", class: "govuk-button govuk-button--warning" %>

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -69,7 +69,7 @@ feature 'Edit course vacancies', type: :feature do
     end
   end
 
-  context 'A full time course with one running site but no vacancies' do
+  context 'A full time course with one running site with no vacancies and one new site' do
     let(:course) do
       build(
         :course,
@@ -77,7 +77,8 @@ feature 'Edit course vacancies', type: :feature do
         course_code: course_code,
         provider: provider,
         site_statuses: [
-          jsonapi_site_status('Uni 1', :no_vacancies, 'running')
+          jsonapi_site_status('Uni 1', :no_vacancies, 'running'),
+          jsonapi_site_status('Uni 2', :full_time, 'new_status')
         ]
       )
     end
@@ -106,7 +107,7 @@ feature 'Edit course vacancies', type: :feature do
     end
   end
 
-  context 'A full time course with multiple running sites' do
+  context 'A full time course with multiple new or running sites' do
     let(:course) do
       build(
         :course,
@@ -116,6 +117,8 @@ feature 'Edit course vacancies', type: :feature do
         site_statuses: [
           jsonapi_site_status('Running Uni 1', :full_time, 'running'),
           jsonapi_site_status('Running Uni 2', :full_time, 'running'),
+          jsonapi_site_status('New Uni 3', :full_time, 'new_status'),
+          jsonapi_site_status('New Uni 4', :no_vacancies, 'new_status'),
           jsonapi_site_status('Not running Uni', :full_time, 'suspended')
         ]
       )
@@ -130,18 +133,20 @@ feature 'Edit course vacancies', type: :feature do
       )
     end
 
-    scenario 'only render site statuses that are running' do
+    scenario 'only render site statuses that are new or running' do
       expect(course_vacancies_page).to have_vacancies_radio_choice
       expect(course_vacancies_page.vacancies_radio_has_some_vacancies).to be_checked
 
       [
         ["Running Uni 1", true],
-        ["Running Uni 2", true]
+        ["Running Uni 2", true],
+        ["New Uni 3", false],
+        ["New Uni 4", false],
       ].each do |name, checked|
-        expect(course_vacancies_page.vacancies_running_sites_checkboxes).to have_field(name, checked: checked)
+        expect(course_vacancies_page.vacancies_new_or_running_sites_checkboxes).to have_field(name, checked: checked)
       end
 
-      expect(course_vacancies_page.vacancies_running_sites_checkboxes).not_to have_field("Not running Uni")
+      expect(course_vacancies_page.vacancies_new_or_running_sites_checkboxes).not_to have_field("Not running Uni")
     end
   end
 
@@ -154,7 +159,9 @@ feature 'Edit course vacancies', type: :feature do
         provider: provider,
         site_statuses: [
           jsonapi_site_status('Running Uni 1', :no_vacancies, 'running'),
-          jsonapi_site_status('Running Uni 2', :no_vacancies, 'running')
+          jsonapi_site_status('Running Uni 2', :no_vacancies, 'running'),
+          jsonapi_site_status('New Uni 3', :no_vacancies, 'new_status'),
+          jsonapi_site_status('New Uni 4', :full_time, 'new_status'),
         ]
       )
     end
@@ -166,14 +173,16 @@ feature 'Edit course vacancies', type: :feature do
 
       [
         ["Running Uni 1", false],
-        ["Running Uni 2", false]
+        ["Running Uni 2", false],
+        ["New Uni 3", false],
+        ["New Uni 4", false],
       ].each do |name, checked|
-        expect(course_vacancies_page.vacancies_running_sites_checkboxes).to have_field(name, checked: checked)
+        expect(course_vacancies_page.vacancies_new_or_running_sites_checkboxes).to have_field(name, checked: checked)
       end
     end
   end
 
-  context 'A full time or part time course with one site' do
+  context 'A full time or part time course with one running site and one new site' do
     let(:course) do
       build(
         :course,
@@ -182,24 +191,27 @@ feature 'Edit course vacancies', type: :feature do
         provider: provider,
         site_statuses: [
           jsonapi_site_status('Uni full and part time 1', :full_time_and_part_time, 'running'),
+          jsonapi_site_status('Uni full and part time 2', :no_vacancies, 'new_status')
         ]
       )
     end
 
-    scenario 'presents a radio button choice and shows both study modes for the site' do
+    scenario 'presents a radio button choice and shows both study modes for the sites' do
       expect(course_vacancies_page).to have_vacancies_radio_choice
       expect(course_vacancies_page.vacancies_radio_has_some_vacancies).to be_checked
 
       [
         ["Uni full and part time 1 (Full time)", true],
-        ["Uni full and part time 1 (Part time)", true]
+        ["Uni full and part time 1 (Part time)", true],
+        ["Uni full and part time 2 (Full time)", false],
+        ["Uni full and part time 2 (Part time)", false]
       ].each do |name, checked|
-        expect(course_vacancies_page.vacancies_running_sites_checkboxes).to have_field(name, checked: checked)
+        expect(course_vacancies_page.vacancies_new_or_running_sites_checkboxes).to have_field(name, checked: checked)
       end
     end
   end
 
-  context 'A full time or part time course with multiple running sites' do
+  context 'A full time or part time course with multiple new and running sites' do
     let(:course) do
       build(
         :course,
@@ -210,6 +222,7 @@ feature 'Edit course vacancies', type: :feature do
           jsonapi_site_status('Uni 1', :full_time, 'running'),
           jsonapi_site_status('Uni 2', :part_time, 'running'),
           jsonapi_site_status('Uni 3', :full_time_and_part_time, 'running'),
+          jsonapi_site_status('Uni 4', :full_time_and_part_time, 'new_status'),
           jsonapi_site_status('Not running Uni', :full_time, 'suspended')
         ]
       )
@@ -225,9 +238,11 @@ feature 'Edit course vacancies', type: :feature do
         ["Uni 2 (Full time)", false],
         ["Uni 2 (Part time)", true],
         ["Uni 3 (Full time)", true],
-        ["Uni 3 (Part time)", true]
+        ["Uni 3 (Part time)", true],
+        ["Uni 4 (Full time)", false],
+        ["Uni 4 (Part time)", false]
       ].each do |name, checked|
-        expect(course_vacancies_page.vacancies_running_sites_checkboxes).to have_field(name, checked: checked)
+        expect(course_vacancies_page.vacancies_new_or_running_sites_checkboxes).to have_field(name, checked: checked)
       end
     end
   end

--- a/spec/helpers/vacancy_helper_spec.rb
+++ b/spec/helpers/vacancy_helper_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
-feature 'Vacancy helpers', type: :helper do
+ffeature 'Vacancy helpers', type: :helper do
   describe '#vacancy_available_for_course_site_status' do
     let(:vacancy_study_mode) { nil }
+    let(:is_new) { false }
 
     subject do
       helper.vacancy_available_for_course_site_status?(
@@ -12,233 +13,264 @@ feature 'Vacancy helpers', type: :helper do
       )
     end
 
-    context 'with a full time or part time course' do
-      let(:course) { double(:course, study_mode: 'full_time_or_part_time') }
+    context 'with status as new' do
+      let(:is_new) { true }
 
-      context 'when the vacancy study mode is full time' do
-        let(:vacancy_study_mode) { :full_time }
-
-        context 'with a full and part time vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: true,
-              full_time_vacancies?:               false,
-              part_time_vacancies?:               false
-            )
-          end
-
-          it { should eq true }
-        end
-
-        context 'with a full time vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: false,
-              full_time_vacancies?:               true,
-              part_time_vacancies?:               false
-            )
-          end
-
-          it { should eq true }
-        end
-
-        context 'with a part time vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: false,
-              full_time_vacancies?:               false,
-              part_time_vacancies?:               true
-            )
-          end
-
-          it { should eq false }
-        end
-
-        context 'with no vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: false,
-              full_time_vacancies?:               false,
-              part_time_vacancies?:               false
-            )
-          end
-
-          it { should eq false }
-        end
+      let(:course) { double(:course) }
+      let(:site_status) do
+        double(
+          new?: is_new
+        )
       end
 
-      context 'when the vacancy study mode is part time' do
-        let(:vacancy_study_mode) { :part_time }
-
-        context 'with a full and part time vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: true,
-              full_time_vacancies?:               false,
-              part_time_vacancies?:               false
-            )
-          end
-
-          it { should eq true }
-        end
-
-        context 'with a full time vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: false,
-              full_time_vacancies?:               true,
-              part_time_vacancies?:               false
-            )
-          end
-
-          it { should eq false }
-        end
-
-        context 'with a part time vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: false,
-              full_time_vacancies?:               false,
-              part_time_vacancies?:               true
-            )
-          end
-
-          it { should eq true }
-        end
-
-        context 'with no vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: false,
-              full_time_vacancies?:               false,
-              part_time_vacancies?:               false
-            )
-          end
-
-          it { should eq false }
-        end
-      end
-
-      context 'without a vacancy study mode set' do
-        context 'with a full and part time vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: true,
-              full_time_vacancies?:               false,
-              part_time_vacancies?:               false
-            )
-          end
-
-          it { should eq true }
-        end
-
-        context 'with a full time vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: false,
-              full_time_vacancies?:               true,
-              part_time_vacancies?:               false
-            )
-          end
-
-          it { should eq false }
-        end
-
-        context 'with a part time vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: false,
-              full_time_vacancies?:               false,
-              part_time_vacancies?:               true
-            )
-          end
-
-          it { should eq false }
-        end
-
-        context 'with no vacancy' do
-          let(:site_status) do
-            double(
-              :site_status,
-              full_time_and_part_time_vacancies?: false,
-              full_time_vacancies?:               false,
-              part_time_vacancies?:               false
-            )
-          end
-
-          it { should eq false }
-        end
-      end
+      it { should eq false }
     end
 
-    context 'with a full time course and vacancy' do
-      let(:course) { double(:course, study_mode: 'full_time') }
+    context 'with status as not new' do
+      context 'with a full time or part time course' do
+        let(:course) { double(:course, study_mode: 'full_time_or_part_time') }
 
-      context 'with a full time vacancy' do
-        let(:site_status) do
-          double(
-            :site_status,
-            full_time_and_part_time_vacancies?: false,
-            full_time_vacancies?:               true,
-            part_time_vacancies?:               false
-          )
+        context 'when the vacancy study mode is full time' do
+          let(:vacancy_study_mode) { :full_time }
+
+          context 'with a full and part time vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: true,
+                full_time_vacancies?:               false,
+                part_time_vacancies?:               false,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq true }
+          end
+
+          context 'with a full time vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: false,
+                full_time_vacancies?:               true,
+                part_time_vacancies?:               false,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq true }
+          end
+
+          context 'with a part time vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: false,
+                full_time_vacancies?:               false,
+                part_time_vacancies?:               true,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq false }
+          end
+
+          context 'with no vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: false,
+                full_time_vacancies?:               false,
+                part_time_vacancies?:               false,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq false }
+          end
         end
 
-        it { should eq true }
+        context 'when the vacancy study mode is part time' do
+          let(:vacancy_study_mode) { :part_time }
+
+          context 'with a full and part time vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: true,
+                full_time_vacancies?:               false,
+                part_time_vacancies?:               false,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq true }
+          end
+
+          context 'with a full time vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: false,
+                full_time_vacancies?:               true,
+                part_time_vacancies?:               false,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq false }
+          end
+
+          context 'with a part time vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: false,
+                full_time_vacancies?:               false,
+                part_time_vacancies?:               true,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq true }
+          end
+
+          context 'with no vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: false,
+                full_time_vacancies?:               false,
+                part_time_vacancies?:               false,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq false }
+          end
+        end
+
+        context 'without a vacancy study mode set' do
+          context 'with a full and part time vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: true,
+                full_time_vacancies?:               false,
+                part_time_vacancies?:               false,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq true }
+          end
+
+          context 'with a full time vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: false,
+                full_time_vacancies?:               true,
+                part_time_vacancies?:               false,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq false }
+          end
+
+          context 'with a part time vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: false,
+                full_time_vacancies?:               false,
+                part_time_vacancies?:               true,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq false }
+          end
+
+          context 'with no vacancy' do
+            let(:site_status) do
+              double(
+                :site_status,
+                full_time_and_part_time_vacancies?: false,
+                full_time_vacancies?:               false,
+                part_time_vacancies?:               false,
+                new?:                               is_new
+              )
+            end
+
+            it { should eq false }
+          end
+        end
       end
 
-      context 'with no vacancy' do
-        let(:site_status) do
-          double(
-            :site_status,
-            full_time_and_part_time_vacancies?: false,
-            full_time_vacancies?:               false,
-            part_time_vacancies?:               false
-          )
+      context 'with a full time course and vacancy' do
+        let(:course) { double(:course, study_mode: 'full_time') }
+
+        context 'with a full time vacancy' do
+          let(:site_status) do
+            double(
+              :site_status,
+              full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?:               true,
+              part_time_vacancies?:               false,
+              new?:                               is_new
+            )
+          end
+
+          it { should eq true }
         end
 
-        it { should eq false }
+        context 'with no vacancy' do
+          let(:site_status) do
+            double(
+              :site_status,
+              full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?:               false,
+              part_time_vacancies?:               false,
+              new?:                               is_new
+            )
+          end
+
+          it { should eq false }
+        end
       end
-    end
 
-    context 'with a part time course' do
-      let(:course) { double(:course, study_mode: 'part_time') }
+      context 'with a part time course' do
+        let(:course) { double(:course, study_mode: 'part_time') }
 
-      context 'with a part time vacancy' do
-        let(:site_status) do
-          double(
-            :site_status,
-            full_time_and_part_time_vacancies?: false,
-            full_time_vacancies?:               false,
-            part_time_vacancies?:               true
-          )
+        context 'with a part time vacancy' do
+          let(:site_status) do
+            double(
+              :site_status,
+              full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?:               false,
+              part_time_vacancies?:               true,
+              new?:                               is_new
+            )
+          end
+
+          it { should eq true }
         end
 
-        it { should eq true }
-      end
+        context 'with no vacancy' do
+          let(:site_status) do
+            double(
+              :site_status,
+              full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?:               false,
+              part_time_vacancies?:               false,
+              new?:                               is_new
+            )
+          end
 
-      context 'with no vacancy' do
-        let(:site_status) do
-          double(
-            :site_status,
-            full_time_and_part_time_vacancies?: false,
-            full_time_vacancies?:               false,
-            part_time_vacancies?:               false
-          )
+          it { should eq false }
         end
-
-        it { should eq false }
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_vacancies.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_vacancies.rb
@@ -9,7 +9,7 @@ module PageObjects
         element :vacancies_radio_choice, '.govuk-radios'
         element :vacancies_radio_no_vacancies, '#course_has_vacancies_false.govuk-radios__input'
         element :vacancies_radio_has_some_vacancies, '#course_has_vacancies_true.govuk-radios__input'
-        element :vacancies_running_sites_checkboxes, '.govuk-radios__conditional .govuk-checkboxes'
+        element :vacancies_new_or_running_sites_checkboxes, '.govuk-radios__conditional .govuk-checkboxes'
 
         element :confirm_no_vacancies_checkbox, '#change_vacancies_confirmation[value="no_vacancies_confirmation"]'
         element :confirm_has_vacancies_checkbox, '#change_vacancies_confirmation[value="has_vacancies_confirmation"]'


### PR DESCRIPTION
### Context
Misalignment, a `site_status` with `new_status` can be added to a course.

But afterwards the when editing vacancies for the `site_status`, the `site_status` does not show up.

### Changes proposed in this pull request
A new_status for a site on a course should show up in order for it to be allowed to assign vacancies

### Guidance to review
A `site_status` with `new_status` regardless of `vac_status` should default to not having any `vac_status` set to allow for the users to set it themselves 

I believe that this is legacy UCAS data.
