### PR TITLE
[1886] move validations out of controller

### DIFF
--- a/app/controllers/concerns/edit_basic_detail.rb
+++ b/app/controllers/concerns/edit_basic_detail.rb
@@ -10,19 +10,7 @@ module EditBasicDetail
 
   def update
     @errors = errors
-    return render :edit if @errors.any?
-
-    # Age range 'other' override
-    course = params.dig(:course)
-    is_other = course.dig(:age_range_in_years) == "Other"
-
-    if course.dig(:course_age_range_in_years_other_from).present? &&
-        course.dig(:course_age_range_in_years_other_to).present? &&
-        is_other
-      params[:course][:age_range_in_years] = "#{course.dig(:course_age_range_in_years_other_from)}_to_#{course.dig(:course_age_range_in_years_other_to)}"
-    elsif is_other
-      params[:course][:age_range_in_years] = nil
-    end
+    return render :edit if @errors.present?
 
     if @course.update(course_params)
       flash[:success] = 'Your changes have been saved'

--- a/app/controllers/courses/age_range_controller.rb
+++ b/app/controllers/courses/age_range_controller.rb
@@ -1,15 +1,57 @@
 module Courses
   class AgeRangeController < ApplicationController
-    include EditBasicDetail
+    decorates_assigned :course
+    before_action :build_course
+
+    def update
+      # Age range 'other' override
+      course = params.dig(:course)
+      is_other = course.dig(:age_range_in_years) == "other"
+      age_from = course.dig(:course_age_range_in_years_other_from)
+      age_to = course.dig(:course_age_range_in_years_other_to)
+
+      if is_other && (age_from.blank? || age_to.blank?)
+        errors = {
+          age_range_in_years: ["Enter an age for both from and to"],
+          age_range_in_years_from: ["Enter an age"],
+          age_range_in_years_to: ["Enter an age"],
+        }
+      elsif age_from.present? && age_to.present? && is_other
+        params[:course][:age_range_in_years] = "#{age_from}_to_#{age_to}"
+      elsif is_other
+        params[:course][:age_range_in_years] = nil
+      end
+
+      @errors = errors
+      return render :edit if @errors.present?
+
+      if @course.update(course_params)
+        flash[:success] = 'Your changes have been saved'
+        redirect_to(
+          details_provider_recruitment_cycle_course_path(
+            @course.provider_code,
+            @course.recruitment_cycle_year,
+            @course.course_code
+          )
+        )
+      else
+        @errors = @course.errors.messages
+        render :edit
+      end
+    end
 
   private
 
-    def errors
-      params.dig(:course, :age_range_in_years) ? {} : { age_range_in_years: ["Pick an age range"] }
-    end
-
     def course_params
       params.require(:course).permit(:age_range_in_years)
+    end
+
+    def build_course
+      @course = Course
+        .where(recruitment_cycle_year: params[:recruitment_cycle_year])
+        .where(provider_code: params[:provider_code])
+        .find(params[:code])
+        .first
     end
   end
 end

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -35,23 +35,29 @@
             <% end %>
             <div class="govuk-radios__divider">or</div>
             <div class="govuk-radios__item">
-              <%= form.radio_button :age_range_in_years, 'Other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" },
-                checked: course.other_age_range?,
+              <%= form.radio_button :age_range_in_years, 'other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" },
+                checked: course.other_age_range? && course.age_range_in_years.present?,
                 aria: { describedby: @errors && @errors[:age_range_in_years] ? "course_age_range_in_years-error" : '' } %>
-              <%= form.label :age_range_in_years, t("edit_options.age_range_in_years.other.label"), value: 'Other', class: 'govuk-label govuk-radios__label' %>
+              <%= form.label :age_range_in_years, t("edit_options.age_range_in_years.other.label"), value: 'other', class: 'govuk-label govuk-radios__label' %>
             </div>
-            <div class="govuk-radios__conditional" id="other-container"">
+            <div class="govuk-radios__conditional <%= 'govuk-radios__conditional--hidden' if !course.other_age_range? %>" id="other-container">
               <p class="govuk-body">Enter an age range in years, for example: 5 to 11. The course must cover 4 or more school years.</p>
-              <div class="govuk-form-group ">
+              <%= render "shared/error_messages", field: :age_range_in_years_from if @errors %>
+              <div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years_from].present?) %>">
                 <label class="govuk-label" for="course_course_age_range_in_years_other_from">From</label>
-                <%= form.text_field 'course_age_range_in_years_other_from',
-                    value: course.other_age_range? ? course.age_range_in_years.split('_').first : '',
+                <%= form.number_field 'course_age_range_in_years_other_from',
+                    min: 0,
+                    max: 46,
+                    value: (course.other_age_range? && course.age_range_in_years.present?) ? course.age_range_in_years.split('_').first : '',
                     class: 'govuk-input govuk-input--width-2' %>
               </div>
-              <div class="govuk-form-group ">
+              <%= render "shared/error_messages", field: :age_range_in_years_to if @errors %>
+              <div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years_to].present?) %>">
                 <label class="govuk-label" for="course_course_age_range_in_years_other_to">To</label>
-                <%= form.text_field 'course_age_range_in_years_other_to',
-                    value: course.other_age_range? ? course.age_range_in_years.split('_').last : '',
+                <%= form.number_field 'course_age_range_in_years_other_to',
+                    min: 4,
+                    max: 50,
+                    value: (course.other_age_range? && course.age_range_in_years.present?) ? course.age_range_in_years.split('_').last : '',
                     class: 'govuk-input govuk-input--width-2' %>
               </div>
             </div>


### PR DESCRIPTION
### Context
Course age range

### Changes proposed in this pull request
- Ensure `age_range_in_years` is present when splitting 
- Add validations for "other"

### Guidance to review
- Try and save the age range without choosing an option
