### PR TITLE
[1807] Bugfix - hide published-on if never published

### DIFF
--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -71,7 +71,9 @@
       <div class="govuk-!-margin-bottom-6" data-qa="provider__content-status">
         <%= provider.status_tag %>
       </div>
-      <p class="govuk-body">Last published on <%= l(@provider&.last_published_at.to_date) %></p>
+      <% if @provider&.last_published_at %>
+        <p class="govuk-body">Last published on <%= l(@provider&.last_published_at.to_date) %></p>
+      <% end %>
 
       <h2 class="govuk-heading-m">View on a course</h2>
       <p class="govuk-body">This information will show on all your courses.</p>

--- a/spec/features/providers/details_spec.rb
+++ b/spec/features/providers/details_spec.rb
@@ -2,22 +2,57 @@ require 'rails_helper'
 
 feature 'View provider', type: :feature do
   let(:org_detail_page) { PageObjects::Page::Organisations::OrganisationDetails.new }
-  let(:provider) do
-    build :provider,
-          provider_code: 'A0',
-          content_status: 'published'
-  end
 
-  scenario 'viewing organisation details page' do
+  before do
     allow(Settings).to receive(:rollover).and_return(false)
     stub_omniauth
+  end
+
+  context "with empty provider details" do
+    let(:provider) do
+      build :provider,
+            provider_code: 'A0',
+            content_status: 'empty',
+            last_published_at: nil
+    end
+
+    it 'renders correctly' do
+      test_details_page 'Empty'
+    end
+  end
+
+  context "with draft provider details" do
+    let(:provider) do
+      build :provider,
+            provider_code: 'A0',
+            content_status: 'draft'
+    end
+
+    it 'renders correctly' do
+      test_details_page 'Draft'
+    end
+  end
+
+  context "with published provider details" do
+    let(:provider) do
+      build :provider,
+            provider_code: 'A0',
+            content_status: 'published'
+    end
+
+    it 'renders correctly' do
+      test_details_page 'Published'
+    end
+  end
+
+  def test_details_page(expected_status)
     stub_api_v2_request(
       "/recruitment_cycles/#{provider.recruitment_cycle.year}",
       provider.recruitment_cycle.to_jsonapi
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{provider.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}",
+        "/providers/#{provider.provider_code}",
       provider.to_jsonapi
     )
 
@@ -42,6 +77,6 @@ feature 'View provider', type: :feature do
     expect(org_detail_page.train_with_disability).to have_content(provider.train_with_disability)
 
     expect(org_detail_page).to have_status_panel
-    expect(org_detail_page.content_status).to have_content('Published')
+    expect(org_detail_page.content_status).to have_content(expected_status)
   end
 end


### PR DESCRIPTION

### Context

Was falling over with a nil error for new records.

(replaces #508 which had a typo in the branch name)

### Changes proposed in this pull request

Handle providers with no published enrichment

Without the patch the updated test now fails

```
$ be rspec spec/features/providers/details_spec.rb -fd
2019-08-08 16:11:34 WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrom
e::Service#driver_path= instead.
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

View provider
  with empty provider details
    renders correctly (FAILED - 1)
  with draft provider details
Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead.
    renders correctly
  with published provider details
Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead.
    renders correctly
```
### Guidance to review

:eye: 