### PR TITLE
[2007] Remove single location special case

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -106,7 +106,9 @@
           Locations
         </dt>
         <dd class="govuk-summary-list__value" data-qa="course__locations">
-          <% if course.sites.size == 1 %>
+          <% if course.sites.empty? %>
+            <span class="app-course-parts__fields__value--empty">None</span>
+          <% elsif course.sites.size == 1 %>
             <%= course.sites.first.location_name %>
           <% else %>
             <ul class="govuk-list app-courses-locations-list">
@@ -117,18 +119,10 @@
               <% end %>
             </ul>
           <% end %>
-          <% if @provider.sites.size == 1 %>
-            <p class="govuk-body govuk-hint">You can’t change this because you only have 1&nbsp;location</p>
-            <p class="govuk-body">
-              <%= link_to "Manage all your locations", provider_recruitment_cycle_sites_path(@provider.provider_code), class: "govuk-link", data: { qa: "course__manage_provider_locations_link" } %>
-            </p>
-          <% end %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <% if @provider.sites.size > 1 %>
-            <%= link_to locations_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_locations_link" } do %>
-              Change<span class="govuk-visually-hidden"> locations</span>
-            <% end %>
+          <%= link_to locations_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_locations_link" } do %>
+            Change<span class="govuk-visually-hidden"> locations</span>
           <% end %>
         </dd>
       </div>

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}Locations - #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
 
 <% if @errors.present? %>
@@ -24,11 +24,13 @@
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.name_and_code %></span>
-  Locations
+  Pick the locations for this course
 </h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-body govuk-!-margin-bottom-6"><%= link_to "Manage all your locations", provider_recruitment_cycle_sites_path(@provider.provider_code), class: "govuk-link", data: { qa: "course__manage_provider_locations_link" } %> to add to or edit this list.</p>
+
     <%= form_for course, url: locations_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :put do |f| %>
       <div class="govuk-form-group">
         <div class="govuk-checkboxes">

--- a/spec/features/courses/details_spec.rb
+++ b/spec/features/courses/details_spec.rb
@@ -159,26 +159,6 @@ feature 'Course details', type: :feature do
     end
   end
 
-  context 'when the provider only has one location' do
-    let(:provider) { build(:provider, provider_code: 'A0', accredited_body?: true, sites: [site1]) }
-    let(:course) do
-      build :course,
-            site_statuses: [site_status1],
-            provider: provider,
-            ucas_status: 'new',
-            recruitment_cycle: current_recruitment_cycle
-    end
-
-    scenario 'viewing the course details page' do
-      visit "/organisations/A0/#{course.recruitment_cycle.year}/courses/#{course.course_code}/details"
-
-      expect(course_details_page).not_to have_edit_locations_link
-      expect(course_details_page.manage_provider_locations_link).to have_content(
-        "Manage all your locations"
-      )
-    end
-  end
-
   context 'when the course is new and not running' do
     let(:course) do
       build :course,

--- a/spec/features/courses/sites/edit_spec.rb
+++ b/spec/features/courses/sites/edit_spec.rb
@@ -49,9 +49,9 @@ feature 'Edit course sites', type: :feature do
   end
 
   scenario 'viewing the edit locations page' do
-    expect(page).to have_link('Back', href: provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code))
+    expect(page).to have_link('Back', href: details_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code))
     expect(page).to have_link('Cancel changes', href: details_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code))
-    expect(locations_page.title).to have_content('Locations')
+    expect(locations_page.title).to have_content('Pick the locations for this course')
     expect(locations_page.caption).to have_content(
       "#{course.name} (#{course.course_code})"
     )


### PR DESCRIPTION
For some of our courses there is bad data – some don't have any locations. We can't easily set locations for these course.

We were assuming that for providers with 1 location, all courses would have that location. That's not the case.

Most of the affected courses weren't running in 2019.

Make it possible for providers to self-serve and fix their courses by going in and adding the missing location.

Move guidance about managing locations to the Pick your locations page and make it available to all providers.

Supersedes #540.

![Screen Shot 2019-08-21 at 15 55 49](https://user-images.githubusercontent.com/319055/63443148-3814c080-c42c-11e9-8c0e-eb042d58cc4b.png)
![Screen Shot 2019-08-21 at 15 55 57](https://user-images.githubusercontent.com/319055/63443149-3814c080-c42c-11e9-943f-daded772d11e.png)
