### PR TITLE
[1783] Add provider enrichments status sidebar

### DIFF
--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -39,4 +39,18 @@
       </dl>
     </div>
   </div>
+
+  <aside class="govuk-grid-column-one-third" data-qa="provider__status_panel">
+    <div class="app-related">
+      <div class="govuk-!-margin-bottom-6" data-qa="provider__content-status">
+        <%= provider.status_tag %>
+      </div>
+      <p class="govuk-body">Last published on <%= l(@provider&.last_published_at.to_date) %></p>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+      <h2 class="govuk-heading-m">View on a course</h2>
+      <p class="govuk-body">This information will show on all your courses.</p>
+      <p class="govuk-body">View any course to see how it will look to applicants.</p>
+    </div>
+  </aside>
 </div>

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -24,6 +24,7 @@ FactoryBot.define do
     postcode { nil }
     recruitment_cycle_year { '2019' }
     last_published_at { DateTime.new(2019).utc.iso8601 }
+    content_status { 'Published' }
 
     after :build do |provider, evaluator|
       # Necessary gubbins necessary to make JSONAPIClient's associations work.

--- a/spec/features/providers/details_spec.rb
+++ b/spec/features/providers/details_spec.rb
@@ -36,5 +36,8 @@ feature 'View provider', type: :feature do
     )
     expect(org_detail_page.train_with_us).to have_content(provider.train_with_us)
     expect(org_detail_page.train_with_disability).to have_content(provider.train_with_disability)
+
+    expect(org_detail_page).to have_status_panel
+    expect(org_detail_page.content_status).to have_content('Published')
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/organisation_details.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_details.rb
@@ -12,6 +12,7 @@ module PageObjects
         element :address, '[data-qa=enrichment__address]'
         element :train_with_us, '[data-qa=enrichment__train_with_us]'
         element :train_with_disability, '[data-qa=enrichment__train_with_disability]'
+        element :status_panel, '[data-qa=provider__status_panel]'
         element :content_status, '[data-qa=provider__content-status]'
       end
     end


### PR DESCRIPTION
### Context
Moving provider enrichments to rails 🎉 

### Changes proposed in this pull request
Add status panel for provider enrichments

### Guidance to review
TODO: Add the publish button once we have an endpoint on the backend to call
# After
![localhost_3000_organisations_2AT_2019_details(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/61595925-fb6b6480-abf4-11e9-903c-eb745d2928fc.png)