### PR TITLE
[1868] show all contact errors on provider editing

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,12 +28,15 @@ module ApplicationHelper
                 href: href
   end
 
-  def enrichment_summary_label(model, key, field)
-    if @errors&.key? field
+  def enrichment_summary_label(model, key, fields)
+    if fields.select { |field| @errors&.key? field }.any?
+      errors = fields.map { |field|
+        @errors[field]&.map { |error| enrichment_error_link(model, field, error) }
+      }.flatten
       content_tag :dt, class: 'govuk-summary-list__key app-course-parts__fields__label--error' do
         [
           content_tag(:span, key),
-          *@errors[field].map { |error| enrichment_error_link(model, field, error) }
+          *errors
         ].reduce(:+)
       end
     else
@@ -41,7 +44,7 @@ module ApplicationHelper
     end
   end
 
-  def enrichment_summary_value(value, field)
+  def enrichment_summary_value(value, fields)
     css_class = 'govuk-summary-list__value govuk-summary-list__value--truncate'
 
     if value.blank?
@@ -49,12 +52,13 @@ module ApplicationHelper
       css_class += ' app-course-parts__fields__value--empty'
     end
 
-    content_tag :dd, value, class: css_class, data: { qa: "enrichment__#{field}" }
+    data_qa = "enrichment__#{fields.first}"
+    content_tag :dd, value, class: css_class, data: { qa: data_qa }
   end
 
-  def enrichment_summary_item(model, key, value, field)
+  def enrichment_summary_item(model, key, value, fields)
     content_tag :div, class: 'govuk-summary-list__row' do
-      enrichment_summary_label(model, key, field) + enrichment_summary_value(value, field)
+      enrichment_summary_label(model, key, fields) + enrichment_summary_value(value, fields)
     end
   end
 end

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -16,9 +16,9 @@
   <%= link_to 'About this course', about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link' %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
-  <%= enrichment_summary_item(:course,  'About this course', course.about_course, 'about_course') %>
-  <%= enrichment_summary_item(:course,  'Interview process (optional)', course.interview_process, 'interview_process') %>
-  <%= enrichment_summary_item(:course,  'How school placements work', course.how_school_placements_work, 'how_school_placements_work') %>
+  <%= enrichment_summary_item(:course,  'About this course', course.about_course, ['about_course']) %>
+  <%= enrichment_summary_item(:course,  'Interview process (optional)', course.interview_process, ['interview_process']) %>
+  <%= enrichment_summary_item(:course,  'How school placements work', course.how_school_placements_work, ['how_school_placements_work']) %>
 </dl>
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">
@@ -29,15 +29,15 @@
   <% end %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
-  <%= enrichment_summary_item(:course,  'Course length', course.length, 'course_length') %>
+  <%= enrichment_summary_item(:course,  'Course length', course.length, ['course_length']) %>
 
   <% if course.has_fees? %>
-    <%= enrichment_summary_item(:course,  'Fee for UK and EU students', number_to_currency(course.fee_uk_eu), 'fee_uk_eu') %>
-    <%= enrichment_summary_item(:course,  'Fee for international students (optional)', number_to_currency(course.fee_international), 'international_fees') %>
-    <%= enrichment_summary_item(:course,  'Fee details (optional)', course.fee_details, 'fee_details') %>
-    <%= enrichment_summary_item(:course,  'Financial support you offer (optional)', course.financial_support, 'financial_support') %>
+    <%= enrichment_summary_item(:course,  'Fee for UK and EU students', number_to_currency(course.fee_uk_eu), ['fee_uk_eu']) %>
+    <%= enrichment_summary_item(:course,  'Fee for international students (optional)', number_to_currency(course.fee_international), ['international_fees']) %>
+    <%= enrichment_summary_item(:course,  'Fee details (optional)', course.fee_details, ['fee_details']) %>
+    <%= enrichment_summary_item(:course,  'Financial support you offer (optional)', course.financial_support, ['financial_support']) %>
   <% else %>
-    <%= enrichment_summary_item(:course,  'Salary', course.salary_details, 'salary_details') %>
+    <%= enrichment_summary_item(:course,  'Salary', course.salary_details, ['salary_details']) %>
   <% end %>
 </dl>
 
@@ -45,7 +45,7 @@
   <%= link_to 'Requirements and eligibility', requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link' %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
-  <%= enrichment_summary_item(:course,  'Qualifications needed', course.required_qualifications, 'qualifications') %>
-  <%= enrichment_summary_item(:course,  'Personal qualities (optional)', course.personal_qualities, 'personal_qualities') %>
-  <%= enrichment_summary_item(:course,  'Other requirements (optional)', course.other_requirements, 'other_requirements') %>
+  <%= enrichment_summary_item(:course,  'Qualifications needed', course.required_qualifications, ['qualifications']) %>
+  <%= enrichment_summary_item(:course,  'Personal qualities (optional)', course.personal_qualities, ['personal_qualities']) %>
+  <%= enrichment_summary_item(:course,  'Other requirements (optional)', course.other_requirements, ['other_requirements']) %>
 </dl>

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -43,10 +43,10 @@
         <%= govuk_link_to "Contact details", contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
       </h3>
       <dl class="govuk-summary-list">
-        <%= enrichment_summary_item(:provider, 'Email address', @provider.email, 'email') %>
-        <%= enrichment_summary_item(:provider, 'Telephone number', @provider.telephone, 'telephone') %>
-        <%= enrichment_summary_item(:provider, 'Website', @provider.website, 'website') %>
-        <%= enrichment_summary_item(:provider, 'Contact address', @provider.full_address, 'address') %>
+        <%= enrichment_summary_item(:provider, 'Email address', @provider.email, ['email']) %>
+        <%= enrichment_summary_item(:provider, 'Telephone number', @provider.telephone, ['telephone']) %>
+        <%= enrichment_summary_item(:provider, 'Website', @provider.website, ['website']) %>
+        <%= enrichment_summary_item(:provider, 'Contact address', @provider.full_address, ['address1', 'address2', 'address3', 'address4', 'postcode']) %>
       </dl>
     </div>
 
@@ -55,11 +55,11 @@
         <%= govuk_link_to "About your organisation", about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
       </h3>
       <dl class="govuk-summary-list">
-        <%= enrichment_summary_item(:provider, 'About your organisation', @provider.train_with_us, 'train_with_us') %>
-        <%= enrichment_summary_item(:provider, 'Training with disabilities and other needs', @provider.train_with_disability, 'train_with_disability') %>
+        <%= enrichment_summary_item(:provider, 'About your organisation', @provider.train_with_us, ['train_with_us']) %>
+        <%= enrichment_summary_item(:provider, 'Training with disabilities and other needs', @provider.train_with_disability, ['train_with_disability']) %>
         <% if @provider.accredited_bodies.present? %>
           <% @provider.accredited_bodies.each do |provider| %>
-            <%= enrichment_summary_item(:provider, "#{provider['provider_name']} (optional)", provider['description'], "accrediting_provider_#{provider['provider_code']}") %>
+            <%= enrichment_summary_item(:provider, "#{provider['provider_name']} (optional)", provider['description'], ["accrediting_provider_#{provider['provider_code']}"]) %>
           <% end %>
         <% end %>
       </dl>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'View helpers', type: :helper do
 
   describe "#enrichment_summary_label" do
     it "returns correct content" do
-      expect(helper.enrichment_summary_label(:course, 'About course', "about_course")).to eq('<dt class="govuk-summary-list__key">About course</dt>')
+      expect(helper.enrichment_summary_label(:course, 'About course', %w[about_course])).to eq('<dt class="govuk-summary-list__key">About course</dt>')
     end
 
     context "with errors" do
@@ -26,26 +26,26 @@ RSpec.feature 'View helpers', type: :helper do
       end
 
       it "returns correct content" do
-        expect(helper.enrichment_summary_label(:course, 'About course', :about_course)).to eq("<dt class=\"govuk-summary-list__key app-course-parts__fields__label--error\"><span>About course</span><a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#about_course_wrapper\">Something about the course</a></dt>")
+        expect(helper.enrichment_summary_label(:course, 'About course', [:about_course])).to eq("<dt class=\"govuk-summary-list__key app-course-parts__fields__label--error\"><span>About course</span><a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#about_course_wrapper\">Something about the course</a></dt>")
       end
     end
   end
 
   describe "#enrichment_summary_value" do
     it "returns the value" do
-      expect(helper.enrichment_summary_value('Something about the course', 'about'))
+      expect(helper.enrichment_summary_value('Something about the course', %w[about]))
         .to eq('<dd class="govuk-summary-list__value govuk-summary-list__value--truncate" data-qa="enrichment__about">Something about the course</dd>')
     end
 
     it "returns 'empty' when value is empty" do
-      expect(helper.enrichment_summary_value('', 'about'))
+      expect(helper.enrichment_summary_value('', %w[about]))
         .to eq('<dd class="govuk-summary-list__value govuk-summary-list__value--truncate app-course-parts__fields__value--empty" data-qa="enrichment__about">Empty</dd>')
     end
   end
 
   describe "#enrichment_summary_item" do
     it "returns correct content" do
-      expect(helper.enrichment_summary_item(:course, 'About course', 'Something about the course', 'about'))
+      expect(helper.enrichment_summary_item(:course, 'About course', 'Something about the course', %w[about]))
         .to eq('<div class="govuk-summary-list__row"><dt class="govuk-summary-list__key">About course</dt><dd class="govuk-summary-list__value govuk-summary-list__value--truncate" data-qa="enrichment__about">Something about the course</dd></div>')
     end
   end


### PR DESCRIPTION
### Context

Display all contact address errors.

### Changes proposed in this pull request

- `"field"` to `"fields"` 
- `fields` is now an array rather than a single string
