### PR TITLE
[2018] Add editing of a course's accredited body

### DIFF
--- a/app/controllers/courses/accredited_body_controller.rb
+++ b/app/controllers/courses/accredited_body_controller.rb
@@ -1,0 +1,26 @@
+module Courses
+  class AccreditedBodyController < ApplicationController
+    include CourseBasicDetailConcern
+
+    before_action :build_provider
+
+  private
+
+    def errors
+      params.dig(:course, :accrediting_provider_code) ? {} : { accrediting_provider_code: ["Pick an accredited body"] }
+    end
+
+    def build_course
+      @course = Course
+        .where(recruitment_cycle_year: params[:recruitment_cycle_year])
+        .where(provider_code: params[:provider_code])
+        .includes(:accrediting_provider)
+        .find(params[:code])
+        .first
+    end
+
+    def course_params
+      params.require(:course).permit(:accrediting_provider_code)
+    end
+  end
+end

--- a/app/views/courses/accredited_body/edit.html.erb
+++ b/app/views/courses/accredited_body/edit.html.erb
@@ -1,0 +1,59 @@
+<%= content_for :page_title, "Pick an accredited body  – #{course.name_and_code}" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Who is the accredited body?
+    </h1>
+
+    <%= form_with model: course,
+          url: accredited_body_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+          method: :put do |form| %>
+
+      <div class="govuk-form-group">
+        <div class="govuk-radios" data-module="radios" data-qa="course__accredited_body">
+          <% @provider.accredited_bodies.each do |provider| %>
+            <div class="govuk-radios__item">
+              <%= form.radio_button :accrediting_provider_code,
+                                    provider["provider_code"],
+                                    checked: provider["provider_code"] == @course.accrediting_provider&.provider_code,
+                                    class: 'govuk-radios__input' %>
+              <%= form.label :accrediting_provider_code,
+                             provider["provider_name"],
+                             value: provider["provider_code"],
+                             class: 'govuk-label govuk-radios__label' %>
+            </div>
+          <% end %>
+
+        </div>
+      </div>
+
+      <details class="govuk-details govuk-!-margin-bottom-2">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Help with adding a different accredited body
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p class="govuk-body">
+            Contact the Becoming a Teacher team to request a different accredited body: <%= bat_contact_mail_to bat_contact_email_address_with_wrap, subject: "Edit #{@course.name} (#{@provider.provider_code}/#{@course.course_code}) accredited body" %>
+          </p>
+        </div>
+      </details>
+
+      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
+                      class: "govuk-button govuk-!-margin-top-3", data: { qa: 'course__save' } %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes',
+          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,9 @@ Rails.application.routes.draw do
         get '/outcome', on: :member, to: 'courses/outcome#edit'
         put '/outcome', on: :member, to: 'courses/outcome#update'
 
+        get '/accredited-body', on: :member, to: 'courses/accredited_body#edit'
+        put '/accredited-body', on: :member, to: 'courses/accredited_body#update'
+
         get '/age-range', on: :member, to: 'courses/age_range#edit'
         put '/age-range', on: :member, to: 'courses/age_range#update'
 

--- a/spec/features/courses/accredited_body/edit_spec.rb
+++ b/spec/features/courses/accredited_body/edit_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+id_selector = ->(code) { "course_accrediting_provider_code_#{code.downcase}" }
+for_selector = ->(code) { "[for=\"#{id_selector.(code)}\"]" }
+
+feature 'Edit accredited body', type: :feature do
+  let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+  let(:accredited_body_page) { PageObjects::Page::Organisations::CourseAccreditedBody.new }
+  let(:course_details_page) { PageObjects::Page::Organisations::CourseDetails.new }
+  let(:accrediting_provider_1) { build(:provider) }
+  let(:accrediting_provider_2) { build(:provider) }
+  let(:accredited_bodies) {
+    [
+      { "provider_name": accrediting_provider_1.provider_name, "provider_code" => accrediting_provider_1.provider_code },
+      { "provider_name": accrediting_provider_2.provider_name, "provider_code" => accrediting_provider_2.provider_code },
+    ]
+  }
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "accrediting_provider")
+    stub_api_v2_resource(course, include: "sites,provider.sites,accrediting_provider")
+
+    accredited_body_page.load_with_course(course)
+  end
+
+  context 'a course with no accredited body' do
+    let(:provider) { build(:provider) }
+    let(:course) { build(:course, provider: provider) }
+
+    scenario 'can cancel changes' do
+      click_on 'Cancel changes'
+      expect(course_details_page).to be_displayed
+    end
+
+    xscenario 'can navigate to the edit screen and back again' do
+      course_details_page.load_with_course(course)
+      click_on 'Change outcome'
+      expect(accredited_body_page).to be_displayed
+      click_on 'Back'
+      expect(course_details_page).to be_displayed
+    end
+  end
+
+  context 'a course with accredited bodies' do
+    let(:provider) { build(:provider, accredited_bodies: accredited_bodies) }
+    let(:course) do
+      build(
+        :course,
+        provider: provider,
+        accrediting_provider: accrediting_provider_2,
+      )
+    end
+
+    scenario 'presents a choice for each accrediting body' do
+      expect(accredited_body_page).to have_accredited_body_fields
+      expect(accredited_body_page.accredited_body_fields)
+        .to have_selector(
+          for_selector.(accrediting_provider_1.provider_code),
+          text: accrediting_provider_1.provider_name
+        )
+      expect(accredited_body_page.accredited_body_fields)
+        .to have_selector(
+          for_selector.(accrediting_provider_2.provider_code),
+          text: accrediting_provider_2.provider_name
+        )
+    end
+
+    scenario 'has the correct value selected' do
+      expect(accredited_body_page.accredited_body_fields)
+        .to have_field(
+          id_selector.(accrediting_provider_2.provider_code),
+          checked: true
+        )
+    end
+
+    scenario 'can be updated' do
+      update_course_stub = stub_api_v2_request(
+        "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+        "/providers/#{provider.provider_code}" \
+        "/courses/#{course.course_code}",
+        course.to_jsonapi,
+        :patch, 200
+      ).with(body: {
+        data: {
+          course_code: course.course_code,
+          type: "courses",
+          attributes: {
+            accrediting_provider_code: accrediting_provider_1.provider_code,
+          }
+        }
+      }.to_json)
+
+      choose(accrediting_provider_1.provider_name)
+      click_on 'Save'
+
+      expect(course_details_page).to be_displayed
+      expect(course_details_page.flash).to have_content('Your changes have been saved')
+      expect(update_course_stub).to have_been_requested
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/course_accredited_body.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_accredited_body.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseAccreditedBody < CourseBase
+        set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/accredited-body'
+
+        element :accredited_body_fields, '[data-qa="course__accredited_body"]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Basic details editing

https://www2.qa.publish-teacher-training-courses.service.gov.uk/organisations/2FD/2020/courses/35JL/details

![Selection_023](https://user-images.githubusercontent.com/19378/64029981-954ff680-cb3d-11e9-8656-dbfea8a4b3ac.png)


### Changes proposed in this pull request

* Just existing accredited bodies for now; "other" to be added soon.
* This is a hidden feature, no link to it yet.
* Changing to  other providers can be done by support using  the existing contact link on the details page

The new screen:

<img width="860" alt="Screenshot 2019-08-30 at 12 03 55" src="https://user-images.githubusercontent.com/1650875/64016236-53638800-cb1e-11e9-8804-60d99f4cfc5a.png">

### Guidance to review

:ship:

Find the hidden page at `/organisations/2FD/2020/courses/35JL/accredited-body`

