### PR TITLE
[1925] Update logic for applications open for next cycle

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -126,13 +126,13 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def applications_open_from_message_for(recruitment_cycle)
-    is_current_recruitment_cycle = object.recruitment_cycle_year == recruitment_cycle.year
+    is_current_recruitment_cycle = recruitment_cycle.year == Settings.current_cycle.to_s
     if is_current_recruitment_cycle
       "As soon as the course is on Find (recommended)"
     else
       year = recruitment_cycle.year.to_i
       day_month = Date.parse(recruitment_cycle.application_start_date).strftime('%-d %B')
-      "On #{day_month} when applications for the #{year - 1} – #{year} cycle open"
+      "On #{day_month} when applications for the #{year} – #{year + 1} cycle open"
     end
   end
 

--- a/spec/features/courses/applications_open/edit_spec.rb
+++ b/spec/features/courses/applications_open/edit_spec.rb
@@ -101,7 +101,7 @@ feature 'Edit course applications open', type: :feature do
 
       scenario 'has the correct content' do
         expect(applications_open_page).to(
-          have_content("As soon as the course is on Find")
+          have_content("when applications for the #{current_recruitment_cycle.year}")
         )
       end
     end


### PR DESCRIPTION
### Context

Editing applications open.

### Changes proposed in this pull request

The logic was flawed; we should be comparing against the known current
cycle instead of the one being passed in. Updated the test as well.

### Guidance to review

#### Current cycle

![Screenshot 2019-08-16 at 15 19 33](https://user-images.githubusercontent.com/1650875/63174181-5a2bce80-c039-11e9-85dc-303b27df2d44.png)

#### Next cycle

![Screenshot 2019-08-16 at 15 19 38](https://user-images.githubusercontent.com/1650875/63174182-5ac46500-c039-11e9-955d-aa5d22bedd5c.png)