### PR TITLE
[XXXX] Don't render empty course locations list

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -108,8 +108,8 @@
         <dd class="govuk-summary-list__value" data-qa="course__locations">
           <% if course.sites.size == 1 %>
             <%= course.sites.first.location_name %>
-          <% else %>
-            <ul class="govuk-list app-courses-locations-list">
+          <% elsif course.sites.size > 1 %>
+            <ul class="govuk-list app-courses-locations-list" data-qa="courses__locations-list">
               <% course.alphabetically_sorted_sites.each do |site| %>
                 <li>
                   <%= site.location_name %>

--- a/spec/features/courses/details_spec.rb
+++ b/spec/features/courses/details_spec.rb
@@ -173,6 +173,7 @@ feature 'Course details', type: :feature do
       visit "/organisations/A0/#{course.recruitment_cycle.year}/courses/#{course.course_code}/details"
 
       expect(course_details_page).not_to have_edit_locations_link
+      expect(course_details_page).not_to have_locations_list
       expect(course_details_page.manage_provider_locations_link).to have_content(
         "Manage all your locations"
       )

--- a/spec/site_prism/page_objects/page/organisations/course_details.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_details.rb
@@ -12,6 +12,7 @@ module PageObjects
         element :description, '[data-qa=course__description]'
         element :course_code, '[data-qa=course__course_code]'
         element :locations, '[data-qa=course__locations]'
+        element :locations_list, '[data-qa=courses__locations-list]'
         element :edit_locations_link, '[data-qa=course__edit_locations_link]'
         element :manage_provider_locations_link, '[data-qa=course__manage_provider_locations_link]'
         element :apprenticeship, '[data-qa=course__apprenticeship]'


### PR DESCRIPTION
### Context
Empty location list causing whitespace

### Changes proposed in this pull request
Don't render empty list when there is only one course location

### Guidance to review
🚢 

# Before
<img width="1552" alt="Screenshot 2019-08-21 at 10 27 25" src="https://user-images.githubusercontent.com/3071606/63420285-4c41c900-c3fe-11e9-85f2-a0de345741fb.png">

# After
<img width="1552" alt="Screenshot 2019-08-21 at 10 23 46" src="https://user-images.githubusercontent.com/3071606/63420183-16044980-c3fe-11e9-803b-22494935143a.png">
