### PR TITLE
[2002] Edit course salaried/fee/apprenticeship

### DIFF
--- a/app/controllers/courses/fee_or_salary_controller.rb
+++ b/app/controllers/courses/fee_or_salary_controller.rb
@@ -1,0 +1,13 @@
+module Courses
+  class FeeOrSalaryController < ApplicationController
+    include CourseBasicDetailConcern
+
+  private
+
+    def errors; end
+
+    def course_params
+      params.require(:course).permit(:program_type)
+    end
+  end
+end

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -88,7 +88,11 @@
           <dd class="govuk-summary-list__value" data-qa="course__funding">
             <%= course.funding %>
           </dd>
-          <dd class="govuk-summary-list__actions"></dd>
+          <dd class="govuk-summary-list__actions">
+            <%= link_to fee_or_salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_entry_requirements_link" } do %>
+              Change<span class="govuk-visually-hidden"> fee or salary</span>
+            <% end %>
+          </dd>
         </div>
       <% end %>
 

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -89,9 +89,10 @@
             <%= course.funding %>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <%= link_to fee_or_salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_entry_requirements_link" } do %>
+            <!-- <%= link_to fee_or_salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_entry_requirements_link" } do %>
               Change<span class="govuk-visually-hidden"> fee or salary</span>
             <% end %>
+            -->
           </dd>
         </div>
       <% end %>

--- a/app/views/courses/fee_or_salary/edit.html.erb
+++ b/app/views/courses/fee_or_salary/edit.html.erb
@@ -1,0 +1,51 @@
+<%= content_for :page_title, "Edit Fee or Salary – #{course.name_and_code}" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<h1 class="govuk-heading-xl">
+</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with model: course, url: fee_or_salary_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code), method: :put do |form| %>
+      <div
+        class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:program_type]&.any?) %>"
+        data-qa="course__program_type">
+
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              Is it fee paying or salaried?
+            </h1>
+          </legend>
+
+          <%= render "shared/error_messages", field: :program_type if @errors %>
+          <div class="govuk-radios" data-module="radios">
+            <% @course.meta['edit_options']['program_type'].each do |value| %>
+              <div class="govuk-radios__item">
+                <%= form.radio_button :program_type,
+                        value,
+                        class: 'govuk-radios__input' %>
+                <%= form.label :program_type,
+                        t("edit_options.fee_or_salary.#{value}.label"),
+                        value: value,
+                        class: 'govuk-label govuk-radios__label' %>
+              </div>
+            <% end %>
+          </div>
+        </fieldset>
+      </div>
+
+      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
+        class: "govuk-button", data: { qa: 'course__save' }
+      %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes', details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    <% end %>
+  </div>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,3 +105,10 @@ en:
         label: "No"
       scitt_programme:
         label: "No"
+    fee_or_salary:
+      pg_teaching_apprenticeship:
+        label: "Teaching apprenticeship (with salary)"
+      school_direct_training_programme:
+        label: "Fee paying (no salary)"
+      school_direct_salaried_training_programme:
+        label: "Salaried"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,9 @@ Rails.application.routes.draw do
         get '/apprenticeship', on: :member, to: 'courses/apprenticeship#edit'
         put '/apprenticeship', on: :member, to: 'courses/apprenticeship#update'
 
+        get '/fee-or-salary', on: :member, to: 'courses/fee_or_salary#edit'
+        put '/fee-or-salary', on: :member, to: 'courses/fee_or_salary#update'
+
         get '/full-part-time', on: :member, to: 'courses/study_mode#edit'
         put '/full-part-time', on: :member, to: 'courses/study_mode#update'
 

--- a/spec/features/courses/fee_or_salary/edit_spec.rb
+++ b/spec/features/courses/fee_or_salary/edit_spec.rb
@@ -23,7 +23,7 @@ feature 'Edit course fee or salary status', type: :feature do
     fee_or_salary_page.load_with_course(course)
   end
 
-  context 'A course that can be an apprenticeship' do
+  context 'A course belonging to a non-accredited body' do
     let(:program_type) { 'pg_teaching_apprenticeship' }
     let(:program_types) { %w[pg_teaching_apprenticeship school_direct_training_programme school_direct_salaried_training_programme] }
     let(:course) do
@@ -42,7 +42,7 @@ feature 'Edit course fee or salary status', type: :feature do
       expect(course_details_page).to be_displayed
     end
 
-    scenario 'can navigate to the edit screen and back again' do
+    xscenario 'can navigate to the edit screen and back again' do
       course_details_page.load_with_course(course)
       click_on 'Change fee or salary'
       expect(fee_or_salary_page).to be_displayed
@@ -50,7 +50,7 @@ feature 'Edit course fee or salary status', type: :feature do
       expect(course_details_page).to be_displayed
     end
 
-    scenario 'presents the correct choices for each study mode' do
+    scenario 'presents the correct choices' do
       expect(fee_or_salary_page).to have_program_type_fields
       expect(fee_or_salary_page.program_type_fields)
         .to have_selector('[for="course_program_type_pg_teaching_apprenticeship"]', text: 'Teaching apprenticeship (with salary)')
@@ -97,7 +97,7 @@ feature 'Edit course fee or salary status', type: :feature do
       end
     end
 
-    scenario 'it can be updated to a salraied direct training program' do
+    scenario 'it can be updated to a salaried direct training program' do
       update_course_stub = stub_api_v2_request(
         "/recruitment_cycles/#{course.recruitment_cycle.year}" \
         "/providers/#{provider.provider_code}" \

--- a/spec/features/courses/fee_or_salary/edit_spec.rb
+++ b/spec/features/courses/fee_or_salary/edit_spec.rb
@@ -1,0 +1,136 @@
+require 'rails_helper'
+
+feature 'Edit course fee or salary status', type: :feature do
+  let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+  let(:fee_or_salary_page) { PageObjects::Page::Organisations::CourseFeeOrSalary.new }
+  let(:course_details_page) { PageObjects::Page::Organisations::CourseDetails.new }
+  let(:provider) { build(:provider, accredited_body?: false) }
+
+  before do
+    stub_omniauth
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}",
+      current_recruitment_cycle.to_jsonapi
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
+      provider.to_jsonapi(include: %i[courses accrediting_provider])
+    )
+
+    stub_course_request
+    stub_course_details_tab
+    fee_or_salary_page.load_with_course(course)
+  end
+
+  context 'A course that can be an apprenticeship' do
+    let(:program_type) { 'pg_teaching_apprenticeship' }
+    let(:program_types) { %w[pg_teaching_apprenticeship school_direct_training_programme school_direct_salaried_training_programme] }
+    let(:course) do
+      build(
+        :course,
+        program_type: program_type,
+        edit_options: {
+          program_type: program_types
+        },
+        provider: provider
+      )
+    end
+
+    scenario 'can cancel changes' do
+      click_on 'Cancel changes'
+      expect(course_details_page).to be_displayed
+    end
+
+    scenario 'can navigate to the edit screen and back again' do
+      course_details_page.load_with_course(course)
+      click_on 'Change fee or salary'
+      expect(fee_or_salary_page).to be_displayed
+      click_on 'Back'
+      expect(course_details_page).to be_displayed
+    end
+
+    scenario 'presents the correct choices for each study mode' do
+      expect(fee_or_salary_page).to have_program_type_fields
+      expect(fee_or_salary_page.program_type_fields)
+        .to have_selector('[for="course_program_type_pg_teaching_apprenticeship"]', text: 'Teaching apprenticeship (with salary)')
+      expect(fee_or_salary_page.program_type_fields)
+        .to have_selector('[for="course_program_type_school_direct_training_programme"]', text: 'Fee paying (no salary)')
+      expect(fee_or_salary_page.program_type_fields)
+        .to have_selector('[for="course_program_type_school_direct_salaried_training_programme"]', text: 'Salaried')
+    end
+
+    context 'and it is an apprenticeship' do
+      scenario 'it has the correct value selected' do
+        expect(fee_or_salary_page.program_type_fields)
+          .to have_field('course_program_type_pg_teaching_apprenticeship', checked: true)
+        expect(fee_or_salary_page.program_type_fields)
+          .to have_field('course_program_type_school_direct_training_programme', checked: false)
+        expect(fee_or_salary_page.program_type_fields)
+          .to have_field('course_program_type_school_direct_salaried_training_programme', checked: false)
+      end
+    end
+
+    context 'and it is a direct training programme' do
+      let(:program_type) { 'school_direct_training_programme' }
+
+      scenario 'it has the correct value selected' do
+        expect(fee_or_salary_page.program_type_fields)
+          .to have_field('course_program_type_pg_teaching_apprenticeship', checked: false)
+        expect(fee_or_salary_page.program_type_fields)
+          .to have_field('course_program_type_school_direct_training_programme', checked: true)
+        expect(fee_or_salary_page.program_type_fields)
+          .to have_field('course_program_type_school_direct_salaried_training_programme', checked: false)
+      end
+    end
+
+    context 'and it is a direct salaried training programme' do
+      let(:program_type) { 'school_direct_salaried_training_programme' }
+
+      scenario 'it has the correct value selected' do
+        expect(fee_or_salary_page.program_type_fields)
+          .to have_field('course_program_type_pg_teaching_apprenticeship', checked: false)
+        expect(fee_or_salary_page.program_type_fields)
+          .to have_field('course_program_type_school_direct_training_programme', checked: false)
+        expect(fee_or_salary_page.program_type_fields)
+          .to have_field('course_program_type_school_direct_salaried_training_programme', checked: true)
+      end
+    end
+
+    scenario 'it can be updated to a salraied direct training program' do
+      update_course_stub = stub_api_v2_request(
+        "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+        "/providers/#{provider.provider_code}" \
+        "/courses/#{course.course_code}",
+        course.to_jsonapi,
+        :patch, 200
+      )
+
+      choose('course_program_type_school_direct_salaried_training_programme')
+      click_on 'Save'
+
+      expect(course_details_page).to be_displayed
+      expect(course_details_page.flash).to have_content('Your changes have been saved')
+      expect(update_course_stub).to have_been_requested
+    end
+  end
+
+  def stub_course_request
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}/courses" \
+      "/#{course.course_code}",
+      course.to_jsonapi
+    )
+  end
+
+  def stub_course_details_tab
+    stub_api_v2_request(
+      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
+      "/courses/#{course.course_code}" \
+      "?include=sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites])
+    )
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/course_fee_or_salary.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_fee_or_salary.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseFeeOrSalary < CourseBase
+        set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/fee-or-salary'
+
+        element :program_type_fields, '[data-qa="course__program_type"]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We need the ability to edit whether the course is fee-paying, salaried, or an apprenticeship

### Changes proposed in this pull request
- Adds a new page for editing fee or salary
  - Populates fields based on the backend
  - **temporarily disabled**

### Guidance to review

- Check out this branch and https://github.com/DFE-Digital/manage-courses-backend/pull/743/ on the backend
- Uncomment out the line in the basic details tab
- Go to a course on a non-accredited body
- Edit fee or salary
