### PR TITLE
[1925] Update content for applications open

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -126,9 +126,14 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def applications_open_from_message_for(recruitment_cycle)
-    year = recruitment_cycle.year.to_i
-    day_month = Date.parse(recruitment_cycle.application_start_date).strftime('%-d %B')
-    "On #{day_month} when applications for the #{year - 1} – #{year} cycle open"
+    is_current_recruitment_cycle = object.recruitment_cycle_year == recruitment_cycle.year
+    if is_current_recruitment_cycle
+      "As soon as the course is on Find (recommended)"
+    else
+      year = recruitment_cycle.year.to_i
+      day_month = Date.parse(recruitment_cycle.application_start_date).strftime('%-d %B')
+      "On #{day_month} when applications for the #{year - 1} – #{year} cycle open"
+    end
   end
 
 private

--- a/spec/features/courses/applications_open/edit_spec.rb
+++ b/spec/features/courses/applications_open/edit_spec.rb
@@ -28,7 +28,8 @@ feature 'Edit course applications open', type: :feature do
       build(
         :course,
         applications_open_from: '2018-10-09',
-        provider: provider
+        provider: provider,
+        recruitment_cycle: current_recruitment_cycle
       )
     end
 
@@ -86,6 +87,24 @@ feature 'Edit course applications open', type: :feature do
       expect(course_details_page.flash).to have_content('Your changes have been saved')
       expect(update_course_stub).to have_been_requested
     end
+
+    context 'for the current recruitment cycle' do
+      scenario 'has the correct content' do
+        expect(applications_open_page).to(
+          have_content("As soon as the course is on Find")
+        )
+      end
+    end
+
+    context 'for the next recruitment cycle' do
+      let(:current_recruitment_cycle) { build(:recruitment_cycle, :next_cycle) }
+
+      scenario 'has the correct content' do
+        expect(applications_open_page).to(
+          have_content("As soon as the course is on Find")
+        )
+      end
+    end
   end
 
   context 'a course with an applications open from value of 2018-12-12' do
@@ -93,9 +112,6 @@ feature 'Edit course applications open', type: :feature do
       build(
         :course,
         applications_open_from: '2018-12-12',
-        edit_options: {
-          applications_open_from: %w[2018-10-09 other]
-        },
         provider: provider
       )
     end


### PR DESCRIPTION
### Context

The design is slightly different when the course is part of the current cycle.

### Changes proposed in this pull request

![Screenshot 2019-08-14 at 15 49 51](https://user-images.githubusercontent.com/1650875/63031048-494d5280-beab-11e9-9431-fab53bd6fd2f.png)
