### PR TITLE
[2033] add new page for course applications open

### DIFF
--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -3,6 +3,20 @@ module Courses
     before_action :build_recruitment_cycle
     include CourseBasicDetailConcern
 
+    def continue
+      @errors = errors
+
+      if @errors.present?
+        render :new
+      else
+        redirect_to confirmation_provider_recruitment_cycle_courses_path(
+          params[:provider_code],
+          params[:recruitment_cycle_year],
+          course_params
+        )
+      end
+    end
+
   private
 
     def errors; end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -77,15 +77,15 @@ class Course < Base
   end
 
   def year
-    applications_open_from.split('-').first
+    applications_open_from.split('-').first if applications_open_from.present?
   end
 
   def month
-    applications_open_from.split('-').second
+    applications_open_from.split('-').second if applications_open_from.present?
   end
 
   def day
-    applications_open_from.split('-').third
+    applications_open_from.split('-').third if applications_open_from.present?
   end
 
 private

--- a/app/views/courses/applications_open/_form_fields.html.erb
+++ b/app/views/courses/applications_open/_form_fields.html.erb
@@ -1,0 +1,58 @@
+<div class="govuk-form-group">
+  <div class="govuk-radios govuk-radios--conditional" data-module="radios">
+    <div class="govuk-radios__item">
+      <%= form.radio_button :applications_open_from, @recruitment_cycle.application_start_date,
+            class: 'govuk-radios__input', data: { qa: 'applications_open_from' }
+      %>
+      <%= form.label :applications_open_from, course.applications_open_from_message_for(@recruitment_cycle),
+            for: "course_applications_open_from_#{@recruitment_cycle.application_start_date}",
+            class: 'govuk-label govuk-radios__label'
+      %>
+    </div>
+    <div class="govuk-radios__item">
+      <%= form.radio_button :applications_open_from, 'other',
+            class: 'govuk-radios__input',
+            checked: @course.applications_open_from != @recruitment_cycle.application_start_date,
+            aria: { 'controls': 'other-container' },  data: { qa: 'applications_open_from_other' }
+      %>
+      <%= form.label :applications_open_from,
+            value: 'other',
+            class: 'govuk-label govuk-radios__label'
+      %>
+    </div>
+    <div class="govuk-radios__conditional <%=
+      "govuk-radios__conditional--hidden" unless @course.applications_open_from != @recruitment_cycle.application_start_date
+    %>" id="other-container">
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend">
+            What date will applications open?
+          </legend>
+          <span class="govuk-hint">
+            For example, 31 10 <%= @recruitment_cycle.year %>
+          </span>
+          <div class="govuk-date-input">
+            <div class="govuk-date-input__item">
+              <%= render "shared/form_field",
+                form: form, field: :day do |field, options| %>
+                <%= form.text_field field, options.merge(autocomplete: 'off', class: 'govuk-input govuk-input--width-2') %>
+              <% end %>
+            </div>
+            <div class="govuk-date-input__item">
+              <%= render "shared/form_field",
+                form: form, field: :month do |field, options| %>
+                <%= form.text_field field, options.merge(autocomplete: 'off', class: 'govuk-input govuk-input--width-2') %>
+              <% end %>
+            </div>
+            <div class="govuk-date-input__item">
+              <%= render "shared/form_field",
+                form: form, field: :year do |field, options| %>
+                <%= form.text_field field, options.merge(autocomplete: 'off', class: 'govuk-input govuk-input--width-4') %>
+              <% end %>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/courses/applications_open/_form_fields.html.erb
+++ b/app/views/courses/applications_open/_form_fields.html.erb
@@ -12,7 +12,7 @@
     <div class="govuk-radios__item">
       <%= form.radio_button :applications_open_from, 'other',
             class: 'govuk-radios__input',
-            checked: @course.applications_open_from != @recruitment_cycle.application_start_date,
+            checked: @course.applications_open_from.present? && @course.applications_open_from != @recruitment_cycle.application_start_date,
             aria: { 'controls': 'other-container' },  data: { qa: 'applications_open_from_other' }
       %>
       <%= form.label :applications_open_from,
@@ -21,7 +21,7 @@
       %>
     </div>
     <div class="govuk-radios__conditional <%=
-      "govuk-radios__conditional--hidden" unless @course.applications_open_from != @recruitment_cycle.application_start_date
+      "govuk-radios__conditional--hidden" unless @course.applications_open_from.present? && @course.applications_open_from  != @recruitment_cycle.application_start_date
     %>" id="other-container">
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">

--- a/app/views/courses/applications_open/edit.html.erb
+++ b/app/views/courses/applications_open/edit.html.erb
@@ -12,64 +12,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: course, url: applications_open_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code), method: :put do |form| %>
-      <div class="govuk-form-group">
-        <div class="govuk-radios govuk-radios--conditional" data-module="radios">
-          <div class="govuk-radios__item">
-            <%= form.radio_button :applications_open_from, @recruitment_cycle.application_start_date,
-                  class: 'govuk-radios__input', data: { qa: 'applications_open_from' }
-            %>
-            <%= form.label :applications_open_from, course.applications_open_from_message_for(@recruitment_cycle),
-                  for: "course_applications_open_from_#{@recruitment_cycle.application_start_date}",
-                  class: 'govuk-label govuk-radios__label'
-            %>
-          </div>
-          <div class="govuk-radios__item">
-            <%= form.radio_button :applications_open_from, 'other',
-                  class: 'govuk-radios__input',
-                  checked: @course.applications_open_from != @recruitment_cycle.application_start_date,
-                  aria: { 'controls': 'other-container' },  data: { qa: 'applications_open_from_other' }
-            %>
-            <%= form.label :applications_open_from,
-                  value: 'other',
-                  class: 'govuk-label govuk-radios__label'
-            %>
-          </div>
-          <div class="govuk-radios__conditional <%=
-            "govuk-radios__conditional--hidden" unless @course.applications_open_from != @recruitment_cycle.application_start_date
-          %>" id="other-container">
-            <div class="govuk-form-group">
-              <fieldset class="govuk-fieldset">
-                <legend class="govuk-fieldset__legend">
-                  What date will applications open?
-                </legend>
-                <span class="govuk-hint">
-                  For example, 31 10 <%= @recruitment_cycle.year %>
-                </span>
-                <div class="govuk-date-input">
-                  <div class="govuk-date-input__item">
-                    <%= render "shared/form_field",
-                      form: form, field: :day do |field, options| %>
-                      <%= form.text_field field, options.merge(autocomplete: 'off', class: 'govuk-input govuk-input--width-2') %>
-                    <% end %>
-                  </div>
-                  <div class="govuk-date-input__item">
-                    <%= render "shared/form_field",
-                      form: form, field: :month do |field, options| %>
-                      <%= form.text_field field, options.merge(autocomplete: 'off', class: 'govuk-input govuk-input--width-2') %>
-                    <% end %>
-                  </div>
-                  <div class="govuk-date-input__item">
-                    <%= render "shared/form_field",
-                      form: form, field: :year do |field, options| %>
-                      <%= form.text_field field, options.merge(autocomplete: 'off', class: 'govuk-input govuk-input--width-4') %>
-                    <% end %>
-                  </div>
-                </div>
-              </fieldset>
-            </div>
-          </div>
-        </div>
-      </div>
+
+      <%= render 'form_fields', form: form %>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -1,0 +1,32 @@
+<%= content_for :page_title, "When will applications open?" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(
+                           @provider.provider_code,
+                           @provider.recruitment_cycle_year
+                        )) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<h1 class="govuk-heading-xl" id="applications_open_from-error">
+  When will applications open?
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: course,
+                  url: continue_provider_recruitment_cycle_courses_applications_open_path(
+                    @provider.provider_code,
+                    @provider.recruitment_cycle_year
+                  ),
+                  method: :get do |form| %>
+
+      <%= render 'form_fields', form: form %>
+
+      <%= form.submit "Continue",
+                      class: "govuk-button",
+                      data: { qa: 'course__save' } %>
+
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,9 @@ Rails.application.routes.draw do
         end
         resource :start_date, on: :member, only: %i[new], controller: 'courses/start_date', path: 'start-date' do
           get 'continue'
+          end
+        resource :applications_open, on: :member, only: %i[new], controller: 'courses/applications_open' do
+          get 'continue'
         end
         get 'confirmation'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,8 +54,8 @@ Rails.application.routes.draw do
         end
         resource :start_date, on: :member, only: %i[new], controller: 'courses/start_date', path: 'start-date' do
           get 'continue'
-          end
-        resource :applications_open, on: :member, only: %i[new], controller: 'courses/applications_open' do
+        end
+        resource :applications_open, on: :member, only: %i[new], controller: 'courses/applications_open', path: 'applications-open' do
           get 'continue'
         end
         get 'confirmation'

--- a/spec/features/courses/applications_open/new_spec.rb
+++ b/spec/features/courses/applications_open/new_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+feature 'new course applications open', type: :feature do
+  let(:new_applications_open_page) do
+    PageObjects::Page::Organisations::Courses::NewApplicationsOpenPage.new
+  end
+
+  let(:provider) { build(:provider) }
+  let(:recruitment_cycle) { build(:recruitment_cycle) }
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(provider)
+    new_course = build(:course, :new, provider: provider)
+    stub_api_v2_new_resource(new_course)
+    stub_api_v2_resource(recruitment_cycle)
+    stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
+  end
+
+  scenario "sends user to confirmation page" do
+    visit new_provider_recruitment_cycle_courses_applications_open_path(provider.provider_code, provider.recruitment_cycle_year)
+
+    expect(new_applications_open_page.applications_open_field).to_not be_checked
+    expect(new_applications_open_page.applications_open_field_other).to_not be_checked
+
+    expect(new_applications_open_page.applications_open_field_day.value).to be_nil
+    expect(new_applications_open_page.applications_open_field_month.value).to be_nil
+    expect(new_applications_open_page.applications_open_field_year.value).to be_nil
+
+    expect(new_applications_open_page).to have_applications_open_field
+    expect(new_applications_open_page).to have_applications_open_field_other
+
+    new_applications_open_page.applications_open_field.click
+
+    click_on 'Continue'
+
+    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_applications_open_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_applications_open_page.rb
@@ -1,0 +1,17 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class NewApplicationsOpenPage < CourseBase
+          set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/application_open/new'
+
+          element :applications_open_field, '[data-qa="applications_open_from"]'
+          element :applications_open_field_other, '[data-qa="applications_open_from_other"]'
+          element :applications_open_field_day, '[data-qa="day"]'
+          element :applications_open_field_month, '[data-qa="month"]'
+          element :applications_open_field_year, '[data-qa="year"]'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Creating a new course

### Changes proposed in this pull request
Add new course page for "applications open"

### Guidance to review
Example: `/organisations/2CG/2019/courses/applications-open/new`