### PR TITLE
[1961] Remove `#manage_ui_url` method

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -7,10 +7,6 @@ module ViewHelper
     govuk_link_to('Back', url, class: "govuk-back-link")
   end
 
-  def manage_ui_url(relative_path)
-    URI.join(Settings.manage_ui.base_url, relative_path).to_s
-  end
-
   def search_ui_url(relative_path)
     URI.join(Settings.search_ui.base_url, relative_path).to_s
   end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -13,12 +13,6 @@ RSpec.feature 'View helpers', type: :helper do
     end
   end
 
-  describe "#manage_ui_url" do
-    it "returns full Manage Courses UI URL to the passed path" do
-      expect(helper.manage_ui_url('/organisations/A0')).to eq("https://localhost:44364/organisations/A0")
-    end
-  end
-
   describe "#enrichment_error_url" do
     it "returns enrichment error URL" do
       course = Course.new(build(:course).attributes)


### PR DESCRIPTION
### Context

`#manage_ui_url` is not being used. Remove dead code.

### Changes proposed in this pull request

Delete dead code

### Guidance to review

Double check it is not being used.
