### PR TITLE
[1827] Allow users to edit a course outcome

### DIFF
--- a/app/controllers/courses/outcome_controller.rb
+++ b/app/controllers/courses/outcome_controller.rb
@@ -1,0 +1,45 @@
+module Courses
+  class OutcomeController < ApplicationController
+    decorates_assigned :course
+    before_action :build_course
+
+    def edit; end
+
+    def update
+      @errors = missing_outcome_error
+      return render :edit if @errors.any?
+
+      if @course.update(course_params)
+        flash[:success] = 'Your changes have been saved'
+        redirect_to(
+          details_provider_recruitment_cycle_course_path(
+            @course.provider_code,
+            @course.recruitment_cycle_year,
+            @course.course_code
+          )
+        )
+      else
+        @errors = @course.errors.messages
+        render :edit
+      end
+    end
+
+  private
+
+    def missing_outcome_error
+      params.dig(:course, :qualification) ? {} : { qualification: ["Pick an outcome"] }
+    end
+
+    def course_params
+      params.require(:course).permit(:qualification)
+    end
+
+    def build_course
+      @course = Course
+        .where(recruitment_cycle_year: params[:recruitment_cycle_year])
+        .where(provider_code: params[:provider_code])
+        .find(params[:code])
+        .first
+    end
+  end
+end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -28,7 +28,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def outcome
-    object.qualifications.sort.map(&:upcase).join(' with ')
+    I18n.t("edit_options.qualifications.#{object.qualification}.label")
   end
 
   def is_send?

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -38,7 +38,11 @@
         <dd class="govuk-summary-list__value" data-qa="course__qualifications">
           <%= course.outcome %>
         </dd>
-        <dd class="govuk-summary-list__actions"></dd>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to outcome_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_entry_requirements_link" } do %>
+            Change<span class="govuk-visually-hidden"> outcome</span>
+          <% end %>
+        </dd>
       </div>
 
       <% if @provider.accredited_body? %>

--- a/app/views/courses/outcome/edit.html.erb
+++ b/app/views/courses/outcome/edit.html.erb
@@ -1,0 +1,60 @@
+<%= content_for :page_title, "Pick a course outcome – #{course.name_and_code}" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: course,
+          url: outcome_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+          method: :put do |form| %>
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <h1 class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-top-0">
+            <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+            Pick a course outcome
+          </h1>
+        </legend>
+        <div class="<%= cns("govuk-form-group", "govuk-!-margin-bottom-8", "govuk-form-group--error": @errors && @errors[:qualification]&.any?) %>"
+        data-qa="course__qualification">
+          <%= render "shared/error_messages", field: :qualification if @errors %>
+          <% @course.meta['edit_options']['qualifications'].each do |value| %>
+            <% help = t("edit_options.qualifications.#{value}.help") %>
+            <% label = t("edit_options.qualifications.#{value}.label") %>
+
+            <div class="govuk-radios__item">
+              <%= form.radio_button :qualification,
+                    value,
+                    class: 'govuk-radios__input',
+                    data: {
+                      'aria-describedby': "#{value}-help"
+                    }
+              %>
+              <%= form.label :qualification,
+                    label,
+                    value: value,
+                    class: 'govuk-label govuk-radios__label'
+              %>
+              <span id="<%= "#{value}-help" %>" class="govuk-hint govuk-radios__hint">
+                <%= help %>
+              </span>
+            </div>
+          <% end %>
+        </div>
+      </fieldset>
+
+      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
+        class: "govuk-button", data: { qa: 'course__save' }
+      %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes',
+          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,3 +58,19 @@ en:
       not_required:
         details_label: 'No requirement'
         help: 'You will receive applications from candidates who will not have a grade C (or 4) or above.'
+    qualifications:
+      qts:
+        label: 'QTS'
+        help: 'Qualified teacher status'
+      pgce:
+        label: 'PGCE only (without QTS)'
+        help: 'Postgraduate certificate in education'
+      pgce_with_qts:
+        label: 'PGCE with QTS'
+        help: 'Postgraduate certificate in education with qualified teacher status'
+      pgde:
+        label: 'PGDE only (without QTS)'
+        help: 'Postgraduate diploma in education'
+      pgde_with_qts:
+        label: 'PGDE with QTS'
+        help: 'Postgraduate diploma in education with qualified teacher status'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,9 @@ Rails.application.routes.draw do
 
         get '/entry-requirements', on: :member, to: 'courses/entry_requirements#edit'
         put '/entry-requirements', on: :member, to: 'courses/entry_requirements#update'
+
+        get '/outcome', on: :member, to: 'courses/outcome#edit'
+        put '/outcome', on: :member, to: 'courses/outcome#update'
       end
 
       resources :sites, path: 'locations', on: :member, except: %i[destroy show]

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -8,7 +8,7 @@ describe CourseDecorator do
     build :course,
           course_code: 'A1',
           name: 'Mathematics',
-          qualifications: %w[qts pgce],
+          qualification: 'pgce_with_qts',
           study_mode: 'full_time',
           start_date: Time.zone.local(2019),
           site_statuses: [site_status],

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     content_status { "published" }
     ucas_status { 'running' }
     accrediting_provider { nil }
-    qualifications { %w[qts pgce] }
+    qualification { 'pgce_with_qts' }
     start_date     { Time.zone.local(2019) }
     funding        { 'fee' }
     applications_open_from { DateTime.new(2019).utc.iso8601 }

--- a/spec/factories/errors.rb
+++ b/spec/factories/errors.rb
@@ -24,13 +24,25 @@ FactoryBot.define do
       attributes
     end
 
+    trait :for_course_outcome do
+      errors {
+        [
+          {
+            title: "Invalid qualification",
+            detail: "Qualification error",
+            source: { pointer: "/data/attributes/qualification" }
+          }
+        ]
+      }
+    end
+
     trait :for_course_publish do
       errors {
         [
           {
             title: "Invalid about_course",
             detail: "About course can't be blank",
-            source: { pointer: "/data/atributes/about_course" }
+            source: { pointer: "/data/attributes/about_course" }
           }
         ]
       }

--- a/spec/features/courses/details_spec.rb
+++ b/spec/features/courses/details_spec.rb
@@ -5,7 +5,6 @@ feature 'Course details', type: :feature do
   let(:provider) { build(:provider, provider_code: 'A0', accredited_body?: false, sites: [site1, site2]) }
   let(:course) do
     build :course,
-          qualifications: %w[qts pgce],
           study_mode: 'full_time',
           start_date: Time.zone.local(2019),
           sites: [site1, site2],

--- a/spec/features/courses/outcome/edit_spec.rb
+++ b/spec/features/courses/outcome/edit_spec.rb
@@ -1,0 +1,171 @@
+require 'rails_helper'
+
+feature 'Edit course outcome', type: :feature do
+  let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+  let(:outcome_page) { PageObjects::Page::Organisations::CourseOutcome.new }
+  let(:course_details_page) { PageObjects::Page::Organisations::CourseDetails.new }
+  let(:provider) { build(:provider) }
+
+  before do
+    stub_omniauth
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}",
+      current_recruitment_cycle.to_jsonapi
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
+      build(:provider).to_jsonapi(include: %i[courses accrediting_provider])
+    )
+
+    stub_course_request
+    stub_course_details_tab
+    outcome_page.load_with_course(course)
+  end
+
+  context 'a course that offers QTS' do
+    let(:course) do
+      build(
+        :course,
+        edit_options: {
+          qualifications: %w[qts pgce_with_qts pgde_with_qts]
+        },
+        provider: provider
+      )
+    end
+
+    scenario 'can cancel changes' do
+      click_on 'Cancel changes'
+      expect(course_details_page).to be_displayed
+    end
+
+    scenario 'can navigate to the edit screen and back again' do
+      course_details_page.load_with_course(course)
+      click_on 'Change outcome'
+      expect(outcome_page).to be_displayed
+      click_on 'Back'
+      expect(course_details_page).to be_displayed
+    end
+
+    scenario 'presents a choice for each qualification' do
+      expect(outcome_page).to have_qualification_fields
+      expect(outcome_page.qualification_fields)
+        .to have_selector('[for="course_qualification_qts"]', text: 'QTS')
+      expect(outcome_page.qualification_fields)
+        .to have_selector('[for="course_qualification_pgce_with_qts"]', text: 'PGCE with QTS')
+      expect(outcome_page.qualification_fields)
+        .to have_selector('[for="course_qualification_pgde_with_qts"]', text: 'PGDE with QTS')
+    end
+
+    scenario 'has the correct value selected' do
+      expect(outcome_page.qualification_fields)
+        .to have_field('course_qualification_pgce_with_qts', checked: true)
+    end
+
+    scenario 'can be updated' do
+      update_course_stub = stub_api_v2_request(
+        "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+        "/providers/#{provider.provider_code}" \
+        "/courses/#{course.course_code}",
+        course.to_jsonapi,
+        :patch, 200
+      )
+
+      choose('course_qualification_qts')
+      click_on 'Save'
+
+      expect(course_details_page).to be_displayed
+      expect(course_details_page.flash).to have_content('Your changes have been saved')
+      expect(update_course_stub).to have_been_requested
+    end
+  end
+
+  context 'a further education course that doesn’t offer QTS' do
+    let(:course) do
+      build(
+        :course,
+        edit_options: {
+          qualifications: %w[pgce pgde]
+        },
+        qualification: 'pgde',
+        provider: provider
+      )
+    end
+
+    scenario 'presents a choice for each qualification' do
+      expect(outcome_page).to have_qualification_fields
+      expect(outcome_page.qualification_fields)
+        .to have_selector('[for="course_qualification_pgce"]', text: 'PGCE only')
+      expect(outcome_page.qualification_fields)
+        .to have_selector('[for="course_qualification_pgde"]', text: 'PGDE only')
+    end
+
+    scenario 'has the correct value selected' do
+      expect(outcome_page.qualification_fields)
+        .to have_field('course_qualification_pgde', checked: true)
+    end
+  end
+
+  context 'a course with bad data' do
+    let(:course) do
+      build(
+        :course,
+        edit_options: {
+          qualifications: %w[qts]
+        },
+        provider: provider,
+        qualification: 'something_else'
+      )
+    end
+
+    scenario 'shows an error if the form is submitted without providing answers' do
+      click_on 'Save'
+      expect(outcome_page).to be_displayed
+
+      expect(outcome_page.error_flash)
+        .to have_content('You’ll need to correct some information')
+
+      expect(outcome_page.error_flash).to have_content("Pick an outcome")
+      expect(outcome_page).to have_selector("#qualification-error")
+    end
+
+    scenario 'shows validation errors returned by backend' do
+      update_course_stub = stub_api_v2_request(
+        "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+        "/providers/#{provider.provider_code}" \
+        "/courses/#{course.course_code}",
+        build(:error, :for_course_outcome), :patch, 422
+      )
+
+      choose('course_qualification_qts')
+      click_on 'Save'
+      expect(outcome_page).to be_displayed
+
+      expect(outcome_page.error_flash)
+        .to have_content('You’ll need to correct some information')
+
+      expect(outcome_page.error_flash).to have_content("Qualification error")
+      expect(outcome_page).to have_selector("#qualification-error")
+      expect(update_course_stub).to have_been_requested
+    end
+  end
+
+  def stub_course_request
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}/courses" \
+      "/#{course.course_code}",
+      course.to_jsonapi
+    )
+  end
+
+  def stub_course_details_tab
+    stub_api_v2_request(
+      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
+      "/courses/#{course.course_code}" \
+      "?include=sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites])
+    )
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/course_outcome.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_outcome.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseOutcome < CourseBase
+        set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/outcome'
+
+        element :qualification_fields, '[data-qa="course__qualification"]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Allow providers to edit the outcomes of their courses
Depends on https://github.com/DFE-Digital/manage-courses-backend/pull/649

### Changes proposed in this pull request

- Stop using the array of qualifications to generate the outcome
- Use the qualification returned from backend to show the one stored in en.yml.
- Removes the only frontend dependency on `course.qualifications` (`['qts', 'pgce']`), favouring `course.qualification` (`pgce_with_qts`).

### Screenshots

#### QTS courses
![Screen Shot 2019-07-26 at 11 50 43](https://user-images.githubusercontent.com/319055/61946926-bac86e00-af9b-11e9-81bf-220588f36923.png)

#### Errors
![Screen Shot 2019-07-26 at 11 51 09](https://user-images.githubusercontent.com/319055/61946929-bac86e00-af9b-11e9-922f-d9162b80c82f.png)

#### FE courses
![Screen Shot 2019-07-26 at 11 51 29](https://user-images.githubusercontent.com/319055/61946930-bac86e00-af9b-11e9-8465-7dbc003cb0f8.png)

