### PR TITLE
[1854] Move about your org link to recruitment cycle page

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -40,6 +40,11 @@ module BreadcrumbHelper
     recruitment_cycle_breadcrumb << ["Locations", path]
   end
 
+  def organisation_details_breadcrumb
+    path = details_provider_recruitment_cycle_path(@provider.provider_code, @recruitment_cycle.year)
+    recruitment_cycle_breadcrumb << ["About your organisation", path]
+  end
+
   def edit_site_breadcrumb
     path = edit_provider_recruitment_cycle_site_path(@provider.provider_code, @site.recruitment_cycle_year, @site.id)
     sites_breadcrumb << [@site_name_before_update, path]

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -1,7 +1,5 @@
 <%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}About your organisation" %>
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_path(@provider.provider_code)) %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:organisation_details) %>
 
 <% if @errors.present? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary" data-ga-event-form="error">

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -33,14 +33,6 @@
       </ul>
     <% end %>
 
-    <h2 class="govuk-heading-m"><%= govuk_link_to "About your organisation", details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %></h2>
-    <p class="govuk-body">Use this section to:</p>
-    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
-      <li>write about your organisation</li>
-      <li>set your contact details</li>
-      <li>publish this information on all course pages</li>
-    </ul>
-
     <% unless @provider.rolled_over? %>
       <%= render partial: 'recruitment_cycles/courses_info', locals: { provider: @provider, year: '2019' } %>
       <%= render partial: 'recruitment_cycles/locations_info', locals: { provider: @provider, year: '2019' } %>

--- a/app/views/recruitment_cycles/_about_organisation.html.erb
+++ b/app/views/recruitment_cycles/_about_organisation.html.erb
@@ -1,0 +1,8 @@
+<h2 class="govuk-heading-m"><%= govuk_link_to "About your organisation", details_provider_recruitment_cycle_path(provider.provider_code, year) %></h2>
+<p class="govuk-body">Use this section to:</p>
+<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
+  <li>write about your organisation</li>
+  <li>set your contact details</li>
+  <li>publish this information on all course pages</li>
+</ul>
+

--- a/app/views/recruitment_cycles/show.html.erb
+++ b/app/views/recruitment_cycles/show.html.erb
@@ -18,6 +18,7 @@
     <% end %>
     <hr class="govuk-section-break govuk-section-break--m">
 
+    <%= render partial: 'recruitment_cycles/about_organisation', locals: { provider: @provider, year: params[:year] } %>
     <%= render partial: 'recruitment_cycles/courses_info', locals: { provider: @provider, year: params[:year] } %>
     <%= render partial: 'recruitment_cycles/locations_info', locals: { provider: @provider, year: params[:year] } %>
   </div>

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     train_with_us { Faker::Lorem.sentence(word_count: 100) }
     accredited_bodies { [] }
     train_with_disability { Faker::Lorem.sentence(word_count: 100) }
-    website { nil }
+    website { 'https://cat.me' }
     email { 'info@acme-scitt.org' }
     telephone { '020 8123 4567' }
     address1 { nil }

--- a/spec/features/providers/details_spec.rb
+++ b/spec/features/providers/details_spec.rb
@@ -4,7 +4,6 @@ feature 'View provider', type: :feature do
   let(:org_detail_page) { PageObjects::Page::Organisations::OrganisationDetails.new }
 
   before do
-    allow(Settings).to receive(:rollover).and_return(false)
     stub_omniauth
   end
 
@@ -58,6 +57,8 @@ feature 'View provider', type: :feature do
 
     visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
 
+    expect_breadcrumbs_to_be_correct
+
     expect(current_path).to eq details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
 
     expect(org_detail_page).to have_link(
@@ -78,5 +79,15 @@ feature 'View provider', type: :feature do
 
     expect(org_detail_page).to have_status_panel
     expect(org_detail_page.content_status).to have_content(expected_status)
+  end
+
+  def expect_breadcrumbs_to_be_correct
+    breadcrumbs = org_detail_page.breadcrumbs
+
+    expect(breadcrumbs[0].text).to eq(provider.provider_name)
+    expect(breadcrumbs[0]["href"]).to eq("/organisations/#{provider.provider_code}")
+
+    expect(breadcrumbs[1].text).to eq(provider.recruitment_cycle.title)
+    expect(breadcrumbs[1]["href"]).to eq("/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}")
   end
 end

--- a/spec/features/recruitment_cyles/show_spec.rb
+++ b/spec/features/recruitment_cyles/show_spec.rb
@@ -31,6 +31,7 @@ feature 'Recruitment cycles', type: :feature do
         expect(recruitment_cycle_page.title).to have_content('Current cycle')
         expect(recruitment_cycle_page).to have_link('Locations', href: "/organisations/#{provider.provider_code}/#{year}/locations")
         expect(recruitment_cycle_page).to have_link('Courses',   href: "/organisations/#{provider.provider_code}/#{year}/courses")
+        expect(recruitment_cycle_page).to have_link('About your organisation', href: "/organisations/#{provider.provider_code}/#{year}/details")
       end
     end
 
@@ -45,6 +46,7 @@ feature 'Recruitment cycles', type: :feature do
         expect(recruitment_cycle_page.title).to have_content('Next cycle')
         expect(recruitment_cycle_page).to have_link('Locations', href: "/organisations/#{provider.provider_code}/#{year}/locations")
         expect(recruitment_cycle_page).to have_link('Courses',   href: "/organisations/#{provider.provider_code}/#{year}/courses")
+        expect(recruitment_cycle_page).to have_link('About your organisation', href: "/organisations/#{provider.provider_code}/#{year}/details")
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/organisation_details.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_details.rb
@@ -15,6 +15,7 @@ module PageObjects
         element :status_panel, '[data-qa=provider__status_panel]'
         element :content_status, '[data-qa=provider__content-status]'
         element :flash, '.govuk-success-summary'
+        elements :breadcrumbs, '.govuk-breadcrumbs__link'
       end
     end
   end


### PR DESCRIPTION
### Context
Move "About your Organisation" link into the "Current Cycle" or "Next Cycle" page for organisations so that providers can edit the content or information about their organisation in advance of the next cycle without affecting the content or information presented on the current cycle.

### Changes proposed in this pull request

- Move "About your organisation" link to recruitment cycle pages
- Add new breadcrumb helper for organisation details page
- Replace `back` link with breadcrumbs
- Fixes "may be confusing" error for details spec

### Guidance to review
