### PR TITLE
Use entry requirement options from backend

### DIFF
--- a/app/views/courses/_entry_requirements.html.erb
+++ b/app/views/courses/_entry_requirements.html.erb
@@ -1,37 +1,12 @@
-<% case gcse_subject_code %>
-<% when 'must_have_qualification_at_application_time' %>
-  <details class="govuk-details govuk-!-margin-bottom-2">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text"><%= gcse_subject %> GCSE: Must have</span>
-    </summary>
-    <div class="govuk-details__text">
-      <p class="govuk-body">
-        UCAS will block applications from candidates who haven’t gained their <%= gcse_subject %> GCSE yet or who need to take an equivalency test.
-      </p>
-    </div>
-  </details>
-<% when 'expect_to_achieve_before_training_begins' %>
-  <details class="govuk-details govuk-!-margin-bottom-2">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text"><%= gcse_subject %> GCSE: Taking</span>
-    </summary>
-    <div class="govuk-details__text">
-      <p class="govuk-body">
-        You will consider candidates with a pending <%= gcse_subject %> GCSE. But UCAS will block applications from someone who needs to take an equivalency test.
-      </p>
-    </div>
-  </details>
-<% when 'equivalence_test' %>
-  <details class="govuk-details govuk-!-margin-bottom-2">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text"><%= gcse_subject %> GCSE: Equivalence test</span>
-    </summary>
-    <div class="govuk-details__text">
-      <p class="govuk-body">
-        You will consider candidates who need to take an equivalency test as well as those with a pending <%= gcse_subject %> GCSE.
-      </p>
-    </div>
-  </details>
-<% else %>
-  <p class="govuk-body"><%= gcse_subject %> GCSE: No requirement</p>
-<% end %>
+<details class="govuk-details govuk-!-margin-bottom-2">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      <%= gcse_subject %> GCSE: <%= t("edit_options.entry_requirements.#{gcse_subject_code}.details_label") %>
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">
+      <%= t("edit_options.entry_requirements.#{gcse_subject_code}.help") %>
+    </p>
+  </div>
+</details>

--- a/app/views/courses/entry_requirements/_subject_choices.html.erb
+++ b/app/views/courses/entry_requirements/_subject_choices.html.erb
@@ -9,24 +9,7 @@
     </legend>
     <%= render "shared/error_messages", field: subject if @errors %>
     <div class="govuk-radios govuk-radios--conditional">
-      <% [
-          [
-            '1. Must have (least flexible)',
-            'must_have_qualification_at_application_time',
-            'UCAS will block applications from candidates who haven’t gained their GCSE yet or who need to take an equivalency test.'
-          ],
-          [
-            '2: Taking',
-            'expect_to_achieve_before_training_begins',
-            'You will consider candidates with a pending GCSE. But UCAS will block applications from someone who needs to take an equivalency test.'
-          ],
-          [
-            '3: Equivalence test',
-            'equivalence_test',
-            'You will consider candidates who need to take an equivalency test as well as those with a pending GCSE.'
-          ]
-        ].each do |label, value, guidance|
-      %>
+      <% @course.meta['edit_options']['entry_requirements'].each do |value| %>
         <div class="govuk-radios__item">
           <%= form.radio_button subject,
                 value,
@@ -36,12 +19,12 @@
                 }
           %>
           <%= form.label subject,
-                label,
+                t("edit_options.entry_requirements.#{value}.label"),
                 value: value,
                 class: 'govuk-label govuk-radios__label'
           %>
           <span id="<%= "#{subject}-#{value}-help" %>" class="govuk-hint govuk-radios__hint">
-            <%= guidance %>
+            <%= t("edit_options.entry_requirements.#{value}.help") %>
           </span>
         </div>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,3 +41,20 @@ en:
     formats:
       default: "%-d %B %Y"
       short: "%B %Y"
+  edit_options:
+    entry_requirements:
+      must_have_qualification_at_application_time:
+        label: '1. Must have (least flexible)'
+        help: 'UCAS will block applications from candidates who haven’t gained their GCSE yet or who need to take an equivalency test.'
+        details_label: 'Must have'
+      expect_to_achieve_before_training_begins:
+        label: '2: Taking'
+        help: 'You will consider candidates with a pending GCSE. But UCAS will block applications from someone who needs to take an equivalency test.'
+        details_label: 'Taking'
+      equivalence_test:
+        label: '3: Equivalence test'
+        help: 'You will consider candidates who need to take an equivalency test as well as those with a pending GCSE.'
+        details_label: 'Equivalence test'
+      not_required:
+        details_label: 'No requirement'
+        help: 'You will receive applications from candidates who will not have a grade C (or 4) or above.'

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
       sites { [] }
       site_statuses { [] }
       recruitment_cycle { build :recruitment_cycle }
+      edit_options {}
     end
 
     sequence(:id)
@@ -51,6 +52,7 @@ FactoryBot.define do
     english { 'must_have_qualification_at_application_time' }
     science { 'not_required' }
     gcse_subjects_required { %w[maths english] }
+    meta { nil }
 
     after :build do |course, evaluator|
       # Necessary gubbins necessary to make JSONAPIClient's associations work.
@@ -67,6 +69,11 @@ FactoryBot.define do
       course.recruitment_cycle = evaluator.recruitment_cycle
       course.provider_code = evaluator.provider&.provider_code
       course.recruitment_cycle_year = evaluator&.recruitment_cycle&.year
+
+      if evaluator.edit_options
+        course.meta = {}
+        course.meta['edit_options'] = evaluator.edit_options
+      end
     end
 
     trait :with_vacancy do

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -5,6 +5,11 @@ feature 'Edit course entry requirements', type: :feature do
   let(:entry_requirements_page) { PageObjects::Page::Organisations::CourseEntryRequirements.new }
   let(:course_details_page) { PageObjects::Page::Organisations::CourseDetails.new }
   let(:provider) { build(:provider) }
+  let(:edit_options) {
+    {
+      entry_requirements: %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test]
+    }
+  }
 
   before do
     stub_omniauth
@@ -27,6 +32,7 @@ feature 'Edit course entry requirements', type: :feature do
     let(:course) do
       build(
         :course,
+        edit_options: edit_options,
         gcse_subjects_required: [],
         provider: provider
       )
@@ -41,6 +47,7 @@ feature 'Edit course entry requirements', type: :feature do
     let(:course) do
       build(
         :course,
+        edit_options: edit_options,
         provider: provider,
         maths: 'must_have_qualification_at_application_time',
         english: 'expect_to_achieve_before_training_begins',
@@ -116,6 +123,7 @@ feature 'Edit course entry requirements', type: :feature do
     let(:course) do
       build(
         :course,
+        edit_options: edit_options,
         provider: provider,
         maths: 'must_have_qualification_at_application_time',
         english: 'expect_to_achieve_before_training_begins',
@@ -162,6 +170,7 @@ feature 'Edit course entry requirements', type: :feature do
     let(:course) do
       build(
         :course,
+        edit_options: edit_options,
         provider: provider,
         maths: 'not_set',
         english: 'not_set',


### PR DESCRIPTION
### Context

- Pull in options from backend rather than hardcoding
- Use keys to determine labels and help text

### Guidance to review

Goes alongside https://github.com/DFE-Digital/manage-courses-backend/pull/651
