### PR TITLE
[1956] Add continue to new course entry requirements

### DIFF
--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -2,7 +2,15 @@ module Courses
   class EntryRequirementsController < ApplicationController
     include CourseBasicDetailConcern
 
-    before_action :not_found_if_no_gcse_subjects_required
+    before_action :not_found_if_no_gcse_subjects_required, except: :continue
+
+    def continue
+      redirect_to new_provider_recruitment_cycle_courses_outcome_path(
+        params[:provider_code],
+        params[:recruitment_cycle_year],
+        course_params
+      )
+    end
 
   private
 

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -28,11 +28,11 @@
     </p>
 
     <%= form_with model: course,
-                  url: new_provider_recruitment_cycle_courses_entry_requirements_path(
+                  url: continue_provider_recruitment_cycle_courses_entry_requirements_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
                   ),
-                  method: :put do |form| %>
+                  method: :get do |form| %>
 
 
       <%= render 'form_fields', form: form, gcse_subjects_required: course.gcse_subjects_required %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,9 @@ Rails.application.routes.draw do
 
       resource :courses, only: [] do
         resource :outcome, on: :member, only: %i[new], controller: 'courses/outcome'
-        resource :entry_requirements, on: :member, only: %i[new], controller: 'courses/entry_requirements'
+        resource :entry_requirements, on: :member, only: %i[new], controller: 'courses/entry_requirements' do
+          get 'continue'
+        end
       end
 
       resources :courses, param: :code do

--- a/spec/features/courses/entry_requirements/new_spec.rb
+++ b/spec/features/courses/entry_requirements/new_spec.rb
@@ -51,6 +51,11 @@ feature 'new course entry_requirements', type: :feature do
         expect(new_entry_requirements_page.send(subject)).to have_field('2: Taking')
         expect(new_entry_requirements_page.send(subject)).to have_field('3: Equivalence test')
       end
+
+      choose('course_maths_expect_to_achieve_before_training_begins')
+      click_on 'Continue'
+
+      expect(current_path).to eq new_provider_recruitment_cycle_courses_outcome_path(provider.provider_code, provider.recruitment_cycle_year)
     end
   end
 
@@ -80,6 +85,11 @@ feature 'new course entry_requirements', type: :feature do
         expect(new_entry_requirements_page.send(subject)).to have_field('2: Taking')
         expect(new_entry_requirements_page.send(subject)).to have_field('3: Equivalence test')
       end
+
+      choose('course_english_expect_to_achieve_before_training_begins')
+      click_on 'Continue'
+
+      expect(current_path).to eq new_provider_recruitment_cycle_courses_outcome_path(provider.provider_code, provider.recruitment_cycle_year)
     end
   end
 end


### PR DESCRIPTION
### Context
Hook up "Continue" on new course entry requirements 

### Changes proposed in this pull request
Redirect to course outcomes after new course entry requirements

### Guidance to review
Pick a provider and manually  `https://localhost:3000/organisations/PROVIDER_CODE/2020/courses/entry_requirements/new` then click continue
