### PR TITLE
updated base_url in config/settings/qa.yml

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -2,13 +2,13 @@ dfe_signin:
   issuer: https://signin-test-oidc-as.azurewebsites.net
   profile: https://signin-test-pfl-as.azurewebsites.net
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
-  base_url: https://bat-qa-mcfe-as.azurewebsites.net
+  base_url: https://www2.qa.publish-teacher-training-courses.service.gov.uk
 manage_backend:
-  base_url: https://bat-qa-mcbe-as.azurewebsites.net
+  base_url: https://api2.qa.publish-teacher-training-courses.service.gov.uk
 manage_ui:
-  base_url: https://bat-qa-mcui-as.azurewebsites.net
+  base_url: https://www.qa.publish-teacher-training-courses.service.gov.uk
 search_ui:
-  base_url: https://bat-qa-sacui-as.azurewebsites.net
+  base_url: https://www.qa.find-poqaraduate-teacher-training.service.gov.uk
 environment:
   label: "QA"
   selector_name: "qa"

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -8,7 +8,7 @@ manage_backend:
 manage_ui:
   base_url: https://www.qa.publish-teacher-training-courses.service.gov.uk
 search_ui:
-  base_url: https://www.qa.find-poqaraduate-teacher-training.service.gov.uk
+  base_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk
 environment:
   label: "QA"
   selector_name: "qa"


### PR DESCRIPTION
### Context
Update qa environment to use non-Azure domains

### Changes proposed in this pull request
Change base_url value in qa.yml file from default azure web app .azurewebsites.net urls to service domains

### Guidance to review
base_url updated in qa.yml file only. New staging service domain urls are as follows:
mcapi: https://api.qa.publish-teacher-training-courses.service.gov.uk
mcbe: https://api2.qa.publish-teacher-training-courses.service.gov.uk
mcfe: https://www2.qa.publish-teacher-training-courses.service.gov.uk
mcspt: https://support.qa.publish-teacher-training-courses.service.gov.uk
mcui: https://www.qa.publish-teacher-training-courses.service.gov.uk
sacapi: https://api.qa.find-postgraduate-teacher-training.service.gov.uk
sacui: https://www.qa.find-postgraduate-teacher-training.service.gov.uk