### PR TITLE
[1925] Temporarily disable link to edit applications from

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -145,9 +145,9 @@
           <%= l(course.applications_open_from&.to_date) %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to applications_open_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_start_date_link" } do %>
+          <!-- <%= link_to applications_open_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_start_date_link" } do %>
             Change<span class="govuk-visually-hidden"> applications open date</span>
-          <% end %>
+          <% end %> -->
         </dd>
       </div>
 

--- a/spec/features/courses/applications_open/edit_spec.rb
+++ b/spec/features/courses/applications_open/edit_spec.rb
@@ -38,7 +38,7 @@ feature 'Edit course applications open', type: :feature do
       expect(course_details_page).to be_displayed
     end
 
-    scenario 'can navigate to the edit screen and back again' do
+    xscenario 'can navigate to the edit screen and back again' do
       course_details_page.load_with_course(course)
       click_on 'Change applications open date'
       expect(applications_open_page).to be_displayed


### PR DESCRIPTION
### Context

There's bugs with this feature so if it's in master, we can't ship frontend.

### Changes proposed in this pull request

Hide the link.

This will allow us to ship while we iron out any remaining bugs.

### Guidance to review

:ship: