### PR TITLE
[1692] Restrict entry requirement options based on course level

### DIFF
--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -2,6 +2,7 @@ module Courses
   class EntryRequirementsController < ApplicationController
     decorates_assigned :course
     before_action :build_course
+    before_action :not_found_if_further_education
 
     def edit; end
 
@@ -37,6 +38,10 @@ module Courses
         .where(provider_code: params[:provider_code])
         .find(params[:code])
         .first
+    end
+
+    def not_found_if_further_education
+      render file: 'errors/not_found', status: :not_found if course.is_further_education?
     end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -63,6 +63,14 @@ class Course < Base
     running_site_statuses.length > 1 || full_time_or_part_time?
   end
 
+  def is_primary?
+    level == 'primary'
+  end
+
+  def is_secondary?
+    level == 'secondary'
+  end
+
   def is_further_education?
     level == 'further_education'
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -63,6 +63,10 @@ class Course < Base
     running_site_statuses.length > 1 || full_time_or_part_time?
   end
 
+  def is_further_education?
+    level == 'further_education'
+  end
+
 private
 
   def post_request(path)

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -174,13 +174,23 @@
         <dt class="govuk-summary-list__key">
           UCAS Apply: GCSE requirements for applicants
         </dt>
-        <dd class="govuk-summary-list__value govuk-!-padding-right-0" data-qa="course__entry_requirements">
-          <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'Maths', gcse_subject_code: course.maths } %>
-          <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'English', gcse_subject_code: course.english } %>
-          <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'Science', gcse_subject_code: course.science } %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-        </dd>
+        <% if course.is_further_education? %>
+          <dd class="govuk-summary-list__value" data-qa="course__entry_requirements">
+            There are no GCSE requirements for further education courses
+          </dd>
+          <dd class="govuk-summary-list__actions"></dd>
+        <% else %>
+          <dd class="govuk-summary-list__value govuk-!-padding-right-0" data-qa="course__entry_requirements">
+            <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'Maths', gcse_subject_code: course.maths } %>
+            <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'English', gcse_subject_code: course.english } %>
+            <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'Science', gcse_subject_code: course.science } %>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <%= link_to entry_requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_entry_requirements_link" } do %>
+              Change<span class="govuk-visually-hidden"> entry requirements</span>
+            <% end %>
+          </dd>
+        <% end %>
       </div>
     </dl>
   </div>

--- a/app/views/courses/entry_requirements/_subject_choices.html.erb
+++ b/app/views/courses/entry_requirements/_subject_choices.html.erb
@@ -21,10 +21,6 @@
             '3: Equivalence test',
             'equivalence_test',
             'You will consider candidates who need to take an equivalency test as well as those with a pending GCSE.'
-          ],
-          [
-            'No GCSE requirement',
-            'not_required'
           ]
         ].each do |label, value, guidance|
       %>

--- a/app/views/courses/entry_requirements/edit.html.erb
+++ b/app/views/courses/entry_requirements/edit.html.erb
@@ -30,7 +30,16 @@
 
       <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :maths } %>
       <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :english } %>
-      <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :science } %>
+
+      <% if course.is_primary? %>
+        <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :science } %>
+      <% else %>
+        <h2 class="govuk-heading-m">
+          Science GCSE
+        </h2>
+        <p class="govuk-body">There is no science GCSE requirement for secondary courses.</p>
+        <%= form.hidden_field 'science', value: 'not_set' %>
+      <% end %>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       <p class="govuk-body">Changes will appear on UCAS Apply within 2 hours.</p>

--- a/spec/features/courses/details_spec.rb
+++ b/spec/features/courses/details_spec.rb
@@ -101,6 +101,22 @@ feature 'Course details', type: :feature do
     expect(course_details_page).to have_entry_requirements
   end
 
+  context 'a further education course' do
+    let(:course) do
+      build(
+        :course,
+        provider: provider,
+        level: 'further_education'
+      )
+    end
+
+    scenario 'has no entry requirements' do
+      course_details_page.load_with_course(course)
+      expect(course_details_page.entry_requirements).to have_content('no GCSE requirements')
+      expect(course_details_page.entry_requirements).not_to have_content('Maths GCSE')
+    end
+  end
+
   context 'when the provider only has one location' do
     let(:provider) { build(:provider, provider_code: 'A0', accredited_body?: true, sites: [site1]) }
     let(:course) do

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -23,6 +23,20 @@ feature 'Edit course entry requirements', type: :feature do
     entry_requirements_page.load_with_course(course)
   end
 
+  context 'a further education course' do
+    let(:course) do
+      build(
+        :course,
+        level: 'further_education',
+        provider: provider
+      )
+    end
+
+    scenario '404s when you try to edit entry requirements' do
+      expect(page.status_code).to eq(404)
+    end
+  end
+
   context 'any course' do
     let(:course) do
       build(
@@ -40,7 +54,6 @@ feature 'Edit course entry requirements', type: :feature do
     end
 
     scenario 'can navigate to the edit screen and back again' do
-      pending('Disabled until we put Change link in')
       course_details_page.load_with_course(course)
       click_on 'Change entry requirements'
       expect(entry_requirements_page).to be_displayed


### PR DESCRIPTION
### Context

- Lock down the editing options based on the legal rules
- This can only be merged when we've cleaned up the data:
  - All secondary course science requirements should be not_required or not_set
  - All FE requirements should be not_required

### Changes proposed in this pull request

- Don't allow any editing of FE course entry requirements
- Don't allow editing of Science entry requirements on Secondary courses

![Screen Shot 2019-07-19 at 13 55 04](https://user-images.githubusercontent.com/319055/61547110-a1c33880-aa42-11e9-9fb9-3017ad9e8d44.png)