### PR TITLE
updated dfe sign-in details in config/settings/new_staging.yml file

### DIFF
--- a/config/settings/new_prod.yml
+++ b/config/settings/new_prod.yml
@@ -1,7 +1,7 @@
 dfe_signin:
-  issuer: https://signin-test-oidc-as.azurewebsites.net
-  profile: https://signin-test-pfl-as.azurewebsites.net
+  issuer: https://oidc.signin.education.gov.uk
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
+  profile: https://profile.signin.education.gov.uk
   base_url: https://bat-prod-mcfe-as.azurewebsites.net
 manage_backend:
   base_url: https://bat-prod-mcbe-as.azurewebsites.net

--- a/config/settings/new_staging.yml
+++ b/config/settings/new_staging.yml
@@ -1,6 +1,6 @@
 dfe_signin:
-  issuer: https://signin-test-oidc-as.azurewebsites.net
-  profile: https://signin-test-pfl-as.azurewebsites.net
+  issuer: https://pp-oidc.signin.education.gov.uk
+  profile: https://pp-profile.signin.education.gov.uk
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   base_url: https://www2.staging.publish-teacher-training-courses.service.gov.uk
 manage_backend:


### PR DESCRIPTION
### Context
DfE signin services have multiple env i.e. test, pre-prod and prod. To replicate our development workflow with DfE signin environments, our dev and qa is already pointing to DfE's test env. This change ensures that BAT's new prod and staging is pointing to DfE's prod and pre-prod respectively.   

### Changes proposed in this pull request
Update DfE's signin issuer and profile urls to respective environments in yaml files 

