### PR TITLE
[1897] Add course level new page

### DIFF
--- a/app/controllers/courses/level_controller.rb
+++ b/app/controllers/courses/level_controller.rb
@@ -1,0 +1,27 @@
+module Courses
+  class LevelController < ApplicationController
+    include CourseBasicDetailConcern
+
+    def continue
+      @errors = errors
+
+      if @errors.present?
+        render :new
+      else
+        redirect_to new_provider_recruitment_cycle_courses_entry_requirements_path(
+          params[:provider_code],
+          params[:recruitment_cycle_year],
+          course_params
+        )
+      end
+    end
+
+  private
+
+    def errors; end
+
+    def course_params
+      params.require(:course).permit(:level, :is_send)
+    end
+  end
+end

--- a/app/views/courses/level/_form_fields.html.erb
+++ b/app/views/courses/level/_form_fields.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-form-group ">
+  <div class="govuk-radios govuk-radios" data-module="radios">
+    <% %i[primary secondary further_education].each do |level| %>
+      <div class="govuk-radios__item">
+        <%= form.radio_button :level, level,
+          class: 'govuk-radios__input',
+          data: { qa: "course__#{level}" } %>
+        <%= form.label :level, value: level,
+          class: 'govuk-label govuk-radios__label' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -1,0 +1,32 @@
+<%= content_for :page_title, "Pick a course type" %>
+
+<%= render 'shared/errors' %>
+
+<h1 class="govuk-heading-xl">
+  What type of course?
+</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: course,
+                  url: continue_provider_recruitment_cycle_courses_level_path(
+                    @course.provider_code,
+                    @course.recruitment_cycle_year,
+                    @course.course_code
+                  ),
+                  method: :get do |form| %>
+      <h2 class="govuk-heading-m remove-top-margin">Level</h2>
+
+      <%= render 'form_fields', form: form %>
+
+      <h2 class="govuk-heading-m remove-top-margin">
+        Special educational needs and disability (SEND)
+      </h2>
+
+      <%= render 'courses/send/form_fields', form: form %>
+
+      <%= form.submit "Continue",
+                      class: "govuk-button",
+                      data: { qa: 'course__save' } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/courses/send/_form_fields.html.erb
+++ b/app/views/courses/send/_form_fields.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-form-group">
+  <div class="govuk-checkboxes" data-module="checkboxes">
+    <div class="govuk-checkboxes__item">
+      <%= form.check_box(:is_send, checked: @course.is_send?(course, form.object, :is_send), data: { qa: 'is_send' }, class: 'govuk-checkboxes__input') %>
+      <%= form.label(:is_send, "This course has an additional SEND specialism", class: 'govuk-label govuk-checkboxes__label') %>
+    </div>
+  </div>
+</div>

--- a/app/views/courses/send/edit.html.erb
+++ b/app/views/courses/send/edit.html.erb
@@ -12,14 +12,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: course, url: send_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code), method: :put do |form| %>
 
-      <div class="govuk-form-group">
-        <div class="govuk-checkboxes" data-module="checkboxes">
-          <div class="govuk-checkboxes__item">
-            <%= form.check_box(:is_send, checked: @course.is_send?(course, form.object, :is_send), data: { qa: 'is_send' }, class: 'govuk-checkboxes__input') %>
-            <%= form.label(:is_send, "This course has an additional SEND specialism", class: 'govuk-label govuk-checkboxes__label') %>
-          </div>
-        </div>
-      </div>
+      <%= render 'form_fields', form: form %>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,9 @@ Rails.application.routes.draw do
         resource :study_mode, on: :member, only: %i[new], controller: 'courses/study_mode' do
           get 'continue'
         end
+        resource :level, on: :member, only: %i[new], controller: 'courses/level' do
+          get 'continue'
+        end
         get 'confirmation'
       end
 

--- a/spec/features/courses/level/new_spec.rb
+++ b/spec/features/courses/level/new_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+feature 'New course level', type: :feature do
+  let(:new_outcome_page) do
+    PageObjects::Page::Organisations::Courses::NewLevelPage.new
+  end
+  let(:provider) { build(:provider) }
+  let(:course) { build(:course, provider: provider, level: :primary) }
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(provider)
+    new_course = build(:course, :new, provider: provider, gcse_subjects_required_using_level: true)
+    stub_api_v2_new_resource(new_course)
+  end
+
+  scenario "sends user to entry requirements" do
+    visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
+    "/courses/level/new"
+
+    choose 'Secondary'
+    click_on 'Continue'
+
+    expect(current_path).to eq new_provider_recruitment_cycle_courses_entry_requirements_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_level_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_level_page.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class NewLevelPage < CourseBase
+          set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/level/new'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Allow providers to select the level of a new course.

### Changes proposed in this pull request

Adds a ontroller action for `continue`, view, page object, and feature spec.

### Guidance to review

![Screenshot 2019-08-23 at 12 01 04](https://user-images.githubusercontent.com/1650875/63590415-a5972d00-c5a3-11e9-91c5-fd9f931e9f13.png)
