### PR TITLE
[1938] add new page for course outcomes

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -1,4 +1,4 @@
-module EditBasicDetail
+module CourseBasicDetailConcern
   extend ActiveSupport::Concern
 
   included do

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -8,17 +8,10 @@ module CourseBasicDetailConcern
   end
 
   def new
-    # Using .find(:new) here is a little bit hacky, but this is the only way I
-    # could find to construct the URL with `.../courses/new` at the end, and at
-    # the end of the day jsonapi defines ids as being strings so it's in no way
-    # invalid. If we can find a way to use custom enpoints or other to improve
-    # this we should.
-    @course = Course
-                .where(recruitment_cycle_year: params[:recruitment_cycle_year],
-                       provider_code: params[:provider_code])
-                .find(:new)
-                .first
-    nil
+    @course = Course.fetch_new(
+      recruitment_cycle_year: @provider.recruitment_cycle_year,
+      provider_code: @provider.provider_code
+    )
   end
 
   def edit; end

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -3,7 +3,22 @@ module CourseBasicDetailConcern
 
   included do
     decorates_assigned :course
-    before_action :build_course
+    before_action :build_provider, only: :new
+    before_action :build_course, only: %i[edit update]
+  end
+
+  def new
+    # Using .find(:new) here is a little bit hacky, but this is the only way I
+    # could find to construct the URL with `.../courses/new` at the end, and at
+    # the end of the day jsonapi defines ids as being strings so it's in no way
+    # invalid. If we can find a way to use custom enpoints or other to improve
+    # this we should.
+    @course = Course
+                .where(recruitment_cycle_year: params[:recruitment_cycle_year],
+                       provider_code: params[:provider_code])
+                .find(:new)
+                .first
+    nil
   end
 
   def edit; end
@@ -28,6 +43,13 @@ module CourseBasicDetailConcern
   end
 
 private
+
+  def build_provider
+    @provider = Provider
+                  .where(recruitment_cycle_year: params[:recruitment_cycle_year])
+                  .find(params[:provider_code])
+                  .first
+  end
 
   def build_course
     @course = Course

--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -1,7 +1,7 @@
 module Courses
   class ApplicationsOpenController < ApplicationController
     before_action :build_recruitment_cycle
-    include EditBasicDetail
+    include CourseBasicDetailConcern
 
   private
 

--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -1,6 +1,6 @@
 module Courses
   class EntryRequirementsController < ApplicationController
-    include EditBasicDetail
+    include CourseBasicDetailConcern
     before_action :not_found_if_no_gcse_subjects_required
 
   private

--- a/app/controllers/courses/outcome_controller.rb
+++ b/app/controllers/courses/outcome_controller.rb
@@ -1,6 +1,6 @@
 module Courses
   class OutcomeController < ApplicationController
-    include EditBasicDetail
+    include CourseBasicDetailConcern
 
   private
 

--- a/app/controllers/courses/send_controller.rb
+++ b/app/controllers/courses/send_controller.rb
@@ -1,6 +1,6 @@
 module Courses
   class SendController < ApplicationController
-    include EditBasicDetail
+    include CourseBasicDetailConcern
 
   private
 

--- a/app/controllers/courses/start_date_controller.rb
+++ b/app/controllers/courses/start_date_controller.rb
@@ -1,6 +1,6 @@
 module Courses
   class StartDateController < ApplicationController
-    include EditBasicDetail
+    include CourseBasicDetailConcern
 
   private
 

--- a/app/controllers/courses/study_mode_controller.rb
+++ b/app/controllers/courses/study_mode_controller.rb
@@ -1,6 +1,6 @@
 module Courses
   class StudyModeController < ApplicationController
-    include EditBasicDetail
+    include CourseBasicDetailConcern
 
     def update
       if params[:course][:study_mode] == 'full_time_or_part_time'

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -11,6 +11,19 @@ class Course < Base
 
   self.primary_key = :course_code
 
+  # Fetch a "new" record from the backend API.
+  def self.fetch_new(recruitment_cycle_year:, provider_code:)
+    # Using .find(:new) here is a little bit hacky, but this is the only way I
+    # could find to construct the URL with `.../courses/new` at the end, and at
+    # the end of the day jsonapi defines ids as being strings so it's in no way
+    # invalid. If we can find a way to use custom endpoints or other to improve
+    # this we should.
+    Course.where(recruitment_cycle_year: recruitment_cycle_year,
+                 provider_code: provider_code)
+      .find(:new)
+      .first
+  end
+
   def publish
     post_request('/publish')
   end

--- a/app/views/courses/outcome/_form.html.erb
+++ b/app/views/courses/outcome/_form.html.erb
@@ -1,0 +1,14 @@
+<% legend = capture do %>
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <h1 class="govuk-fieldset__heading">
+            <%= course_name_and_code %>
+            Pick a course outcome
+        </h1>
+    </legend>
+<% end %>
+
+<%= render "shared/edit_options_radio_buttons",
+           form: form,
+           legend: legend,
+           key: 'qualifications',
+           field: :qualification %>

--- a/app/views/courses/outcome/edit.html.erb
+++ b/app/views/courses/outcome/edit.html.erb
@@ -6,28 +6,19 @@
 <%= render 'shared/errors' %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
-          url: outcome_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
-          method: :put do |form| %>
+    <div class="govuk-grid-column-two-thirds">
+        <%= form_with model: course,
+            url: outcome_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+            method: :put do |form| %>
 
-      <% legend = capture do %>
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= course.name_and_code %></span>
-            Pick a course outcome
-          </h1>
-        </legend>
-      <% end %>
+        <% course_name_and_code = capture do %>
+          <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+        <% end %>
 
-      <%= render "shared/edit_options_radio_buttons",
-            form: form,
-            legend: legend,
-            key: 'qualifications',
-            field: :qualification %>
+        <%= render 'form', form: form, course_name_and_code: course_name_and_code %>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
-        class: "govuk-button", data: { qa: 'course__save' }
+                      class: "govuk-button", data: { qa: 'course__save' }
       %>
 
       <p class="govuk-body">

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -1,0 +1,32 @@
+<%= content_for :page_title, "Pick a course outcome" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(
+                           @provider.provider_code,
+                           @provider.recruitment_cycle_year
+                        )) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: course,
+                  url: new_provider_recruitment_cycle_courses_outcome_path(
+                    @provider.provider_code,
+                    @provider.recruitment_cycle_year
+                  ),
+                  method: :put do |form| %>
+
+      <%= render 'form', form: form, course_name_and_code: nil %>
+
+      <%= form.submit "Continue",
+                      class: "govuk-button", data: { qa: 'course__save' } %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes',
+                    provider_recruitment_cycle_courses_path(course.provider_code, course.recruitment_cycle_year),
+                    class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -20,13 +20,8 @@
       <%= render 'form', form: form, course_name_and_code: nil %>
 
       <%= form.submit "Continue",
-                      class: "govuk-button", data: { qa: 'course__save' } %>
-
-      <p class="govuk-body">
-        <%= link_to 'Cancel changes',
-                    provider_recruitment_cycle_courses_path(course.provider_code, course.recruitment_cycle_year),
-                    class: "govuk-link govuk-link--no-visited-state" %>
-      </p>
+                      class: "govuk-button",
+                      data: { qa: 'course__save' } %>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,10 @@ Rails.application.routes.draw do
       put '/about', on: :member, to: 'providers#update'
       post '/publish', on: :member, to: 'providers#publish'
 
+      resource :courses, only: [] do
+        resource :outcome, on: :member, only: %i[new], controller: 'courses/outcome'
+      end
+
       resources :courses, param: :code do
         delete '/', on: :member, to: 'courses#destroy'
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -166,6 +166,7 @@ FactoryBot.define do
     end
 
     trait :new do
+      id                     { nil }
       qualification          { nil }
       course_code            { nil }
       name                   { nil }

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -4,7 +4,56 @@ FactoryBot.define do
       sites { [] }
       site_statuses { [] }
       recruitment_cycle { build :recruitment_cycle }
-      edit_options {}
+      edit_options do
+        # Shamelessly copied from backend. Also, will need updating when any of
+        # these change, but having these is essential to making this factory
+        # produce valid and usable objects.
+
+        age_range_in_years = case level
+                             when :primary
+                               %w[
+                               3_to_7
+                               5_to_11
+                               7_to_11
+                               7_to_14
+                             ]
+                             when :secondary
+                               %w[
+                               11_to_16
+                               11_to_18
+                               14_to_19
+                             ]
+                             end
+
+        qualifications = case level
+                         when :further_education
+                           %w[pgce pdge]
+                         else
+                           %w[qts pgce_with_qts pgde_with_qts]
+                         end
+
+        {
+          entry_requirements: %i[
+            must_have_qualification_at_application_time
+            expect_to_achieve_before_training_begins
+            equivalence_test
+          ],
+          qualifications: qualifications,
+          age_range_in_years: age_range_in_years,
+          start_dates: ["August #{recruitment_cycle.year.to_i}",
+                        "September #{recruitment_cycle.year.to_i}",
+                        "October #{recruitment_cycle.year.to_i}",
+                        "November #{recruitment_cycle.year.to_i}",
+                        "December #{recruitment_cycle.year.to_i}",
+                        "January #{recruitment_cycle.year.to_i + 1}",
+                        "February #{recruitment_cycle.year.to_i + 1}",
+                        "March #{recruitment_cycle.year.to_i + 1}",
+                        "April #{recruitment_cycle.year.to_i + 1}",
+                        "May #{recruitment_cycle.year.to_i + 1}",
+                        "June #{recruitment_cycle.year.to_i + 1}",
+                        "July #{recruitment_cycle.year.to_i + 1}"]
+        }
+      end
     end
 
     sequence(:id)
@@ -114,6 +163,29 @@ FactoryBot.define do
       fee_international { 14000 }
       fee_details { Faker::Lorem.sentence(word_count: 100) }
       financial_support { Faker::Lorem.sentence(word_count: 100) }
+    end
+
+    trait :new do
+      qualification          { nil }
+      course_code            { nil }
+      name                   { nil }
+      description            { nil }
+      study_mode             { nil }
+      content_status         { nil }
+      ucas_status            { nil }
+      start_date             { nil }
+      funding                { nil }
+      applications_open_from { nil }
+      level                  { nil }
+      subjects               { nil }
+      last_published_at      { nil }
+      scholarship_amount     { nil }
+      bursary_amount         { nil }
+      maths                  { nil }
+      english                { nil }
+      science                { nil }
+      gcse_subjects_required { nil }
+      age_range_in_years     { nil }
     end
   end
 end

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+feature 'new course outcome', type: :feature do
+  let(:recruitment_cycle) { build(:recruitment_cycle) }
+  let(:new_outcome_page) do
+    PageObjects::Page::Organisations::Courses::NewOutcomePage.new
+  end
+  let(:provider) { build(:provider) }
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(provider)
+    new_course = build(:course, :new, provider: provider)
+    stub_api_v2_new_resource(new_course)
+  end
+
+  scenario 'creating a new course' do
+    # Until we have a .../courses/new endpoint go straight to the outcome
+    visit "/organisations/#{provider.provider_code}/#{recruitment_cycle.year}" \
+          "/courses/outcome/new"
+
+    expect(new_outcome_page).to(
+      be_displayed(
+        recruitment_cycle_year: recruitment_cycle.year,
+        provider_code: provider.provider_code
+      )
+    )
+
+    # The qualifications for a new course that hasn't had it's level set just
+    # happens to result in these qualifications. This will change when the new
+    # course flow properly sets the level of the course.
+    expect(new_outcome_page).to have_qualification_fields
+    expect(new_outcome_page.qualification_fields).to have_qts
+    expect(new_outcome_page.qualification_fields).to have_pgce_with_qts
+    expect(new_outcome_page.qualification_fields).to have_pgde_with_qts
+    new_outcome_page.qualification_fields.qts.click
+  end
+end

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -1,9 +1,11 @@
+# coding: utf-8
+
 require 'rails_helper'
 
 feature 'Edit course vacancies', type: :feature do
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
   let(:course_vacancies_page) { PageObjects::Page::Organisations::CourseVacancies.new }
-  let(:courses_page) { PageObjects::Page::Organisations::Courses.new }
+  let(:courses_page) { PageObjects::Page::Organisations::CoursesPage.new }
   let(:course_code) { 'X104' }
   let(:provider) { build(:provider) }
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe Course do
+  describe '#fetch_new' do
+    let(:provider)          { build :provider }
+    let(:course)            { build :course, :new, provider: provider }
+    let(:recruitment_cycle) { course.recruitment_cycle }
+    let(:new_resource_stub) { stub_api_v2_new_resource(course) }
+
+    before do
+      allow(Thread.current).to receive(:fetch).and_return('token')
+
+      stub_omniauth
+      new_resource_stub
+    end
+
+    let(:fetched_new_course) do
+      Course.fetch_new(
+        recruitment_cycle_year: recruitment_cycle.year,
+        provider_code: provider.provider_code
+      )
+    end
+
+    it 'makes a request to the api' do
+      fetched_new_course
+
+      expect(new_resource_stub).to have_been_requested
+    end
+
+    it 'returns the result' do
+      expect(fetched_new_course.id).to eq nil
+      expect(fetched_new_course.type).to eq 'courses'
+    end
+  end
+end

--- a/spec/requests/courses/outcome/new_spec.rb
+++ b/spec/requests/courses/outcome/new_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe '/organisations/:provider_code/:year/courses/:course_code/outcome/new', type: :request do
+  let(:provider) { build(:provider) }
+  let(:course)   { build(:course, provider: provider) }
+
+  let(:new_outcome_page) do
+    PageObjects::Page::Organisations::Courses::NewOutcomePage.new
+  end
+
+  before do
+    stub_omniauth
+    get(auth_dfe_callback_path)
+
+    stub_api_v2_resource(provider)
+
+    new_course = build(:course, :new, provider: provider)
+    stub_api_v2_new_resource(new_course)
+    stub_api_v2_resource_collection([course])
+  end
+
+  it 'renders the new outcome page' do
+    get(new_provider_recruitment_cycle_courses_outcome_path(
+          provider_code: provider.provider_code,
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+        ))
+
+    expect(response.status).to eq 200
+    expect(response).to render_template('courses/outcome/new')
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_outcome_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_outcome_page.rb
@@ -1,0 +1,18 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class NewOutcomePage < CourseBase
+          set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/outcome/new'
+
+          section :qualification_fields, '[data-qa="course__qualification"]' do
+            element :qts,           '#course_qualification_qts'
+            element :pgce,          '#course_qualification_pgce'
+            element :pgce_with_qts, '#course_qualification_pgce_with_qts'
+            element :pgde_with_qts, '#course_qualification_pgde_with_qts'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses_page.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module Page
     module Organisations
-      class Courses < PageObjects::Base
+      class CoursesPage < PageObjects::Base
         set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses'
 
         element :flash, '.govuk-success-summary'

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -119,7 +119,5 @@ private
 end
 
 RSpec.configure do |config|
-  config.include Helpers, type: :feature
-  config.include Helpers, type: :controller
-  config.include Helpers, type: :request
+  config.include Helpers
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,4 +1,31 @@
 module Helpers
+  def url_for_resource_collection(resource)
+    if resource.is_a? RecruitmentCycle
+      '/recruitment_cycles'
+    elsif resource.is_a? Provider
+      url_for_resource(resource.recruitment_cycle) + '/providers'
+    elsif resource.is_a? Course
+      url_for_resource(resource.provider) + '/courses'
+    end
+  end
+
+  def url_for_resource(resource)
+    base_url = url_for_resource_collection(resource)
+
+    if resource.is_a?(RecruitmentCycle)
+      "#{base_url}/#{resource.year}"
+    elsif resource.is_a?(Provider)
+      "#{base_url}/#{resource.provider_code}"
+    elsif resource.is_a?(Course)
+      "#{base_url}/#{resource.course_code}"
+    end
+  end
+
+  def url_for_new_resource(resource)
+    base_url = url_for_resource_collection(resource)
+    "#{base_url}/new"
+  end
+
   def stub_omniauth(user: nil)
     user ||= build(:user)
 
@@ -50,6 +77,42 @@ module Helpers
     end
 
     stubbed_request
+  end
+
+  def stub_api_v2_resource(resource,
+                           jsonapi_response: nil,
+                           include: nil)
+    query_params = {}
+    query_params[:include] = include if include.present?
+
+    url = url_for_resource(resource)
+    url += "?#{query_params.to_param}" if query_params.any?
+
+    jsonapi_response ||= resource.to_jsonapi(include: include)
+    stub_api_v2_request(url, jsonapi_response)
+  end
+
+  def stub_api_v2_new_resource(resource, jsonapi_response = nil)
+    url = url_for_new_resource(resource)
+
+    jsonapi_response ||= resource.to_jsonapi
+    stub_api_v2_request(url, jsonapi_response)
+  end
+
+  def stub_api_v2_resource_collection(resources, jsonapi_response: nil)
+    url = url_for_resource_collection(resources.first)
+
+    jsonapi_response ||= resource_list_to_jsonapi(resources)
+    stub_api_v2_request(url, jsonapi_response)
+  end
+
+  def stub_api_v2_empty_resource_collection(resource,
+                                            child_resource,
+                                            jsonapi_response: nil)
+    url = url_for_resource(resource) + "/#{child_resource}"
+
+    jsonapi_response ||= resource_list_to_jsonapi([])
+    stub_api_v2_request(url, jsonapi_response)
   end
 end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,31 +1,4 @@
 module Helpers
-  def url_for_resource_collection(resource)
-    if resource.is_a? RecruitmentCycle
-      '/recruitment_cycles'
-    elsif resource.is_a? Provider
-      url_for_resource(resource.recruitment_cycle) + '/providers'
-    elsif resource.is_a? Course
-      url_for_resource(resource.provider) + '/courses'
-    end
-  end
-
-  def url_for_resource(resource)
-    base_url = url_for_resource_collection(resource)
-
-    if resource.is_a?(RecruitmentCycle)
-      "#{base_url}/#{resource.year}"
-    elsif resource.is_a?(Provider)
-      "#{base_url}/#{resource.provider_code}"
-    elsif resource.is_a?(Course)
-      "#{base_url}/#{resource.course_code}"
-    end
-  end
-
-  def url_for_new_resource(resource)
-    base_url = url_for_resource_collection(resource)
-    "#{base_url}/new"
-  end
-
   def stub_omniauth(user: nil)
     user ||= build(:user)
 
@@ -113,6 +86,35 @@ module Helpers
 
     jsonapi_response ||= resource_list_to_jsonapi([])
     stub_api_v2_request(url, jsonapi_response)
+  end
+
+private
+
+  def url_for_resource(resource)
+    base_url = url_for_resource_collection(resource)
+
+    if resource.is_a?(RecruitmentCycle)
+      "#{base_url}/#{resource.year}"
+    elsif resource.is_a?(Provider)
+      "#{base_url}/#{resource.provider_code}"
+    elsif resource.is_a?(Course)
+      "#{base_url}/#{resource.course_code}"
+    end
+  end
+
+  def url_for_resource_collection(resource)
+    if resource.is_a? RecruitmentCycle
+      '/recruitment_cycles'
+    elsif resource.is_a? Provider
+      url_for_resource(resource.recruitment_cycle) + '/providers'
+    elsif resource.is_a? Course
+      url_for_resource(resource.provider) + '/courses'
+    end
+  end
+
+  def url_for_new_resource(resource)
+    base_url = url_for_resource_collection(resource)
+    "#{base_url}/new"
   end
 end
 


### PR DESCRIPTION
### Context

So users can set the outcome on their new course.
- renders same form fields as the edit page
- has a "Continue" button (not wired up yet)

### Changes proposed in this pull request

Add "new" page for course outcomes.

### Guidance to review

This turned into more work than anticipated. I'm willing to put some time in the evenings to address any comments/questions on this PR, but pls keep in mind I'm trying to be on holiday so I'd greatly appreciate pro-active comments and, as always, encourage additional commits to help  get this over the line. :)

Some notes:
- I've cut up the PR into commits that should stand on their own, and that can (hopefully) be reviewed in order as a kind of narrative.
- This change relies on a `.../courses/new` endpoint on backend to return the possible outcomes for a course. This wasn't called out on the ticket and is the bulk of the extra work that ate away into my holiday time this weekend. :P
- The PR DFE-Digital/manage-courses-backend#723 adds the `.../courses/new` endpoint and is necessary for this change to work.
- Editing the outcome for a new course that doesn't have a level set isn't well defined ... it happens get the "with qts" outcomes displayed, but really this journey doesn't work without having the level set.
- The success criteria `any existing course params should be rendered as hidden input fields, to allow for editing of this param from the confirmation page` was ignored. This was already enough work without adding this bit.
