### PR TITLE
Show correct year against fees in preview

### DIFF
--- a/app/views/courses/preview/_fees.html.erb
+++ b/app/views/courses/preview/_fees.html.erb
@@ -4,7 +4,7 @@
   <% if course.fee_uk_eu.present? %>
     <div class="body-text">
       <table class="govuk-table">
-        <caption class="govuk-table__caption govuk-!-font-weight-regular govuk-!-margin-bottom-4">The course fees for 2019/2020 are as follows:</caption>
+        <caption class="govuk-table__caption govuk-!-font-weight-regular govuk-!-margin-bottom-4">The course fees for <%= @recruitment_cycle.year_range %> are as follows:</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-visually-hidden govuk-table__row">
             <th class="govuk-table__header">Student type</th>

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -123,6 +123,10 @@ feature 'Preview course', type: :feature do
       course.how_school_placements_work
     )
 
+    expect(preview_course_page).to have_content(
+      'The course fees for 2019 – 2020 are as follows'
+    )
+
     expect(preview_course_page.uk_fees).to have_content(
       '£9,250'
     )


### PR DESCRIPTION
We need to use the recruitment cycle to show which year the fees are for on course preview.