### PR TITLE
[1799] Fix <wbr> in IE9

### DIFF
--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -109,3 +109,9 @@ $button-colour: #00823b;
     }
   }
 }
+
+// Fixes <wbr> in IE9
+// https://stackoverflow.com/a/23759279
+wbr:after {
+  content: "\00200B";
+}


### PR DESCRIPTION
### Context

`mailto` links look a bit wonky in IE.

### Changes proposed in this pull request

The `<wbr>` tag does not seem to work in some versions of IE. This adds some CSS to patch it up. Copy and pasting still works as expected.

### Guidance to review

Repro of the fix is deployed at https://ie9-wbr-fix.tvararu.now.sh.

| Before | After |
|--------|-------|
| ![Screenshot 2019-08-02 at 15 39 23](https://user-images.githubusercontent.com/1650875/62378208-372ef400-b53c-11e9-97a5-8b74200707b4.png) | ![Screenshot 2019-08-02 at 15 39 38](https://user-images.githubusercontent.com/1650875/62378209-372ef400-b53c-11e9-9ab7-a3c1fc133a13.png) |