### PR TITLE
[2065] Decide whether or not to show edit buttons based on edit options

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -19,7 +19,7 @@
           <%= course.is_send? %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <% unless course.is_published? %>
+          <% if @course.meta['edit_options']['show_is_send'] %>
             <%= link_to send_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_is_send" } do %>
               Change<span class="govuk-visually-hidden"> SEND</span>
             <% end %>
@@ -157,7 +157,7 @@
           <%= l(course.applications_open_from&.to_date) %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <% unless course.is_published? %>
+          <% if @course.meta['edit_options']['show_applications_open'] %>
             <%= link_to applications_open_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_open_applications_link" } do %>
               Change<span class="govuk-visually-hidden"> applications open date</span>
             <% end %>
@@ -173,7 +173,7 @@
           <%= l(course.start_date&.to_date, format: :short) %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <% unless course.is_published? %>
+          <% if @course.meta['edit_options']['show_start_date'] %>
             <%= link_to start_date_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_start_date_link" } do %>
               Change<span class="govuk-visually-hidden"> start date</span>
             <% end %>

--- a/spec/features/courses/applications_open/edit_spec.rb
+++ b/spec/features/courses/applications_open/edit_spec.rb
@@ -23,18 +23,39 @@ feature 'Edit course applications open', type: :feature do
     applications_open_page.load_with_course(course)
   end
 
-  context 'published course' do
-    let(:course) do
-      build(
-        :course,
-        content_status: 'published',
-        provider: provider
-      )
+  context 'editing applications open' do
+    context 'if the backend has indicated that applications open can be edited' do
+      let(:course) do
+        build(
+          :course,
+          edit_options: {
+            show_applications_open: true
+          },
+          provider: provider
+        )
+      end
+
+      scenario 'should show the edit link' do
+        course_details_page.load_with_course(course)
+        expect(course_details_page).to have_edit_open_applications_link
+      end
     end
 
-    scenario 'should not show edit link' do
-      course_details_page.load_with_course(course)
-      expect(course_details_page).to_not have_edit_application_status_link
+    context 'if the backend has indicated that applications open cannot be edited' do
+      let(:course) do
+        build(
+          :course,
+          edit_options: {
+            show_applications_open: false
+          },
+          provider: provider
+        )
+      end
+
+      scenario 'should not show edit link' do
+        course_details_page.load_with_course(course)
+        expect(course_details_page).to_not have_edit_open_applications_link
+      end
     end
   end
 
@@ -45,6 +66,9 @@ feature 'Edit course applications open', type: :feature do
         :course,
         applications_open_from: '2018-10-09',
         content_status: 'draft',
+        edit_options: {
+          show_applications_open: true
+        },
         provider: provider,
         recruitment_cycle: current_recruitment_cycle
       )

--- a/spec/features/courses/send/edit_spec.rb
+++ b/spec/features/courses/send/edit_spec.rb
@@ -23,18 +23,39 @@ feature 'Edit course SEND', type: :feature do
     send_page.load_with_course(course)
   end
 
-  context 'published course' do
-    let(:course) do
-      build(
-        :course,
-        content_status: 'published',
-        provider: provider
-      )
+  context 'editing is send' do
+    context 'if the backend has indicated that is send can be edited' do
+      let(:course) do
+        build(
+          :course,
+          edit_options: {
+            show_is_send: true
+          },
+          provider: provider
+        )
+      end
+
+      scenario 'should show the edit link' do
+        course_details_page.load_with_course(course)
+        expect(course_details_page).to have_edit_is_send_link
+      end
     end
 
-    scenario 'should not show edit link' do
-      course_details_page.load_with_course(course)
-      expect(course_details_page).to_not have_edit_is_send_link
+    context 'if the backend has indicated that is send cannot be edited' do
+      let(:course) do
+        build(
+          :course,
+          edit_options: {
+            show_is_send: false
+          },
+          provider: provider
+        )
+      end
+
+      scenario 'should not show the edit link' do
+        course_details_page.load_with_course(course)
+        expect(course_details_page).to_not have_edit_is_send_link
+      end
     end
   end
 
@@ -45,7 +66,8 @@ feature 'Edit course SEND', type: :feature do
         is_send: '1',
         content_status: 'draft',
         edit_options: {
-          is_send_options: %w[0 1]
+          is_send_options: %w[0 1],
+          show_is_send: true
         },
         provider: provider
       )

--- a/spec/features/courses/start_date/edit_spec.rb
+++ b/spec/features/courses/start_date/edit_spec.rb
@@ -23,18 +23,41 @@ feature 'Edit course start date', type: :feature do
     start_date_page.load_with_course(course)
   end
 
-  context 'published course' do
-    let(:course) do
-      build(
-        :course,
-        content_status: 'published',
-        provider: provider
-      )
+  context 'editing start date' do
+    context 'if the backend has indicated that start date can be edited' do
+      let(:course) do
+        build(
+          :course,
+          edit_options: {
+            show_start_date: true,
+            start_dates: ['October 2019', 'November 2019']
+          },
+          provider: provider
+        )
+      end
+
+      scenario 'should show the edit link' do
+        course_details_page.load_with_course(course)
+        expect(course_details_page).to have_edit_start_date_link
+      end
     end
 
-    scenario 'should not show edit link' do
-      course_details_page.load_with_course(course)
-      expect(course_details_page).to_not have_edit_start_date_link
+    context 'if the backend has indicated that start date cannot be edited' do
+      let(:course) do
+        build(
+          :course,
+          edit_options: {
+            show_start_date: false,
+            start_dates: ['October 2019', 'November 2019']
+          },
+          provider: provider
+        )
+      end
+
+      scenario 'should not show the edit link' do
+        course_details_page.load_with_course(course)
+        expect(course_details_page).to_not have_edit_start_date_link
+      end
     end
   end
 
@@ -45,7 +68,8 @@ feature 'Edit course start date', type: :feature do
         start_date: 'October 2019',
         content_status: 'draft',
         edit_options: {
-          start_dates: ['October 2019', 'November 2019']
+          start_dates: ['October 2019', 'November 2019'],
+          show_start_date: true
         },
         provider: provider
       )

--- a/spec/site_prism/page_objects/page/organisations/course_details.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_details.rb
@@ -19,6 +19,7 @@ module PageObjects
         element :funding, '[data-qa=course__funding]'
         element :accredited_body, '[data-qa=course__accredited_body]'
         element :application_status, '[data-qa=course__application_status]'
+        element :edit_open_applications_link, '[data-qa=course__edit_open_applications_link]'
         element :edit_application_status_link, '[data-qa=course__edit_application_status_link]'
         element :is_send, '[data-qa=course__is_send]'
         element :edit_is_send_link, '[data-qa=course__edit_is_send]'


### PR DESCRIPTION
### Context
Frontend counterpart to https://github.com/DFE-Digital/manage-courses-backend/pull/756  
This PR takes https://github.com/DFE-Digital/manage-courses-frontend/pull/570 and moves the logic into the backend to avoid having multiple sources of truth
  
### Changes proposed in this pull request
Either show or hide edit buttons depending on whether `is_send`, `applications_open_from` and `application_start_date` are enabled.  

### Guidance to review
