### PR TITLE
[xxxx] Replaced chromedriver-helper with webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,8 +106,8 @@ group :test do
   gem 'capybara', '>= 2.15'
 
   gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+
+  gem 'webdrivers', '~> 4.0'
 
   # Add Junit formatter for rspec
   gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,8 +50,6 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.0.1)
     application_insights (0.5.6)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     attr_required (1.0.1)
@@ -79,9 +77,6 @@ GEM
       xpath (~> 3.2)
     childprocess (2.0.0)
       rake (< 13.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     config (2.0.0)
@@ -177,7 +172,6 @@ GEM
     httpclient (2.8.3)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.3)
     json (2.2.0)
     json-jwt (1.10.2)
@@ -407,6 +401,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webfinger (1.1.0)
       activesupport
       httpclient (>= 2.4)
@@ -435,7 +433,6 @@ DEPENDENCIES
   byebug
   canonical-rails
   capybara (>= 2.15)
-  chromedriver-helper
   config
   draper
   factory_bot_rails
@@ -474,6 +471,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers (~> 4.0)
   webmock
   webpacker
 


### PR DESCRIPTION
### Context
WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.

### Changes proposed in this pull request
Replaced chromedriver-helper with webdrivers

### Guidance to review
no more 

WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.

`bundle install`
`bundle exec rake`
