### PR TITLE
[2037] Add course new start date page

### DIFF
--- a/app/controllers/courses/start_date_controller.rb
+++ b/app/controllers/courses/start_date_controller.rb
@@ -2,6 +2,20 @@ module Courses
   class StartDateController < ApplicationController
     include CourseBasicDetailConcern
 
+    def continue
+      @errors = errors
+
+      if @errors.present?
+        render :new
+      else
+        redirect_to confirmation_provider_recruitment_cycle_courses_path(
+          params[:provider_code],
+          params[:recruitment_cycle_year],
+          course_params
+        )
+      end
+    end
+
   private
 
     def errors; end

--- a/app/views/courses/start_date/_form_fields.html.erb
+++ b/app/views/courses/start_date/_form_fields.html.erb
@@ -1,0 +1,4 @@
+<%= render "shared/form_field",
+  form: form, field: :start_date, label: "Course start date" do |field, options| %>
+  <%= form.select field, @course.meta["edit_options"]["start_dates"], {}, options.merge(class: 'govuk-select') %>
+<% end %>

--- a/app/views/courses/start_date/edit.html.erb
+++ b/app/views/courses/start_date/edit.html.erb
@@ -12,10 +12,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: course, url: start_date_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code), method: :put do |form| %>
-      <%= render "shared/form_field",
-        form: form, field: :start_date, label: "Course start date" do |field, options| %>
-        <%= form.select field, @course.meta["edit_options"]["start_dates"], {}, options.merge(class: 'govuk-select') %>
-      <% end %>
+      <%= render 'form_fields', form: form %>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
         class: "govuk-button", data: { qa: 'course__save' }

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -1,0 +1,26 @@
+<%= content_for :page_title, "Pick a start date" %>
+
+<%= render 'shared/errors' %>
+
+<h1 class="govuk-heading-xl">
+  When does the course start
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: course,
+                  url: continue_provider_recruitment_cycle_courses_start_date_path(
+                    @course.provider_code,
+                    @course.recruitment_cycle_year,
+                    @course.course_code
+                  ),
+                  method: :get do |form| %>
+
+      <%= render 'form_fields', form: form %>
+
+      <%= form.submit "Continue",
+                      class: "govuk-button",
+                      data: { qa: 'course__save' } %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,9 @@ Rails.application.routes.draw do
         resource :level, on: :member, only: %i[new], controller: 'courses/level' do
           get 'continue'
         end
+        resource :start_date, on: :member, only: %i[new], controller: 'courses/start_date', path: 'start-date' do
+          get 'continue'
+        end
         get 'confirmation'
       end
 

--- a/spec/features/courses/start_date/new_spec.rb
+++ b/spec/features/courses/start_date/new_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+feature 'New course start date', type: :feature do
+  let(:recruitment_cycle) { build(:recruitment_cycle) }
+  let(:provider) { build(:provider) }
+  let(:course) { build(:course, provider: provider) }
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(provider)
+    new_course = build(:course, :new, provider: provider)
+    stub_api_v2_new_resource(new_course)
+    stub_api_v2_resource(recruitment_cycle)
+    stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
+  end
+
+  scenario "choose coure start date" do
+    visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
+    "/courses/start-date/new"
+
+    select 'September 2019'
+    click_on 'Continue'
+
+    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_start_date_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_start_date_page.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class StartDatePage < CourseBase
+          set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/start_date/new'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Creating a new course

### Changes proposed in this pull request
Add new course page for "start date"

### Guidance to review
Example: `/organisations/2CG/2019/courses/start-date/new`