### PR TITLE
[1897] Add course level edit page

### DIFF
--- a/app/controllers/courses/level_controller.rb
+++ b/app/controllers/courses/level_controller.rb
@@ -1,0 +1,13 @@
+module Courses
+  class LevelController < ApplicationController
+    include CourseBasicDetailConcern
+
+  private
+
+    def errors; end
+
+    def course_params
+      params.require(:course).permit(:level)
+    end
+  end
+end

--- a/app/views/courses/level/edit.html.erb
+++ b/app/views/courses/level/edit.html.erb
@@ -1,0 +1,54 @@
+<%= content_for :page_title, "Edit Level – #{course.name_and_code}" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(
+    details_provider_recruitment_cycle_course_path(
+      course.provider_code,
+      course.recruitment_cycle_year,
+      course.course_code
+    )) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<h1 class="govuk-heading-xl">
+  What type of course?
+</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: course,
+                  url: level_provider_recruitment_cycle_course_path(
+                    @course.provider_code,
+                    @course.recruitment_cycle_year,
+                    @course.course_code
+                  ),
+                  method: :put do |form| %>
+      <h2 class="govuk-heading-m remove-top-margin">Level</h2>
+
+      <div class="govuk-form-group ">
+        <div class="govuk-radios govuk-radios" data-module="radios">
+          <% %i[primary secondary further_education].each do |level| %>
+            <div class="govuk-radios__item">
+              <%= form.radio_button :level, level,
+                class: 'govuk-radios__input',
+                data: { qa: "course__#{level}" } %>
+              <%= form.label :level, value: level,
+                class: 'govuk-label govuk-radios__label' %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
+        class: "govuk-button", data: { qa: 'course__save' } %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes',
+          details_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code
+          ), class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,9 @@ Rails.application.routes.draw do
         get '/send', on: :member, to: 'courses/send#edit'
         put '/send', on: :member, to: 'courses/send#update'
 
+        get '/level', on: :member, to: 'courses/level#edit'
+        put '/level', on: :member, to: 'courses/level#update'
+
         get '/full-part-time', on: :member, to: 'courses/study_mode#edit'
         put '/full-part-time', on: :member, to: 'courses/study_mode#update'
 

--- a/spec/features/courses/level/edit_spec.rb
+++ b/spec/features/courses/level/edit_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+feature 'Edit course level', type: :feature do
+  let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+  let(:level_page) { PageObjects::Page::Organisations::CourseLevel.new }
+  let(:details_page) { PageObjects::Page::Organisations::CourseDetails.new }
+  let(:provider) { build(:provider) }
+  let(:course) { build(:course, provider: provider, level: :primary) }
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course)
+    stub_api_v2_resource(
+      course,
+      include: 'sites,provider.sites,accrediting_provider'
+    )
+
+    level_page.load_with_course(course)
+  end
+
+  scenario 'can cancel changes' do
+    click_on 'Cancel changes'
+    expect(details_page).to be_displayed
+  end
+
+  # TODO: Enable me when we allow users to access this page.
+  xscenario 'can navigate to the edit screen and back again' do
+    details_page.load_with_course(course)
+    click_on 'Change level'
+    expect(level_page).to be_displayed
+    click_on 'Back'
+    expect(details_page).to be_displayed
+  end
+
+  scenario 'presents a choice for each level' do
+    expect(level_page).to have_primary
+    expect(level_page).to have_secondary
+    expect(level_page).to have_further_education
+  end
+
+  scenario 'has the correct value selected' do
+    expect(level_page.primary).to be_checked
+  end
+
+  scenario 'can be updated' do
+    update_course_stub = stub_api_v2_request(
+      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
+      "/courses/#{course.course_code}",
+      course.to_jsonapi,
+      :patch, 200
+    ).with(body: {
+      data: {
+        course_code: course.course_code,
+        type: "courses",
+        attributes: {
+          level: "secondary"
+        }
+      }
+    }.to_json)
+
+    choose 'Secondary'
+    click_on 'Save'
+
+    expect(details_page).to be_displayed
+    expect(details_page.flash).to have_content('Your changes have been saved')
+    expect(update_course_stub).to have_been_requested
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/course_level.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_level.rb
@@ -1,0 +1,13 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseLevel < CourseBase
+        set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/level'
+
+        element :primary, '[data-qa="course__primary"]'
+        element :secondary, '[data-qa="course__secondary"]'
+        element :further_education, '[data-qa="course__further_education"]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Allow providers to select the level of their course. This doesn't currently work but I've created it anyway.

### Changes proposed in this pull request

New controller, view, route, feature test, and page object.

### Guidance to review

:shipit: This is a prerequisite for the new level page.

![Screenshot 2019-08-23 at 11 58 27](https://user-images.githubusercontent.com/1650875/63588014-56e69480-c59d-11e9-811c-7032dfb9c42a.png)
