### PR TITLE
[1692] Show only required GCSE subjects, includes validation

### DIFF
--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -7,6 +7,9 @@ module Courses
     def edit; end
 
     def update
+      @errors = missing_subject_errors
+      return render :edit if @errors.any?
+
       if @course.update(course_params)
         flash[:success] = 'Your changes have been saved'
         redirect_to(
@@ -23,6 +26,13 @@ module Courses
     end
 
   private
+
+    def missing_subject_errors
+      course.gcse_subjects_required
+        .reject { |subject| params.dig(:course, subject) }
+        .map { |subject| [subject.to_sym, ["Pick an option for #{subject.titleize}"]] }
+        .to_h
+    end
 
     def course_params
       params.require(:course).permit(

--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -2,6 +2,7 @@ module Courses
   class EntryRequirementsController < ApplicationController
     decorates_assigned :course
     before_action :build_course
+    before_action :not_found_if_no_gcse_subjects_required
 
     def edit; end
 
@@ -37,6 +38,10 @@ module Courses
         .where(provider_code: params[:provider_code])
         .find(params[:code])
         .first
+    end
+
+    def not_found_if_no_gcse_subjects_required
+      render file: 'errors/not_found', status: :not_found if course.gcse_subjects_required.empty?
     end
   end
 end

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -184,6 +184,9 @@
             <% end %>
           </dd>
           <dd class="govuk-summary-list__actions">
+            <%= link_to entry_requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_entry_requirements_link" } do %>
+              Change<span class="govuk-visually-hidden"> entry requirements</span>
+            <% end %>
           </dd>
         </div>
       <% end %>

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -160,7 +160,6 @@
         </dd>
         <dd class="govuk-summary-list__actions"></dd>
       </div>
-
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Course code
@@ -170,18 +169,24 @@
         </dd>
         <dd class="govuk-summary-list__actions"></dd>
       </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          UCAS Apply: GCSE requirements for applicants
-        </dt>
-        <dd class="govuk-summary-list__value govuk-!-padding-right-0" data-qa="course__entry_requirements">
-          <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'Maths', gcse_subject_code: course.maths } %>
-          <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'English', gcse_subject_code: course.english } %>
-          <%= render partial: 'courses/entry_requirements', locals: { gcse_subject: 'Science', gcse_subject_code: course.science } %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-        </dd>
-      </div>
+      <% if course.gcse_subjects_required.any? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            UCAS Apply: GCSE requirements for applicants
+          </dt>
+          <dd class="govuk-summary-list__value govuk-!-padding-right-0" data-qa="course__entry_requirements">
+            <% course.gcse_subjects_required.each do |subject| %>
+              <%= render partial: 'courses/entry_requirements',
+                    locals: {
+                      gcse_subject: subject.titleize,
+                      gcse_subject_code: course[subject]
+                    } %>
+            <% end %>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+          </dd>
+        </div>
+      <% end %>
     </dl>
   </div>
   <% if course.is_running? || course.new_and_not_running? %>

--- a/app/views/courses/entry_requirements/_subject_choices.html.erb
+++ b/app/views/courses/entry_requirements/_subject_choices.html.erb
@@ -1,10 +1,13 @@
-<div class="govuk-form-group govuk-!-margin-bottom-8" data-qa="course__<%= subject %>_requirements">
+<div
+  class="<%= cns("govuk-form-group", "govuk-!-margin-bottom-8", "govuk-form-group--error": @errors && @errors[subject]&.any?) %>"
+  data-qa="course__<%= subject %>_requirements">
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
       <h2 class="govuk-fieldset__heading">
         <%= subject.to_s.titleize %> GCSE
       </h2>
     </legend>
+    <%= render "shared/error_messages", field: subject if @errors %>
     <div class="govuk-radios govuk-radios--conditional">
       <% [
           [

--- a/app/views/courses/entry_requirements/_subject_choices.html.erb
+++ b/app/views/courses/entry_requirements/_subject_choices.html.erb
@@ -21,10 +21,6 @@
             '3: Equivalence test',
             'equivalence_test',
             'You will consider candidates who need to take an equivalency test as well as those with a pending GCSE.'
-          ],
-          [
-            'No GCSE requirement',
-            'not_required'
           ]
         ].each do |label, value, guidance|
       %>
@@ -34,19 +30,16 @@
                 class: 'govuk-radios__input',
                 data: {
                   'aria-describedby': "#{subject}-#{value}-help"
-                },
-                checked: course.send(subject) == value
+                }
           %>
           <%= form.label subject,
                 label,
                 value: value,
                 class: 'govuk-label govuk-radios__label'
           %>
-          <% if guidance %>
-            <span id="<%= "#{subject}-#{value}-help" %>" class="govuk-hint govuk-radios__hint">
-              <%= guidance %>
-            </span>
-          <% end %>
+          <span id="<%= "#{subject}-#{value}-help" %>" class="govuk-hint govuk-radios__hint">
+            <%= guidance %>
+          </span>
         </div>
       <% end %>
     </div>

--- a/app/views/courses/entry_requirements/edit.html.erb
+++ b/app/views/courses/entry_requirements/edit.html.erb
@@ -24,13 +24,13 @@
       The codes you pick determine how flexible you are towards those candidates.
     </p>
 
-    <%= form_for @course,
+    <%= form_with model: course,
           url: entry_requirements_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
           method: :put do |form| %>
 
-      <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :maths } %>
-      <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :english } %>
-      <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: :science } %>
+      <% course.gcse_subjects_required.each do |subject| %>
+        <%= render partial: 'courses/entry_requirements/subject_choices', locals: {form: form, subject: subject.to_sym } %>
+      <% end %>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       <p class="govuk-body">Changes will appear on UCAS Apply within 2 hours.</p>

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -50,6 +50,7 @@ FactoryBot.define do
     maths { 'expect_to_achieve_before_training_begins' }
     english { 'must_have_qualification_at_application_time' }
     science { 'not_required' }
+    gcse_subjects_required { %w[maths english] }
 
     after :build do |course, evaluator|
       # Necessary gubbins necessary to make JSONAPIClient's associations work.

--- a/spec/features/courses/details_spec.rb
+++ b/spec/features/courses/details_spec.rb
@@ -101,6 +101,41 @@ feature 'Course details', type: :feature do
     expect(course_details_page).to have_entry_requirements
   end
 
+  context 'a course without required GCSE subjects' do
+    let(:course) do
+      build(
+        :course,
+        provider: provider,
+        gcse_subjects_required: [],
+      )
+    end
+
+    scenario 'has no entry requirements' do
+      course_details_page.load_with_course(course)
+      expect(course_details_page).not_to have_entry_requirements
+    end
+  end
+
+  context 'a course with required GCSE subjects' do
+    let(:course) do
+      build(
+        :course,
+        provider: provider,
+        gcse_subjects_required: %w[maths science],
+        english: 'expect_to_achieve_before_training_begins',
+        science: 'equivalence_test'
+      )
+    end
+
+    scenario 'shows entry requirements' do
+      course_details_page.load_with_course(course)
+      expect(course_details_page).to have_entry_requirements
+      expect(course_details_page.entry_requirements).to have_content('Maths GCSE: Taking')
+      expect(course_details_page.entry_requirements).to have_content('Science GCSE: Equivalence test')
+      expect(course_details_page.entry_requirements).not_to have_content('English GCSE')
+    end
+  end
+
   context 'when the provider only has one location' do
     let(:provider) { build(:provider, provider_code: 'A0', accredited_body?: true, sites: [site1]) }
     let(:course) do

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -55,7 +55,6 @@ feature 'Edit course entry requirements', type: :feature do
     end
 
     scenario 'can navigate to the edit screen and back again' do
-      pending('Disabled until we put Change link in')
       course_details_page.load_with_course(course)
       click_on 'Change entry requirements'
       expect(entry_requirements_page).to be_displayed

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -23,14 +23,29 @@ feature 'Edit course entry requirements', type: :feature do
     entry_requirements_page.load_with_course(course)
   end
 
-  context 'any course' do
+  context 'a course without required GCSE subjects' do
+    let(:course) do
+      build(
+        :course,
+        gcse_subjects_required: [],
+        provider: provider
+      )
+    end
+
+    scenario '404s when you try to edit entry requirements' do
+      expect(page.status_code).to eq(404)
+    end
+  end
+
+  context 'a course with all required subjects (primary)' do
     let(:course) do
       build(
         :course,
         provider: provider,
         maths: 'must_have_qualification_at_application_time',
         english: 'expect_to_achieve_before_training_begins',
-        science: 'equivalence_test'
+        science: 'equivalence_test',
+        gcse_subjects_required: %w[maths english science],
       )
     end
 
@@ -61,7 +76,6 @@ feature 'Edit course entry requirements', type: :feature do
         expect(entry_requirements_page.send(subject)).to have_field('1. Must have (least flexible)')
         expect(entry_requirements_page.send(subject)).to have_field('2: Taking')
         expect(entry_requirements_page.send(subject)).to have_field('3: Equivalence test')
-        expect(entry_requirements_page.send(subject)).to have_field('No GCSE requirement')
       end
     end
 
@@ -91,6 +105,52 @@ feature 'Edit course entry requirements', type: :feature do
       choose('course_maths_expect_to_achieve_before_training_begins')
       choose('course_english_expect_to_achieve_before_training_begins')
       choose('course_science_expect_to_achieve_before_training_begins')
+      click_on 'Save'
+
+      expect(course_details_page).to be_displayed
+      expect(course_details_page.flash).to have_content('Your changes have been saved')
+      expect(update_course_stub).to have_been_requested
+    end
+  end
+
+  context 'a course without science as a required subject (secondary)' do
+    let(:course) do
+      build(
+        :course,
+        provider: provider,
+        maths: 'must_have_qualification_at_application_time',
+        english: 'expect_to_achieve_before_training_begins',
+        science: 'not_set',
+        gcse_subjects_required: %w[maths english]
+      )
+    end
+
+    scenario 'presents a choice for only Maths and English' do
+      expect(entry_requirements_page).to have_maths_requirements
+      expect(entry_requirements_page).to have_english_requirements
+      expect(entry_requirements_page).not_to have_science_requirements
+
+      %w[
+        maths_requirements
+        english_requirements
+      ].each do |subject|
+        expect(entry_requirements_page.send(subject)).to have_field('1. Must have (least flexible)')
+        expect(entry_requirements_page.send(subject)).to have_field('2: Taking')
+        expect(entry_requirements_page.send(subject)).to have_field('3: Equivalence test')
+      end
+    end
+
+    scenario 'can be updated' do
+      update_course_stub = stub_api_v2_request(
+        "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+        "/providers/#{provider.provider_code}" \
+        "/courses/#{course.course_code}",
+        course.to_jsonapi,
+        :patch, 200
+      )
+
+      choose('course_maths_expect_to_achieve_before_training_begins')
+      choose('course_english_expect_to_achieve_before_training_begins')
       click_on 'Save'
 
       expect(course_details_page).to be_displayed


### PR DESCRIPTION
### Context

A cleaner approach to https://github.com/DFE-Digital/manage-courses-frontend/pull/473.
Lock down the editing options based on the legal rules

### Changes proposed in this pull request

- Base all logic on gcse_required_subjects – DFE-Digital/manage-courses-backend#639
- Only show the required subjects for each course when editing entry requirements
- Don't show any entry requirements if there are none needed for the course and make the edit page 404 if the page is requested
- Remove the "No requirement" option, what is shown is always required

When the entry requirements form is submitted without providing an answer to one of the required subjects, show an error.

Doesn’t yet cover the case where an invalid option is passed in. That'll be a separate PR with a backend one.

### Screenshots

![localhost_3000_organisations_2FR_2019_courses_3CVZ_entry-requirements](https://user-images.githubusercontent.com/319055/61743450-3accb900-ad8d-11e9-8bbd-9810db873fad.png)

![localhost_3000_organisations_2FR_2019_courses_3CW3_entry-requirements](https://user-images.githubusercontent.com/319055/61743648-a44cc780-ad8d-11e9-9526-14913d01bee0.png)


