### PR TITLE
[1939] Add continue to new course outcome

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -3,7 +3,7 @@ module CourseBasicDetailConcern
 
   included do
     decorates_assigned :course
-    before_action :build_provider, :build_new_course, only: :new
+    before_action :build_provider, :build_new_course, only: %i[new continue]
     before_action :build_course, only: %i[edit update]
   end
 

--- a/app/controllers/courses/outcome_controller.rb
+++ b/app/controllers/courses/outcome_controller.rb
@@ -2,6 +2,20 @@ module Courses
   class OutcomeController < ApplicationController
     include CourseBasicDetailConcern
 
+    def continue
+      @errors = errors
+
+      if @errors.present?
+        render :new
+      else
+        redirect_to new_provider_recruitment_cycle_courses_entry_requirements_path(
+          params[:provider_code],
+          params[:recruitment_cycle_year],
+          course_params
+        )
+      end
+    end
+
   private
 
     def errors

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -11,11 +11,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: course,
-                  url: new_provider_recruitment_cycle_courses_outcome_path(
+                  url: continue_provider_recruitment_cycle_courses_outcome_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
                   ),
-                  method: :put do |form| %>
+                  method: :get do |form| %>
 
       <%= render 'form_fields', form: form, course_name_and_code: nil %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,9 @@ Rails.application.routes.draw do
       post '/publish', on: :member, to: 'providers#publish'
 
       resource :courses, only: [] do
-        resource :outcome, on: :member, only: %i[new], controller: 'courses/outcome'
+        resource :outcome, on: :member, only: %i[new], controller: 'courses/outcome' do
+          get 'continue'
+        end
         resource :entry_requirements, on: :member, only: %i[new], controller: 'courses/entry_requirements' do
           get 'continue'
         end

--- a/spec/features/courses/outcome/new_spec.rb
+++ b/spec/features/courses/outcome/new_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+feature 'new course outcome', type: :feature do
+  let(:new_outcome_page) do
+    PageObjects::Page::Organisations::Courses::NewOutcomePage.new
+  end
+  let(:provider) { build(:provider) }
+  let(:course) { build(:course, provider: provider) }
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(provider)
+    new_course = build(:course, :new, provider: provider, gcse_subjects_required_using_level: true)
+    stub_api_v2_new_resource(new_course)
+  end
+
+  scenario "sends user to entry requirements" do
+    visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
+    "/courses/outcome/new"
+
+    choose('course_qualification_qts')
+    click_on 'Continue'
+
+    expect(current_path).to eq new_provider_recruitment_cycle_courses_entry_requirements_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+end


### PR DESCRIPTION
### Context

Hook up "Continue" on new course outcome

### Changes proposed in this pull request

Redirect to course entry requirements

### Guidance to review

Go go `/organisations/2CG/2019/courses/outcome/new` and attempt to continue without choosing anything and then after choosing something.