### PR TITLE
Added prod.yml file

### DIFF
--- a/config/settings/prod.yml
+++ b/config/settings/prod.yml
@@ -1,0 +1,14 @@
+dfe_signin:
+  issuer: https://oidc.signin.education.gov.uk
+  secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
+  profile: https://profile.signin.education.gov.uk
+  base_url: https://www2.publish-teacher-training-courses.service.gov.uk
+manage_backend:
+  base_url: https://api2.publish-teacher-training-courses.service.gov.uk
+manage_ui:
+  base_url: https://www.publish-teacher-training-courses.service.gov.uk
+search_ui:
+  base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+environment:
+  label: "Beta"
+  selector_name: "beta"


### PR DESCRIPTION
Context
To ensure that after migration all micro service urls are pointing to service domain.
new_prod.yml and production.yml can be deleted after successful migration to vsts.

Changes proposed in this pull request
Created prod.yml file with settings copied from production.yml but with service domain instead of education domain url.
