### PR TITLE
[1955] Added the new courses entry requirements

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -3,16 +3,11 @@ module CourseBasicDetailConcern
 
   included do
     decorates_assigned :course
-    before_action :build_provider, only: :new
+    before_action :build_provider, :build_new_course, only: :new
     before_action :build_course, only: %i[edit update]
   end
 
-  def new
-    @course = Course.fetch_new(
-      recruitment_cycle_year: @provider.recruitment_cycle_year,
-      provider_code: @provider.provider_code
-    )
-  end
+  def new; end
 
   def edit; end
 
@@ -36,6 +31,13 @@ module CourseBasicDetailConcern
   end
 
 private
+
+  def build_new_course
+    @course = Course.fetch_new(
+      recruitment_cycle_year: @provider.recruitment_cycle_year,
+      provider_code: @provider.provider_code
+    )
+  end
 
   def build_provider
     @provider = Provider

--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -1,9 +1,7 @@
 module Courses
   class EntryRequirementsController < ApplicationController
     include CourseBasicDetailConcern
-    prepend_before_action :authenticate, :build_provider, :build_course
 
-    # weird
     before_action :not_found_if_no_gcse_subjects_required
 
   private

--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -1,6 +1,9 @@
 module Courses
   class EntryRequirementsController < ApplicationController
     include CourseBasicDetailConcern
+    prepend_before_action :authenticate, :build_provider, :build_course
+
+    # weird
     before_action :not_found_if_no_gcse_subjects_required
 
   private

--- a/app/views/courses/entry_requirements/_form.html.erb
+++ b/app/views/courses/entry_requirements/_form.html.erb
@@ -1,0 +1,15 @@
+<% gcse_subjects_required.each do |subject| %>
+    <% legend = capture do %>
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        <h2 class="govuk-fieldset__heading">
+          <%= subject.to_s.titleize %> GCSE
+        </h2>
+      </legend>
+    <% end %>
+
+    <%= render "shared/edit_options_radio_buttons",
+          form: form,
+          legend: legend,
+          key: 'entry_requirements',
+          field: subject.to_sym %>
+  <% end %>

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -1,6 +1,9 @@
-<%= content_for :page_title, "GCSE requirements for applicants – #{course.name_and_code}" %>
+<%= content_for :page_title, "GCSE requirements for applicants" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(
+    @provider.provider_code,
+    @provider.recruitment_cycle_year
+ )) %>
 <% end %>
 
 <%= render 'shared/errors' %>
@@ -25,20 +28,21 @@
     </p>
 
     <%= form_with model: course,
-          url: entry_requirements_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
-          method: :put do |form| %>
+                  url: new_provider_recruitment_cycle_courses_entry_requirements_path(
+                    @provider.provider_code,
+                    @provider.recruitment_cycle_year
+                  ),
+                  method: :put do |form| %>
+
 
       <%= render 'form', form: form, gcse_subjects_required: course.gcse_subjects_required %>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-      <p class="govuk-body">Changes will appear on UCAS Apply within 2 hours.</p>
-
-      <%= form.submit "Save changes", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes',
-          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
-          class: "govuk-link govuk-link--no-visited-state" %>
+        <%= form.submit "Continue",
+                      class: "govuk-button",
+                      data: { qa: 'course__save' } %>
       </p>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
 
       resource :courses, only: [] do
         resource :outcome, on: :member, only: %i[new], controller: 'courses/outcome'
+        resource :entry_requirements, on: :member, only: %i[new], controller: 'courses/entry_requirements'
       end
 
       resources :courses, param: :code do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -54,6 +54,7 @@ FactoryBot.define do
                         "July #{recruitment_cycle.year.to_i + 1}"]
         }
       end
+      gcse_subjects_required_using_level { false }
     end
 
     sequence(:id)
@@ -123,6 +124,17 @@ FactoryBot.define do
       if evaluator.edit_options
         course.meta = {}
         course.meta['edit_options'] = evaluator.edit_options
+      end
+
+      if evaluator.gcse_subjects_required_using_level
+        course.gcse_subjects_required = case course.level
+                                        when :primary
+                                          %w[maths english science]
+                                        when :secondary
+                                          %w[maths english]
+                                        else
+                                          []
+                                        end
       end
     end
 

--- a/spec/features/courses/entry_requirements/new_spec.rb
+++ b/spec/features/courses/entry_requirements/new_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+feature 'new course entry_requirements', type: :feature do
+  let(:recruitment_cycle) { build(:recruitment_cycle) }
+  let(:new_entry_requirements_page) do
+    PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new
+  end
+  let(:provider) { build(:provider) }
+  let(:level) { :further_education }
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(provider)
+    new_course = build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true)
+    stub_api_v2_new_resource(new_course)
+  end
+
+  context 'level further_education' do
+    scenario 'creating a new course' do
+      visit "/organisations/#{provider.provider_code}/#{recruitment_cycle.year}" \
+      "/courses/entry_requirements/new"
+      expect(page.status_code).to eq(404)
+    end
+  end
+
+  context 'level primary' do
+    let(:level) { :primary }
+    scenario 'creating a new course' do
+      visit "/organisations/#{provider.provider_code}/#{recruitment_cycle.year}" \
+      "/courses/entry_requirements/new"
+
+      expect(page.status_code).to eq(200)
+
+      expect(new_entry_requirements_page).to(
+        be_displayed(
+          recruitment_cycle_year: recruitment_cycle.year,
+          provider_code: provider.provider_code
+        )
+      )
+
+      expect(new_entry_requirements_page).to have_maths_requirements
+      expect(new_entry_requirements_page).to have_english_requirements
+      expect(new_entry_requirements_page).to have_science_requirements
+
+      %w[
+        maths_requirements
+        english_requirements
+        science_requirements
+      ].each do |subject|
+        expect(new_entry_requirements_page.send(subject)).to have_field('1. Must have (least flexible)')
+        expect(new_entry_requirements_page.send(subject)).to have_field('2: Taking')
+        expect(new_entry_requirements_page.send(subject)).to have_field('3: Equivalence test')
+      end
+    end
+  end
+
+  context 'level secondary' do
+    let(:level) { :secondary }
+    scenario 'creating a new course' do
+      visit "/organisations/#{provider.provider_code}/#{recruitment_cycle.year}" \
+      "/courses/entry_requirements/new"
+
+      expect(page.status_code).to eq(200)
+      expect(new_entry_requirements_page).to(
+        be_displayed(
+          recruitment_cycle_year: recruitment_cycle.year,
+          provider_code: provider.provider_code
+        )
+      )
+
+      expect(new_entry_requirements_page).to have_maths_requirements
+      expect(new_entry_requirements_page).to have_english_requirements
+      expect(new_entry_requirements_page).to_not have_science_requirements
+
+      %w[
+        maths_requirements
+        english_requirements
+      ].each do |subject|
+        expect(new_entry_requirements_page.send(subject)).to have_field('1. Must have (least flexible)')
+        expect(new_entry_requirements_page.send(subject)).to have_field('2: Taking')
+        expect(new_entry_requirements_page.send(subject)).to have_field('3: Equivalence test')
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_entry_requirements_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_entry_requirements_page.rb
@@ -1,0 +1,15 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class NewEntryRequirementsPage < CourseBase
+          set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/entry_requirements/new'
+
+          element :maths_requirements,   '[data-qa="course__maths"]'
+          element :english_requirements, '[data-qa="course__english"]'
+          element :science_requirements, '[data-qa="course__science"]'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
A new courses entry requirements

### Changes proposed in this pull request
Added routes
Added a shared form

![image](https://user-images.githubusercontent.com/470137/63364195-0557c300-c36d-11e9-87c9-dd38559486e4.png)


### Guidance to review
built upon #534 as the changes in there is fundamental 

There are going to be a few loose ends that most likely addressed in another PR

- This added `gcse_subjects_required_using_level` to make life easier, as the PR also requires a course `level`

- :man_shrugging: hidden fields, user journey isn't quite defined.

- If the course level is further_education user needs to go further
