### PR TITLE
[2031] Pass course creation parameters through

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -34,13 +34,22 @@ module CourseBasicDetailConcern
 private
 
   def build_new_course
-    @course = Course.build_new(
+    course = Course.build_new(
       recruitment_cycle_year: @provider.recruitment_cycle_year,
       provider_code: @provider.provider_code,
       attrs: {
         course: course_params.to_unsafe_hash
       }
-    ).first
+    )
+
+    @course = if course.errors.any?
+                Course.new(
+                  attributes: course_params.to_h,
+                  meta: { edit_options: course.meta['edit_options'] }
+                )
+              else
+                @course = course.first
+              end
   end
 
   def build_provider
@@ -81,7 +90,7 @@ private
         :science
       )
     else
-      ActionController::Parameters.new({})
+      ActionController::Parameters.new({}).permit(:course)
     end
   end
 

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -4,6 +4,7 @@ module CourseBasicDetailConcern
   included do
     decorates_assigned :course
     before_action :build_provider, :build_new_course, only: %i[new continue]
+    before_action :get_previous_course_creation_params, only: %i[new continue]
     before_action :build_course, only: %i[edit update]
   end
 
@@ -52,5 +53,29 @@ private
       .where(provider_code: params[:provider_code])
       .find(params[:code])
       .first
+  end
+
+  def get_previous_course_creation_params
+    return unless params.has_key?(:course)
+
+    @course_creation_params = params.require(:course).permit(
+      :qualification, :maths, :english, :science
+    )
+  end
+
+  def next_step(current_step:, course_params:)
+    if current_step == :outcome
+      new_provider_recruitment_cycle_courses_entry_requirements_path(
+        params[:provider_code],
+        params[:recruitment_cycle_year],
+        course: course_params
+      )
+    elsif current_step == :entry_requirements
+      new_provider_recruitment_cycle_courses_outcome_path(
+        params[:provider_code],
+        params[:recruitment_cycle_year],
+        course: course_params.merge(@course_creation_params)
+      )
+    end
   end
 end

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -34,10 +34,13 @@ module CourseBasicDetailConcern
 private
 
   def build_new_course
-    @course = Course.fetch_new(
+    @course = Course.build_new(
       recruitment_cycle_year: @provider.recruitment_cycle_year,
-      provider_code: @provider.provider_code
-    )
+      provider_code: @provider.provider_code,
+      attrs: {
+        course: course_params.to_unsafe_hash
+      }
+    ).first
   end
 
   def build_provider
@@ -55,15 +58,40 @@ private
       .first
   end
 
-  def get_previous_course_creation_params
-    return unless params.has_key?(:course)
-
-    @course_creation_params = params.require(:course).permit(
-      :qualification, :maths, :english, :science
-    )
+  def course_params
+    if params.key? :course
+      params.require(:course).permit(
+        :page,
+        :about_course,
+        :course_length,
+        :course_length_other_length,
+        :fee_details,
+        :fee_international,
+        :fee_uk_eu,
+        :financial_support,
+        :how_school_placements_work,
+        :interview_process,
+        :other_requirements,
+        :personal_qualities,
+        :salary_details,
+        :required_qualifications,
+        :qualification, # qualification is actually "outcome"
+        :maths,
+        :english,
+        :science
+      )
+    else
+      ActionController::Parameters.new({})
+    end
   end
 
-  def next_step(current_step:, course_params:)
+  def get_previous_course_creation_params
+    @course_creation_params = {} unless params.has_key?(:course)
+
+    @course_creation_params = course_params
+  end
+
+  def next_step(current_step:)
     if current_step == :outcome
       new_provider_recruitment_cycle_courses_entry_requirements_path(
         params[:provider_code],
@@ -74,7 +102,7 @@ private
       new_provider_recruitment_cycle_courses_outcome_path(
         params[:provider_code],
         params[:recruitment_cycle_year],
-        course: course_params.merge(@course_creation_params)
+        course: course_params
       )
     end
   end

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -86,8 +86,6 @@ private
   end
 
   def get_previous_course_creation_params
-    @course_creation_params = {} unless params.has_key?(:course)
-
     @course_creation_params = course_params
   end
 

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -4,7 +4,7 @@ module CourseBasicDetailConcern
   included do
     decorates_assigned :course
     before_action :build_provider, :build_new_course, only: %i[new continue]
-    before_action :get_previous_course_creation_params, only: %i[new continue]
+    before_action :build_previous_course_creation_params, only: %i[new continue]
     before_action :build_course, only: %i[edit update]
   end
 
@@ -94,7 +94,7 @@ private
     end
   end
 
-  def get_previous_course_creation_params
+  def build_previous_course_creation_params
     @course_creation_params = course_params
   end
 

--- a/app/controllers/courses/age_range_controller.rb
+++ b/app/controllers/courses/age_range_controller.rb
@@ -73,10 +73,10 @@ module Courses
     end
 
     def build_new_course
-      @course = Course.fetch_new(
+      @course = Course.build_new(
         recruitment_cycle_year: @provider.recruitment_cycle_year,
         provider_code: @provider.provider_code
-      )
+      ).first
     end
   end
 end

--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -31,16 +31,17 @@ module Courses
     end
 
     def course_params
-      applications_open_from =
-        if actual_params['applications_open_from'] == 'other'
-          "#{actual_params['year']}-#{actual_params['month']}-#{actual_params['day']}"
-        else
-          actual_params['applications_open_from']
-        end
-
-      {
-        applications_open_from: applications_open_from
-      }
+      if params.key?(:course)
+        applications_open_from =
+          if actual_params['applications_open_from'] == 'other'
+            "#{actual_params['year']}-#{actual_params['month']}-#{actual_params['day']}"
+          else
+            actual_params['applications_open_from']
+          end
+        ActionController::Parameters.new(applications_open_from: applications_open_from).permit(:applications_open_from)
+      else
+        ActionController::Parameters.new({}).permit
+      end
     end
 
     def build_recruitment_cycle

--- a/app/controllers/courses/apprenticeship_controller.rb
+++ b/app/controllers/courses/apprenticeship_controller.rb
@@ -15,7 +15,11 @@ module Courses
     def errors; end
 
     def course_params
-      params.require(:course).permit(:program_type)
+      if params.key?(:course)
+        params.require(:course).permit(:program_type)
+      else
+        ActionController::Parameters.new({}).permit
+      end
     end
   end
 end

--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -5,10 +5,9 @@ module Courses
     before_action :not_found_if_no_gcse_subjects_required, except: :continue
 
     def continue
-      redirect_to new_provider_recruitment_cycle_courses_outcome_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course_params
+      redirect_to next_step(
+        current_step: :entry_requirements,
+        course_params: course_params.merge(@course_creation_params)
       )
     end
 

--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -5,10 +5,7 @@ module Courses
     before_action :not_found_if_no_gcse_subjects_required, except: :continue
 
     def continue
-      redirect_to next_step(
-        current_step: :entry_requirements,
-        course_params: course_params.merge(@course_creation_params)
-      )
+      redirect_to next_step(current_step: :entry_requirements)
     end
 
   private
@@ -18,14 +15,6 @@ module Courses
         .reject { |subject| params.dig(:course, subject) }
         .map { |subject| [subject.to_sym, ["Pick an option for #{subject.titleize}"]] }
         .to_h
-    end
-
-    def course_params
-      params.require(:course).permit(
-        :maths,
-        :english,
-        :science
-      )
     end
 
     def not_found_if_no_gcse_subjects_required

--- a/app/controllers/courses/level_controller.rb
+++ b/app/controllers/courses/level_controller.rb
@@ -21,7 +21,11 @@ module Courses
     def errors; end
 
     def course_params
-      params.require(:course).permit(:level, :is_send)
+      if params.key?(:course)
+        params.require(:course).permit(:level, :is_send)
+      else
+        ActionController::Parameters.new({}).permit
+      end
     end
   end
 end

--- a/app/controllers/courses/outcome_controller.rb
+++ b/app/controllers/courses/outcome_controller.rb
@@ -8,10 +8,7 @@ module Courses
       if @errors.present?
         render :new
       else
-        redirect_to next_step(
-          current_step: :outcome,
-          course_params: course_params.merge(@course_creation_params)
-        )
+        redirect_to next_step(current_step: :outcome)
       end
     end
 
@@ -19,10 +16,6 @@ module Courses
 
     def errors
       params.dig(:course, :qualification) ? {} : { qualification: ["Pick an outcome"] }
-    end
-
-    def course_params
-      params.require(:course).permit(:qualification)
     end
   end
 end

--- a/app/controllers/courses/outcome_controller.rb
+++ b/app/controllers/courses/outcome_controller.rb
@@ -8,10 +8,9 @@ module Courses
       if @errors.present?
         render :new
       else
-        redirect_to new_provider_recruitment_cycle_courses_entry_requirements_path(
-          params[:provider_code],
-          params[:recruitment_cycle_year],
-          course_params
+        redirect_to next_step(
+          current_step: :outcome,
+          course_params: course_params.merge(@course_creation_params)
         )
       end
     end

--- a/app/controllers/courses/start_date_controller.rb
+++ b/app/controllers/courses/start_date_controller.rb
@@ -21,7 +21,11 @@ module Courses
     def errors; end
 
     def course_params
-      params.require(:course).permit(:start_date)
+      if params.key?(:course)
+        params.require(:course).permit(:start_date)
+      else
+        ActionController::Parameters.new({}).permit
+      end
     end
   end
 end

--- a/app/controllers/courses/study_mode_controller.rb
+++ b/app/controllers/courses/study_mode_controller.rb
@@ -31,7 +31,11 @@ module Courses
     end
 
     def course_params
-      params.require(:course).permit(:study_mode)
+      if params.key?(:course)
+        params.require(:course).permit(:study_mode)
+      else
+        ActionController::Parameters.new({}).permit
+      end
     end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -5,24 +5,15 @@ class Course < Base
   has_many :sites, through: :site_statuses, source: :site
 
   custom_endpoint :sync_with_search_and_compare, on: :member, request_method: :post
+  custom_endpoint :build_new, on: :collection, request_method: :get
 
   property :fee_international, type: :string
   property :fee_uk_eu, type: :string
+  property :maths, type: :string
+  property :english, type: :string
+  property :science, type: :string
 
   self.primary_key = :course_code
-
-  # Fetch a "new" record from the backend API.
-  def self.fetch_new(recruitment_cycle_year:, provider_code:)
-    # Using .find(:new) here is a little bit hacky, but this is the only way I
-    # could find to construct the URL with `.../courses/new` at the end, and at
-    # the end of the day jsonapi defines ids as being strings so it's in no way
-    # invalid. If we can find a way to use custom endpoints or other to improve
-    # this we should.
-    Course.where(recruitment_cycle_year: recruitment_cycle_year,
-                 provider_code: provider_code)
-      .find(:new)
-      .first
-  end
 
   def publish
     post_request('/publish')

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -34,7 +34,11 @@
                   method: :get do |form| %>
 
 
-      <%= form.hidden_field(:qualification, value: @course_creation_params['qualification']) %>
+      <%= render 'shared/course_creation_hidden_fields',
+        form: form,
+        course_creation_params: @course_creation_params,
+        except_keys: [:maths, :english, :science]
+      %>
       <%= render 'form_fields', form: form, gcse_subjects_required: course.gcse_subjects_required %>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -26,16 +26,15 @@
     <p class="govuk-body govuk-!-margin-bottom-8">
       The codes you pick determine how flexible you are towards those candidates.
     </p>
-
     <%= form_with model: course,
                   url: continue_provider_recruitment_cycle_courses_entry_requirements_path(
                     @provider.provider_code,
-                    @provider.recruitment_cycle_year,
-                    course: @course_creation_params
+                    @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
 
 
+      <%= form.hidden_field(:qualification, value: @course_creation_params['qualification']) %>
       <%= render 'form_fields', form: form, gcse_subjects_required: course.gcse_subjects_required %>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -30,7 +30,8 @@
     <%= form_with model: course,
                   url: continue_provider_recruitment_cycle_courses_entry_requirements_path(
                     @provider.provider_code,
-                    @provider.recruitment_cycle_year
+                    @provider.recruitment_cycle_year,
+                    course: @course_creation_params
                   ),
                   method: :get do |form| %>
 

--- a/app/views/courses/level/_form_fields.html.erb
+++ b/app/views/courses/level/_form_fields.html.erb
@@ -1,4 +1,5 @@
-<div class="govuk-form-group ">
+<div class="govuk-form-group"
+  data-qa="course__level">
   <div class="govuk-radios govuk-radios" data-module="radios">
     <% %i[primary secondary further_education].each do |level| %>
       <div class="govuk-radios__item">

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -17,10 +17,11 @@
                   ),
                   method: :get do |form| %>
 
-      <%= form.hidden_field(:maths, value: @course_creation_params['maths']) unless @course_creation_params['maths'].nil? %>
-      <%= form.hidden_field(:english, value: @course_creation_params['english']) unless @course_creation_params['english'].nil? %>
-      <%= form.hidden_field(:science, value: @course_creation_params['science']) unless @course_creation_params['science'].nil? %>
-
+      <%= render 'shared/course_creation_hidden_fields',
+        form: form,
+        course_creation_params: @course_creation_params,
+        except_keys: [:qualification]
+      %>
       <%= render 'form_fields', form: form, course_name_and_code: nil %>
 
       <%= form.submit "Continue",

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -13,7 +13,8 @@
     <%= form_with model: course,
                   url: continue_provider_recruitment_cycle_courses_outcome_path(
                     @provider.provider_code,
-                    @provider.recruitment_cycle_year
+                    @provider.recruitment_cycle_year,
+                    course: @course_creation_params
                   ),
                   method: :get do |form| %>
 

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -13,10 +13,13 @@
     <%= form_with model: course,
                   url: continue_provider_recruitment_cycle_courses_outcome_path(
                     @provider.provider_code,
-                    @provider.recruitment_cycle_year,
-                    course: @course_creation_params
+                    @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
+
+      <%= form.hidden_field(:maths, value: @course_creation_params['maths']) unless @course_creation_params['maths'].nil? %>
+      <%= form.hidden_field(:english, value: @course_creation_params['english']) unless @course_creation_params['english'].nil? %>
+      <%= form.hidden_field(:science, value: @course_creation_params['science']) unless @course_creation_params['science'].nil? %>
 
       <%= render 'form_fields', form: form, course_name_and_code: nil %>
 

--- a/app/views/shared/_course_creation_hidden_fields.html.erb
+++ b/app/views/shared/_course_creation_hidden_fields.html.erb
@@ -1,0 +1,4 @@
+<% course_creation_params.except(*except_keys).each do |k, v| %>
+  <%= form.hidden_field(k, value: v) %>
+<% end %>
+

--- a/spec/features/courses/age_range_in_years/new_spec.rb
+++ b/spec/features/courses/age_range_in_years/new_spec.rb
@@ -6,7 +6,15 @@ feature 'new course outcome', type: :feature do
   end
   let(:provider) { build(:provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
-  let(:course) { build(:course, provider: provider) }
+  let(:course) do
+    build(:course,
+          :new,
+          provider: provider,
+          level: 'primary',
+          edit_options: {
+            age_range_in_years: %w[3_to_7 5_to_11 7_to_11 7_to_14]
+          })
+  end
 
   before do
     stub_omniauth
@@ -21,6 +29,7 @@ feature 'new course outcome', type: :feature do
     stub_api_v2_new_resource(new_course)
     stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_build_course
   end
 
   scenario "sends user to entry requirements" do

--- a/spec/features/courses/applications_open/new_spec.rb
+++ b/spec/features/courses/applications_open/new_spec.rb
@@ -6,15 +6,16 @@ feature 'new course applications open', type: :feature do
   end
 
   let(:provider) { build(:provider) }
+  let(:course) { build(:course, :new, provider: provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
   before do
     stub_omniauth
     stub_api_v2_resource(provider)
-    new_course = build(:course, :new, provider: provider)
-    stub_api_v2_new_resource(new_course)
     stub_api_v2_resource(recruitment_cycle)
-    stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_build_course
+    stub_api_v2_build_course(applications_open_from: '2018-10-09')
   end
 
   scenario "sends user to confirmation page" do

--- a/spec/features/courses/apprenticeship/new_spec.rb
+++ b/spec/features/courses/apprenticeship/new_spec.rb
@@ -4,16 +4,17 @@ feature 'new course apprenticeship', type: :feature do
   let(:new_apprenticeship_page) do
     PageObjects::Page::Organisations::Courses::NewApprenticeshipPage.new
   end
+  let(:course) { build(:course, :new, provider: provider) }
   let(:provider) { build(:provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
   before do
     stub_omniauth
     stub_api_v2_resource(provider)
-    new_course = build(:course, :new, provider: provider)
-    stub_api_v2_new_resource(new_course)
     stub_api_v2_resource(recruitment_cycle)
-    stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_build_course
+    stub_api_v2_build_course(program_type: 'higher_education_programme')
   end
 
   scenario "sends user to entry requirements" do

--- a/spec/features/courses/entry_requirements/new_spec.rb
+++ b/spec/features/courses/entry_requirements/new_spec.rb
@@ -7,12 +7,13 @@ feature 'new course entry_requirements', type: :feature do
   end
   let(:provider) { build(:provider) }
   let(:level) { :further_education }
+  let(:course)  { build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true) }
 
   before do
     stub_omniauth
     stub_api_v2_resource(provider)
-    new_course = build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true)
-    stub_api_v2_new_resource(new_course)
+    stub_api_v2_new_resource(course)
+    stub_api_v2_build_course
   end
 
   context 'level further_education' do
@@ -27,6 +28,10 @@ feature 'new course entry_requirements', type: :feature do
 
   context 'level primary' do
     let(:level) { :primary }
+    before do
+      stub_api_v2_build_course(maths: 'expect_to_achieve_before_training_begins')
+    end
+
     scenario 'creating a new course' do
       visit new_provider_recruitment_cycle_courses_entry_requirements_path(
         provider.provider_code,
@@ -65,6 +70,9 @@ feature 'new course entry_requirements', type: :feature do
 
   context 'level secondary' do
     let(:level) { :secondary }
+    before do
+      stub_api_v2_build_course(english: 'expect_to_achieve_before_training_begins')
+    end
     scenario 'creating a new course' do
       visit new_provider_recruitment_cycle_courses_entry_requirements_path(
         provider.provider_code,

--- a/spec/features/courses/level/new_spec.rb
+++ b/spec/features/courses/level/new_spec.rb
@@ -5,13 +5,14 @@ feature 'New course level', type: :feature do
     PageObjects::Page::Organisations::Courses::NewLevelPage.new
   end
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, provider: provider, level: :primary) }
+  let(:course) { build(:course, :new, provider: provider, gcse_subjects_required_using_level: true) }
 
   before do
     stub_omniauth
     stub_api_v2_resource(provider)
-    new_course = build(:course, :new, provider: provider, gcse_subjects_required_using_level: true)
-    stub_api_v2_new_resource(new_course)
+    stub_api_v2_new_resource(course)
+    stub_api_v2_build_course
+    stub_api_v2_build_course(is_send: 0, level: 'secondary')
   end
 
   scenario "sends user to entry requirements" do

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature 'new course', :focus, type: :feature do
+feature 'new course', type: :feature do
   let(:recruitment_cycle) { build(:recruitment_cycle) }
   let(:new_level_page) do
     PageObjects::Page::Organisations::Courses::NewLevelPage.new

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -11,28 +11,24 @@ feature 'new course', type: :feature do
   let(:new_entry_requirements_page) do
     PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new
   end
-  let(:build_new_course_request) { stub_build_course_request(initial_params) }
+  let(:build_new_course_request) { stub_api_v2_build_course }
   let(:build_new_course_with_outcome_request) do
-    stub_build_course_request(initial_params.merge('attrs[course][qualification]' => 'qts'))
+    stub_api_v2_build_course('qualification' => 'qts')
   end
   let(:build_new_course_with_outcome_and_entry_requirements_request) do
-    stub_build_course_request(
-      initial_params.merge(
-        'attrs[course][qualification]' => 'qts',
-        'attrs[course][english]' => 'must_have_qualification_at_application_time',
-        'attrs[course][maths]' => 'must_have_qualification_at_application_time',
-        'attrs[course][science]' => 'must_have_qualification_at_application_time'
-      )
+    stub_api_v2_build_course(
+      'qualification' => 'qts',
+      'english' => 'must_have_qualification_at_application_time',
+      'maths' => 'must_have_qualification_at_application_time',
+      'science' => 'must_have_qualification_at_application_time'
     )
   end
   let(:build_new_course_with_outcome_2_and_entry_requirements_request) do
-    stub_build_course_request(
-      initial_params.merge(
-        'attrs[course][qualification]' => 'pgce_with_qts',
-        'attrs[course][english]' => 'must_have_qualification_at_application_time',
-        'attrs[course][maths]' => 'must_have_qualification_at_application_time',
-        'attrs[course][science]' => 'must_have_qualification_at_application_time'
-      )
+    stub_api_v2_build_course(
+      'qualification' => 'pgce_with_qts',
+      'english' => 'must_have_qualification_at_application_time',
+      'maths' => 'must_have_qualification_at_application_time',
+      'science' => 'must_have_qualification_at_application_time'
     )
   end
   let(:provider) { build(:provider) }
@@ -163,20 +159,5 @@ private
       provider_code: provider.provider_code,
       recruitment_cycle_year: provider.recruitment_cycle_year
     }
-  end
-
-  def stub_build_course_request(params)
-    stub_api_v2_request(
-      build_course_request_url(params),
-      course.to_jsonapi
-    )
-  end
-
-  def build_course_request_url(params)
-    base_url = "/recruitment_cycles/#{provider.recruitment_cycle_year}" \
-      "/providers/#{provider.provider_code}/courses/build_new?"
-    url_params = params.map { |k, v| "#{k}=#{v}" }.join("&")
-
-    base_url + url_params
   end
 end

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature 'new course', type: :feature do
+feature 'new course', :focus, type: :feature do
   let(:recruitment_cycle) { build(:recruitment_cycle) }
   let(:new_level_page) do
     PageObjects::Page::Organisations::Courses::NewLevelPage.new
@@ -36,9 +36,7 @@ feature 'new course', type: :feature do
     build :course,
           :new,
           provider: provider,
-          recruitment_cycle: recruitment_cycle,
-          level: :primary,
-          gcse_subjects_required_using_level: true
+          gcse_subjects_required: %w[maths science english]
   end
 
   before do

--- a/spec/features/courses/outcome/new_spec.rb
+++ b/spec/features/courses/outcome/new_spec.rb
@@ -4,6 +4,9 @@ feature 'new course outcome', type: :feature do
   let(:new_outcome_page) do
     PageObjects::Page::Organisations::Courses::NewOutcomePage.new
   end
+  let(:new_entry_requirements_page) do
+    PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new
+  end
   let(:provider) { build(:provider) }
   let(:course) { build(:course, provider: provider) }
 
@@ -14,13 +17,24 @@ feature 'new course outcome', type: :feature do
     stub_api_v2_new_resource(new_course)
   end
 
-  scenario "sends user to entry requirements" do
-    visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
-    "/courses/outcome/new"
+  context 'Selecting QTS' do
+    before do
+      visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
+      "/courses/outcome/new"
 
-    choose('course_qualification_qts')
-    click_on 'Continue'
+      choose('course_qualification_qts')
+      click_on 'Continue'
+    end
 
-    expect(current_path).to eq new_provider_recruitment_cycle_courses_entry_requirements_path(provider.provider_code, provider.recruitment_cycle_year)
+    scenario "sends user to entry requirements" do
+      expect(new_entry_requirements_page).to be_displayed(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year
+      )
+    end
+
+    scenario "stores the qualification in the URL" do
+      expect(new_entry_requirements_page.url_matches['query']).to eq('course[qualification]' => 'qts')
+    end
   end
 end

--- a/spec/features/courses/outcome/new_spec.rb
+++ b/spec/features/courses/outcome/new_spec.rb
@@ -9,22 +9,28 @@ feature 'new course outcome', type: :feature do
   end
   let(:provider) { build(:provider) }
   let(:course) { build(:course, provider: provider) }
+  let(:empty_build_course_request) { stub_api_v2_build_course }
+  let(:build_course_with_qualification_request) { stub_api_v2_build_course(qualification: 'qts') }
 
   before do
     stub_omniauth
     stub_api_v2_resource(provider)
     new_course = build(:course, :new, provider: provider, gcse_subjects_required_using_level: true)
     stub_api_v2_new_resource(new_course)
-    stub_api_v2_build_course
-    stub_api_v2_build_course(qualification: 'qts')
-    # TODO test build course stuff
+    empty_build_course_request
+    build_course_with_qualification_request
+
+    visit_new_outcome_page
+  end
+
+  context 'Loading the page' do
+    scenario 'It builds the course on the backend' do
+      expect(empty_build_course_request).to have_been_made
+    end
   end
 
   context 'Selecting QTS' do
     before do
-      visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
-      "/courses/outcome/new"
-
       choose('course_qualification_qts')
       click_on 'Continue'
     end
@@ -39,5 +45,16 @@ feature 'new course outcome', type: :feature do
     scenario "stores the qualification in the URL" do
       expect(new_entry_requirements_page.url_matches['query']).to eq('course[qualification]' => 'qts')
     end
+
+    scenario "it builds the course with the qualification" do
+      expect(build_course_with_qualification_request).to have_been_made.at_least_once
+    end
+  end
+
+private
+
+  def visit_new_outcome_page
+    visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
+    "/courses/outcome/new"
   end
 end

--- a/spec/features/courses/outcome/new_spec.rb
+++ b/spec/features/courses/outcome/new_spec.rb
@@ -15,6 +15,9 @@ feature 'new course outcome', type: :feature do
     stub_api_v2_resource(provider)
     new_course = build(:course, :new, provider: provider, gcse_subjects_required_using_level: true)
     stub_api_v2_new_resource(new_course)
+    stub_api_v2_build_course
+    stub_api_v2_build_course(qualification: 'qts')
+    # TODO test build course stuff
   end
 
   context 'Selecting QTS' do

--- a/spec/features/courses/start_date/new_spec.rb
+++ b/spec/features/courses/start_date/new_spec.rb
@@ -3,15 +3,16 @@ require "rails_helper"
 feature 'New course start date', type: :feature do
   let(:recruitment_cycle) { build(:recruitment_cycle) }
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, provider: provider) }
+  let(:course) { build(:course, :new, provider: provider) }
 
   before do
     stub_omniauth
     stub_api_v2_resource(provider)
-    new_course = build(:course, :new, provider: provider)
-    stub_api_v2_new_resource(new_course)
+    stub_api_v2_new_resource(course)
     stub_api_v2_resource(recruitment_cycle)
-    stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_build_course
+    stub_api_v2_build_course(start_date: 'September 2019')
   end
 
   scenario "choose coure start date" do

--- a/spec/features/courses/study_mode/new_spec.rb
+++ b/spec/features/courses/study_mode/new_spec.rb
@@ -5,16 +5,17 @@ feature 'new course study mode', type: :feature do
     PageObjects::Page::Organisations::Courses::NewStudyModePage.new
   end
 
+  let(:course) { build(:course, :new, provider: provider) }
   let(:provider) { build(:provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
   before do
     stub_omniauth
     stub_api_v2_resource(provider)
-    new_course = build(:course, :new, provider: provider)
-    stub_api_v2_new_resource(new_course)
     stub_api_v2_resource(recruitment_cycle)
-    stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_build_course
+    stub_api_v2_build_course(study_mode: 'full_time_or_part_time')
   end
 
   scenario "sends user to confirmation page" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,30 +1,29 @@
 require "rails_helper"
 
 describe Course do
-  describe '#fetch_new' do
+  describe '#build_new' do
     let(:provider)          { build :provider }
     let(:course)            { build :course, :new, provider: provider }
     let(:recruitment_cycle) { course.recruitment_cycle }
-    let(:new_resource_stub) { stub_api_v2_new_resource(course) }
+    let(:build_course_stub) { stub_api_v2_build_course }
 
     before do
       allow(Thread.current).to receive(:fetch).and_return('token')
 
       stub_omniauth
-      new_resource_stub
+      build_course_stub
     end
 
     let(:fetched_new_course) do
-      Course.fetch_new(
+      Course.build_new(
         recruitment_cycle_year: recruitment_cycle.year,
         provider_code: provider.provider_code
-      )
+      ).first
     end
 
     it 'makes a request to the api' do
       fetched_new_course
-
-      expect(new_resource_stub).to have_been_requested
+      expect(build_course_stub).to have_been_requested
     end
 
     it 'returns the result' do

--- a/spec/requests/courses/outcome/new_spec.rb
+++ b/spec/requests/courses/outcome/new_spec.rb
@@ -17,6 +17,7 @@ describe '/organisations/:provider_code/:year/courses/:course_code/outcome/new',
     new_course = build(:course, :new, provider: provider)
     stub_api_v2_new_resource(new_course)
     stub_api_v2_resource_collection([course])
+    stub_api_v2_build_course
   end
 
   it 'renders the new outcome page' do

--- a/spec/site_prism/page_objects/page/organisations/courses/new_entry_requirements_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_entry_requirements_page.rb
@@ -3,11 +3,13 @@ module PageObjects
     module Organisations
       module Courses
         class NewEntryRequirementsPage < CourseBase
-          set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/entry-requirements/new'
+          set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/entry-requirements/new{?query*}'
 
           element :maths_requirements,   '[data-qa="course__maths"]'
           element :english_requirements, '[data-qa="course__english"]'
           element :science_requirements, '[data-qa="course__science"]'
+
+          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_level_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_level_page.rb
@@ -4,6 +4,14 @@ module PageObjects
       module Courses
         class NewLevelPage < CourseBase
           set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/level/new'
+
+          section :level_fields, '[data-qa="course__level"]' do
+            element :primary,           '#course_level_primary'
+            element :secondary,         '#course_level_secondary'
+            element :further_education, '#course_level_further_education'
+          end
+
+          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_outcome_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_outcome_page.rb
@@ -3,7 +3,7 @@ module PageObjects
     module Organisations
       module Courses
         class NewOutcomePage < CourseBase
-          set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/outcome/new'
+          set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/outcome/new{?query*}'
 
           section :qualification_fields, '[data-qa="course__qualification"]' do
             element :qts,           '#course_qualification_qts'
@@ -11,6 +11,8 @@ module PageObjects
             element :pgce_with_qts, '#course_qualification_pgce_with_qts'
             element :pgde_with_qts, '#course_qualification_pgde_with_qts'
           end
+
+          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -94,6 +94,13 @@ module Helpers
     stub_api_v2_request(url, jsonapi_response)
   end
 
+  def stub_api_v2_build_course(params = {})
+    stub_api_v2_request(
+      url_for_build_course_with_params(params),
+      course.to_jsonapi
+    )
+  end
+
 private
 
   def url_for_resource(resource)
@@ -121,6 +128,17 @@ private
   def url_for_new_resource(resource)
     base_url = url_for_resource_collection(resource)
     "#{base_url}/new"
+  end
+
+  def url_for_build_course_with_params(params)
+    provider_code = provider.provider_code
+    recruitment_cycle_year = provider.recruitment_cycle_year
+    url = "/recruitment_cycles/#{recruitment_cycle_year}" \
+      "/providers/#{provider_code}/courses/build_new?" \
+      "provider_code=#{provider_code}&recruitment_cycle_year=#{recruitment_cycle_year}&"
+
+    url_params = params.map { |k, v| "attrs[course][#{k}]=#{v}" }.join("&")
+    url + url_params
   end
 end
 


### PR DESCRIPTION
### Context

In order to support the course creation flow, we need to pass parameters through between pages, and integrate with the `build_new` endpoint on the API

### Changes proposed in this pull request

- Pass parameters through from `outcome` -> `entry requirements`
  - Use hidden fields to continually carry them through
- Call `build_new` on `new` and `continue` actions to validate against the backend

### Guidance to review
Running locally:

- Check out this branch
- Check out https://github.com/DFE-Digital/manage-courses-backend/pull/777 on the backend
  - (As of writing this will error on the `entry_requirements` page as the course will be invalid
- Go to `organisations/<provide_code>/2020/courses/new` and fill in an outcome
  - See the param get passed as a get param to the next page