### PR TITLE
[1968] Add allocations help text to course details

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -222,6 +222,23 @@
           </dd>
         </div>
       <% end %>
+      <% if course.next_cycle? && course.has_fees? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Allocations
+          </dt>
+          <dd class="govuk-summary-list__value govuk-!-padding-right-0" data-qa="course__allocations_info">
+            <% if course.subjects.include?('Physical education') %>
+              <p class="govuk-body">Recruitment to fee-funded PE courses is limited by the number of places allocated to you by DfE.</p>
+              <p class="govuk-body">If you haven't already, you must <%= govuk_link_to "request allocations", "https://drive.google.com/open?id=1ujS6MbWMdXOSEWOCd3voV3d4L2HjT-g2zIOzWfqbDa8" %></p>
+            <% else %>
+              Recruitment is not restricted
+            <% end %>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+          </dd>
+        </div>
+      <% end %>
     </dl>
   </div>
   <% if course.is_running? || course.new_and_not_running? %>

--- a/spec/site_prism/page_objects/page/organisations/course_details.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_details.rb
@@ -24,6 +24,7 @@ module PageObjects
         element :edit_age_range_link, '[data-qa=course__edit_age_range_link]'
         element :level, '[data-qa=course__level]'
         element :entry_requirements, '[data-qa=course__entry_requirements]'
+        element :allocations_info, '[data-qa=course__allocations_info]'
       end
     end
   end


### PR DESCRIPTION
### Context
Allocations

### Changes proposed in this pull request
Display basic allocations information to providers

### Guidance to review
# After
![localhost_3000_organisations_2AT_2020_courses_35L7_details(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/63439087-54f9c580-c425-11e9-8419-41935f9b9de3.png)
![localhost_3000_organisations_2AT_2020_courses_35L8_details(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/63439048-44494f80-c425-11e9-91e5-ad0141eb03e8.png)