### PR TITLE
[1792] Provider enrichment improvements

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,22 +9,31 @@ module ApplicationHelper
     markdown.render(source).html_safe
   end
 
-  def course_enrichment_error_link(field, error)
+  def enrichment_error_link(model, field, error)
+    href = case model
+           when :course
+             enrichment_error_url(
+               provider_code: @provider.provider_code,
+               course: @course,
+               field: field.to_s
+             )
+           when :provider
+             provider_enrichment_error_url(
+               provider: @provider,
+               field: field.to_s
+             )
+           end
     content_tag :a, error,
                 class: 'govuk-link govuk-!-display-block',
-                href: enrichment_error_url(
-                  provider_code: @provider.provider_code,
-                  course: @course,
-                  field: field.to_s
-                )
+                href: href
   end
 
-  def enrichment_summary_label(key, field)
+  def enrichment_summary_label(model, key, field)
     if @errors&.key? field
       content_tag :dt, class: 'govuk-summary-list__key app-course-parts__fields__label--error' do
         [
           content_tag(:span, key),
-          *@errors[field].map { |error| course_enrichment_error_link(field, error) }
+          *@errors[field].map { |error| enrichment_error_link(model, field, error) }
         ].reduce(:+)
       end
     else
@@ -43,9 +52,9 @@ module ApplicationHelper
     content_tag :dd, value, class: css_class, data: { qa: "enrichment__#{field}" }
   end
 
-  def enrichment_summary_item(key, value, field)
+  def enrichment_summary_item(model, key, value, field)
     content_tag :div, class: 'govuk-summary-list__row' do
-      enrichment_summary_label(key, field) + enrichment_summary_value(value, field)
+      enrichment_summary_label(model, key, field) + enrichment_summary_value(value, field)
     end
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -46,6 +46,22 @@ module ViewHelper
     }[field]
   end
 
+  def provider_enrichment_error_url(provider:, field:)
+    base = "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}"
+
+    {
+      'train_with_us' => base + '/about?display_errors=true#provider_train_with_us',
+      'train_with_disability' => base + '/about?display_errors=true#provider_train_with_disability',
+      'email' => base + '/contact?display_errors=true#provider_email',
+      'website' => base + '/contact?display_errors=true#provider_website',
+      'telephone' => base + '/contact?display_errors=true#provider_telephone',
+      'address1' => base + '/contact?display_errors=true#provider_address1',
+      'address3' => base + '/contact?display_errors=true#provider_address3',
+      'address4' => base + '/contact?display_errors=true#provider_address4',
+      'postcode' => base + '/contact?display_errors=true#provider_postcode'
+    }[field]
+  end
+
   def header_environment_class
     "app-header__container--#{Settings.environment.selector_name}"
   end

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -16,9 +16,9 @@
   <%= link_to 'About this course', about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link' %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
-  <%= enrichment_summary_item('About this course', course.about_course, 'about_course') %>
-  <%= enrichment_summary_item('Interview process (optional)', course.interview_process, 'interview_process') %>
-  <%= enrichment_summary_item('How school placements work', course.how_school_placements_work, 'how_school_placements_work') %>
+  <%= enrichment_summary_item(:course,  'About this course', course.about_course, 'about_course') %>
+  <%= enrichment_summary_item(:course,  'Interview process (optional)', course.interview_process, 'interview_process') %>
+  <%= enrichment_summary_item(:course,  'How school placements work', course.how_school_placements_work, 'how_school_placements_work') %>
 </dl>
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">
@@ -29,15 +29,15 @@
   <% end %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
-  <%= enrichment_summary_item('Course length', course.length, 'course_length') %>
+  <%= enrichment_summary_item(:course,  'Course length', course.length, 'course_length') %>
 
   <% if course.has_fees? %>
-    <%= enrichment_summary_item('Fee for UK and EU students', number_to_currency(course.fee_uk_eu), 'fee_uk_eu') %>
-    <%= enrichment_summary_item('Fee for international students (optional)', number_to_currency(course.fee_international), 'international_fees') %>
-    <%= enrichment_summary_item('Fee details (optional)', course.fee_details, 'fee_details') %>
-    <%= enrichment_summary_item('Financial support you offer (optional)', course.financial_support, 'financial_support') %>
+    <%= enrichment_summary_item(:course,  'Fee for UK and EU students', number_to_currency(course.fee_uk_eu), 'fee_uk_eu') %>
+    <%= enrichment_summary_item(:course,  'Fee for international students (optional)', number_to_currency(course.fee_international), 'international_fees') %>
+    <%= enrichment_summary_item(:course,  'Fee details (optional)', course.fee_details, 'fee_details') %>
+    <%= enrichment_summary_item(:course,  'Financial support you offer (optional)', course.financial_support, 'financial_support') %>
   <% else %>
-    <%= enrichment_summary_item('Salary', course.salary_details, 'salary_details') %>
+    <%= enrichment_summary_item(:course,  'Salary', course.salary_details, 'salary_details') %>
   <% end %>
 </dl>
 
@@ -45,7 +45,7 @@
   <%= link_to 'Requirements and eligibility', requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link' %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
-  <%= enrichment_summary_item('Qualifications needed', course.required_qualifications, 'qualifications') %>
-  <%= enrichment_summary_item('Personal qualities (optional)', course.personal_qualities, 'personal_qualities') %>
-  <%= enrichment_summary_item('Other requirements (optional)', course.other_requirements, 'other_requirements') %>
+  <%= enrichment_summary_item(:course,  'Qualifications needed', course.required_qualifications, 'qualifications') %>
+  <%= enrichment_summary_item(:course,  'Personal qualities (optional)', course.personal_qualities, 'personal_qualities') %>
+  <%= enrichment_summary_item(:course,  'Other requirements (optional)', course.other_requirements, 'other_requirements') %>
 </dl>

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}Edit 'About your organisation'" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_path(@provider.provider_code)) %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_path(provider_code: @provider.provider_code, year: @provider.recruitment_cycle_year)) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Edit 'About your organisation'" %>
+<%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}Edit 'About your organisation'" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_path(@provider.provider_code)) %>

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}Edit 'Contact information'" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_path(@provider.provider_code)) %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_path(provider_code: @provider.provider_code, year: @provider.recruitment_cycle_year)) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Contact information" %>
+<%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}Edit 'Contact information'" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_path(@provider.provider_code)) %>

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -3,6 +3,28 @@
   <%= govuk_back_link_to(provider_path(@provider.provider_code)) %>
 <% end %>
 
+<% if @errors.present? %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary" data-ga-event-form="error">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      You’ll need to correct some information.
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <% @errors.each do |id, messages| %>
+          <% messages.each do |message| %>
+            <li data-error-message="<%= message %>">
+              <a href="<%= provider_enrichment_error_url(
+                provider: @provider,
+                field: id
+              ) %>"><%= message %></a>
+            </li>
+          <% end %>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
@@ -18,23 +40,23 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-summary-list govuk-summary-list--short">
       <h3 class="govuk-heading-m govuk-!-font-size-27">
-        <%= govuk_link_to "Contact details", contact_provider_recruitment_cycle_path(provider_code: @provider.provider_code, year: @provider.recruitment_cycle_year) %>
+        <%= govuk_link_to "Contact details", contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
       </h3>
       <dl class="govuk-summary-list">
-        <%= enrichment_summary_item('Email address', @provider.email, 'email') %>
-        <%= enrichment_summary_item('Telephone number', @provider.telephone, 'telephone') %>
-        <%= enrichment_summary_item('Website', @provider.website, 'website') %>
-        <%= enrichment_summary_item('Contact address', @provider.full_address, 'address') %>
+        <%= enrichment_summary_item(:provider, 'Email address', @provider.email, 'email') %>
+        <%= enrichment_summary_item(:provider, 'Telephone number', @provider.telephone, 'telephone') %>
+        <%= enrichment_summary_item(:provider, 'Website', @provider.website, 'website') %>
+        <%= enrichment_summary_item(:provider, 'Contact address', @provider.full_address, 'address') %>
       </dl>
     </div>
 
     <div class="govuk-summary-list govuk-summary-list--short">
       <h3 class="govuk-heading-m govuk-!-font-size-27">
-        <%= govuk_link_to "About your organisation", about_provider_recruitment_cycle_path(provider_code: @provider.provider_code, year: @provider.recruitment_cycle_year) %>
+        <%= govuk_link_to "About your organisation", about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
       </h3>
       <dl class="govuk-summary-list">
-        <%= enrichment_summary_item('About your organisation', @provider.train_with_us, 'train_with_us') %>
-        <%= enrichment_summary_item('Training with disabilities and other needs', @provider.train_with_disability, 'train_with_disability') %>
+        <%= enrichment_summary_item(:provider, 'About your organisation', @provider.train_with_us, 'train_with_us') %>
+        <%= enrichment_summary_item(:provider, 'Training with disabilities and other needs', @provider.train_with_disability, 'train_with_disability') %>
       </dl>
     </div>
   </div>

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -1,5 +1,4 @@
-<%= content_for :page_title, "About your organisation" %>
-
+<%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}About your organisation" %>
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_path(@provider.provider_code)) %>
 <% end %>

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -18,7 +18,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-summary-list govuk-summary-list--short">
       <h3 class="govuk-heading-m govuk-!-font-size-27">
-        <%= govuk_link_to "Contact details", manage_ui_url("/organisation/#{@provider.provider_code}/contact") %>
+        <%= govuk_link_to "Contact details", contact_provider_recruitment_cycle_path(provider_code: @provider.provider_code, year: @provider.recruitment_cycle_year) %>
       </h3>
       <dl class="govuk-summary-list">
         <%= enrichment_summary_item('Email address', @provider.email, 'email') %>
@@ -30,7 +30,7 @@
 
     <div class="govuk-summary-list govuk-summary-list--short">
       <h3 class="govuk-heading-m govuk-!-font-size-27">
-        <%= govuk_link_to "About your organisation", manage_ui_url("/organisation/#{@provider.provider_code}/about") %>
+        <%= govuk_link_to "About your organisation", about_provider_recruitment_cycle_path(provider_code: @provider.provider_code, year: @provider.recruitment_cycle_year) %>
       </h3>
       <dl class="govuk-summary-list">
         <%= enrichment_summary_item('About your organisation', @provider.train_with_us, 'train_with_us') %>

--- a/spec/features/providers/details_spec.rb
+++ b/spec/features/providers/details_spec.rb
@@ -23,7 +23,7 @@ feature 'View provider', type: :feature do
 
     expect(org_detail_page).to have_link(
       'Contact details',
-      href: "#{Settings.manage_ui.base_url}/organisation/#{provider.provider_code}/contact"
+      href: "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/contact"
     )
     expect(org_detail_page.caption).to have_content(provider.provider_name)
     expect(org_detail_page.email).to have_content(provider.email)
@@ -32,7 +32,7 @@ feature 'View provider', type: :feature do
 
     expect(org_detail_page).to have_link(
       'About your organisation',
-      href: "#{Settings.manage_ui.base_url}/organisation/#{provider.provider_code}/about"
+      href: "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/about"
     )
     expect(org_detail_page.train_with_us).to have_content(provider.train_with_us)
     expect(org_detail_page.train_with_disability).to have_content(provider.train_with_disability)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature 'View helpers', type: :helper do
-  describe '#course_enrichment_error_link' do
+  describe '#enrichment_error_link' do
     context 'with a course' do
       before do
         @provider = Provider.new(build(:provider).attributes)
@@ -7,7 +7,7 @@ RSpec.feature 'View helpers', type: :helper do
       end
 
       it "returns correct content" do
-        expect(helper.course_enrichment_error_link('about_course', 'Something about the course'))
+        expect(helper.enrichment_error_link(:course, 'about_course', 'Something about the course'))
           .to eq("<a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#about_course_wrapper\">Something about the course</a>")
       end
     end
@@ -15,7 +15,7 @@ RSpec.feature 'View helpers', type: :helper do
 
   describe "#enrichment_summary_label" do
     it "returns correct content" do
-      expect(helper.enrichment_summary_label('About course', "about_course")).to eq('<dt class="govuk-summary-list__key">About course</dt>')
+      expect(helper.enrichment_summary_label(:course, 'About course', "about_course")).to eq('<dt class="govuk-summary-list__key">About course</dt>')
     end
 
     context "with errors" do
@@ -26,7 +26,7 @@ RSpec.feature 'View helpers', type: :helper do
       end
 
       it "returns correct content" do
-        expect(helper.enrichment_summary_label('About course', :about_course)).to eq("<dt class=\"govuk-summary-list__key app-course-parts__fields__label--error\"><span>About course</span><a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#about_course_wrapper\">Something about the course</a></dt>")
+        expect(helper.enrichment_summary_label(:course, 'About course', :about_course)).to eq("<dt class=\"govuk-summary-list__key app-course-parts__fields__label--error\"><span>About course</span><a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#about_course_wrapper\">Something about the course</a></dt>")
       end
     end
   end
@@ -45,7 +45,7 @@ RSpec.feature 'View helpers', type: :helper do
 
   describe "#enrichment_summary_item" do
     it "returns correct content" do
-      expect(helper.enrichment_summary_item('About course', 'Something about the course', 'about'))
+      expect(helper.enrichment_summary_item(:course, 'About course', 'Something about the course', 'about'))
         .to eq('<div class="govuk-summary-list__row"><dt class="govuk-summary-list__key">About course</dt><dd class="govuk-summary-list__value govuk-summary-list__value--truncate" data-qa="enrichment__about">Something about the course</dd></div>')
     end
   end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -26,6 +26,13 @@ RSpec.feature 'View helpers', type: :helper do
     end
   end
 
+  describe "#provider_enrichment_error_url" do
+    it "returns provider enrichment error URL" do
+      provider = Provider.new(build(:provider).attributes)
+      expect(helper.provider_enrichment_error_url(provider: provider, field: 'email')).to eq("/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/contact?display_errors=true#provider_email")
+    end
+  end
+
   describe "#classnames #cns" do
     it "returns joined classname strings" do
       expect(helper.cns('foo', 'bar')).to eq 'foo bar'


### PR DESCRIPTION
### Context

Some small bits of work I've extracted from the bigger provider publish/validations PR that is forthcoming, to slim it down.

### Changes proposed in this pull request

- Add `Error:` to the page titles when errors are present
- Link the details directly to the contact and about pages and vice versa
- Add deep linking capabilities to the `enrichment_summary_item` helper for provider enrichments

### Guidance to review

Easiest reviewed commit by commit.