### PR TITLE
[2053] Add nojs provider search

### DIFF
--- a/app/controllers/courses/accredited_body_controller.rb
+++ b/app/controllers/courses/accredited_body_controller.rb
@@ -5,10 +5,56 @@ module Courses
     before_action :build_provider
     decorates_assigned :provider
 
+    def update
+      @errors = errors
+      return render :edit if @errors.present?
+
+      if course_params[:accrediting_provider_code] == 'other'
+        redirect_to(
+          accredited_body_search_provider_recruitment_cycle_course_path(
+            @course.provider_code,
+            @course.recruitment_cycle_year,
+            @course.course_code,
+            query: course_params[:accredited_body]
+          )
+        )
+      elsif @course.update(course_params)
+        flash[:success] = 'Your changes have been saved'
+        redirect_to(
+          details_provider_recruitment_cycle_course_path(
+            @course.provider_code,
+            @course.recruitment_cycle_year,
+            @course.course_code
+          )
+        )
+      else
+        @errors = @course.errors.messages
+        render :edit
+      end
+    end
+
+    def search
+      build_course
+      @query = params[:query]
+      @provider_suggestions = ProviderSuggestion.suggest(@query)
+    rescue JsonApiClient::Errors::ClientError => e
+      @errors = e
+    end
+
   private
 
     def errors
-      params.dig(:course, :accrediting_provider_code) ? {} : { accrediting_provider_code: ["Pick an accredited body"] }
+      code = course_params[:accrediting_provider_code]
+      query = course_params[:accredited_body]
+      errors = {}
+
+      if code == 'other' && query.length < 3
+        errors = { accredited_body: ["Accredited body search too short, enter 2 or more characters"] }
+      elsif code.nil?
+        errors = { accrediting_provider_code: ["Pick an accredited body"] }
+      end
+
+      errors
     end
 
     def build_course
@@ -21,7 +67,9 @@ module Courses
     end
 
     def course_params
-      params.require(:course).permit(:accrediting_provider_code)
+      params.require(:course).permit(
+        :accrediting_provider_code, :accredited_body
+      )
     end
   end
 end

--- a/app/models/provider_suggestion.rb
+++ b/app/models/provider_suggestion.rb
@@ -1,0 +1,7 @@
+class ProviderSuggestion < Base
+  def self.suggest(query)
+    self.requestor.__send__(
+      :request, :get, "/api/v2/providers/suggest?query=#{query}"
+    )
+  end
+end

--- a/app/views/courses/accredited_body/_provider_search_field.html.erb
+++ b/app/views/courses/accredited_body/_provider_search_field.html.erb
@@ -1,0 +1,12 @@
+<div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:accredited_body]&.any?) %>">
+  <%= form.label :accredited_body,
+    for: 'course_accredited_body',
+    class: 'govuk-label' do %>
+    Name of accredited body
+    <%= render "shared/error_messages", field: :accredited_body %>
+    <span class="govuk-hint">Enter the name or provider code</span>
+  <% end %>
+  <%= form.text_field :accredited_body,
+    autocomplete: 'off',
+    class: 'govuk-input govuk-input govuk-!-width-two-thirds' %>
+</div>

--- a/app/views/courses/accredited_body/_provider_suggestion.html.erb
+++ b/app/views/courses/accredited_body/_provider_suggestion.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-radios__item" data-qa="course__accredited_body_option">
+  <%= form.radio_button :accrediting_provider_code,
+    provider_suggestion["provider_code"],
+    checked: provider_suggestion["provider_code"] == @course.accrediting_provider&.provider_code,
+    class: 'govuk-radios__input' %>
+  <%= form.label :accrediting_provider_code,
+    "#{provider_suggestion["provider_name"]} (#{provider_suggestion["provider_code"]})",
+    value: provider_suggestion["provider_code"],
+    class: 'govuk-label govuk-radios__label' %>
+</div>

--- a/app/views/courses/accredited_body/edit.html.erb
+++ b/app/views/courses/accredited_body/edit.html.erb
@@ -1,6 +1,10 @@
 <%= content_for :page_title, "Pick an accredited body  – #{course.name_and_code}" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+  <%= govuk_back_link_to(
+    details_provider_recruitment_cycle_course_path(
+      course.provider_code,
+      course.recruitment_cycle_year,
+      course.course_code)) %>
 <% end %>
 
 <%= render 'shared/errors' %>
@@ -12,46 +16,52 @@
     </h1>
 
     <%= form_with model: course,
-          url: accredited_body_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
-          method: :put do |form| %>
+      url: accredited_body_provider_recruitment_cycle_course_path(
+        @course.provider_code,
+        @course.recruitment_cycle_year,
+        @course.course_code),
+      method: :put do |form| %>
 
-      <div class="govuk-form-group">
-        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_body">
-          <% provider.accredited_bodies.each do |provider| %>
-            <div class="govuk-radios__item">
-              <%= form.radio_button :accrediting_provider_code,
-                                    provider["provider_code"],
-                                    checked: provider["provider_code"] == @course.accrediting_provider&.provider_code,
-                                    class: 'govuk-radios__input' %>
-              <%= form.label :accrediting_provider_code,
-                             provider["provider_name"],
-                             value: provider["provider_code"],
-                             class: 'govuk-label govuk-radios__label' %>
-            </div>
-          <% end %>
+      <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_body">
+        <% if provider.accredited_bodies.length > 0 %>
+          <%= render partial: "provider_suggestion",
+            collection: provider.accredited_bodies,
+            locals: { form: form }
+          %>
 
-        </div>
+          <div class="govuk-radios__divider">or</div>
+
+          <div class="govuk-radios__item">
+            <%= form.radio_button :accrediting_provider_code,
+              'other',
+              class: 'govuk-radios__input',
+              data: { "aria-controls" => "other-container" },
+              checked: @errors && @errors[:accredited_body]&.any?  %>
+            <%= form.label :accrediting_provider_code,
+              "A new accredited body you’re working with",
+              for: 'course_accrediting_provider_code_other',
+              value: false,
+              class: 'govuk-label govuk-radios__label' %>
+          </div>
+
+          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="other-container">
+            <%= render "provider_search_field", form: form %>
+          </div>
+        <% else %>
+          <%= form.hidden_field :accrediting_provider_code, value: :other %>
+          <%= render "provider_search_field", form: form %>
+        <% end %>
       </div>
-
-      <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            Help with adding a different accredited body
-          </span>
-        </summary>
-        <div class="govuk-details__text">
-          <p class="govuk-body">
-            Contact the Becoming a Teacher team to request a different accredited body: <%= bat_contact_mail_to bat_contact_email_address_with_wrap, subject: "Edit #{@course.name} (#{@provider.provider_code}/#{@course.course_code}) accredited body" %>
-          </p>
-        </div>
-      </details>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
                       class: "govuk-button govuk-!-margin-top-3", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
         <%= link_to 'Cancel changes',
-          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+          details_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code),
           class: "govuk-link govuk-link--no-visited-state" %>
       </p>
     <% end %>

--- a/app/views/courses/accredited_body/search.html.erb
+++ b/app/views/courses/accredited_body/search.html.erb
@@ -1,0 +1,72 @@
+<%= content_for :page_title, "Organisation search" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(
+    details_provider_recruitment_cycle_course_path(
+      course.provider_code,
+      course.recruitment_cycle_year,
+      course.course_code)) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Pick an accredited body
+    </h1>
+
+    <p class="govuk-body">You searched for ‘<%= @query %>’.</p>
+
+    <%= form_with model: course,
+      url: accredited_body_provider_recruitment_cycle_course_path(
+        params[:provider_code],
+        params[:recruitment_cycle_year],
+        params[:code]),
+      method: :put do |form| %>
+
+      <% if @provider_suggestions.any? %>
+        <p class="govuk-body">We found these providers which matched your search:</p>
+
+        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_body">
+          <%= render partial: "provider_suggestion", collection: @provider_suggestions, locals: { form: form }%>
+          <div class="govuk-radios__divider">or</div>
+
+          <div class="govuk-radios__item">
+            <%= form.radio_button :accrediting_provider_code,
+              'other',
+              class: 'govuk-radios__input',
+              data: { "aria-controls" => "other-container" } %>
+            <%= form.label :accrediting_provider_code,
+              "Try another accrediting provider",
+              for: 'course_accrediting_provider_code_other',
+              value: false,
+              class: 'govuk-label govuk-radios__label' %>
+          </div>
+
+          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="other-container">
+            <%= render "provider_search_field", form: form %>
+          </div>
+        </div>
+      <% else %>
+        <p class="govuk-body">We did not find any accredited bodies which matched your search.</p>
+
+        <p class="govuk-body">Try another search:</p>
+
+        <%= form.hidden_field :accrediting_provider_code, value: :other %>
+        <%= render "provider_search_field", form: form %>
+      <% end %>
+
+      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
+        class: "govuk-button govuk-!-margin-top-3", data: { qa: 'course__save' } %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes',
+        details_provider_recruitment_cycle_course_path(
+        course.provider_code,
+        course.recruitment_cycle_year,
+        course.course_code),
+        class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -50,9 +50,9 @@
 
         <p class="govuk-body">This takes you through to the Edit Vacancies page for this course.</p>
 
-        <p class="govuk-body">Here, you're given two options. You can confirm that the course has no vacancies. Or you can confirm that there are still vacancies for this course.</p>
+        <p class="govuk-body">Here, you’re given two options. You can confirm that the course has no vacancies. Or you can confirm that there are still vacancies for this course.</p>
 
-        <p class="govuk-body">If there are no longer any vacancies - if you're no longer recruiting candidates - click the upper box.</p>
+        <p class="govuk-body">If there are no longer any vacancies - if you’re no longer recruiting candidates - click the upper box.</p>
 
         <p class="govuk-body">Once you click 'Publish changes', this course will be closed to applications. Changes will be published immediately to Find.</p>
 
@@ -68,7 +68,7 @@
 
         <p class="govuk-body">Click 'Edit'.</p>
 
-        <p class="govuk-body">As before, you're given two options. Click the lower box to confirm there are vacancies. You'll see a drop down list - this shows the locations related to this course. Tick those locations that still have vacancies. If any location doesn't have vacancies, untick it.</p>
+        <p class="govuk-body">As before, you’re given two options. Click the lower box to confirm there are vacancies. You'll see a drop down list - this shows the locations related to this course. Tick those locations that still have vacancies. If any location doesn't have vacancies, untick it.</p>
 
         <p class="govuk-body">Once you've confirmed that there are vacancies, click 'Publish changes' to open the course to new applications.</p>
 

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,4 +1,4 @@
-<% if @errors[field]&.any? %>
+<% if @errors&.[](field)&.any? %>
   <span id="<%= field.to_s %>-error" class="govuk-error-message">
     <% @errors[field].each do |error| %>
       <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
-# You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
+# You can add backtrace silencers for libraries that you’re using but don't wish to see in your backtraces.
 # Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
 
-# You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
+# You can also remove all the silencers if you’re trying to debug a problem that might stem from framework code.
 # Rails.backtrace_cleaner.remove_silencers!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
 
         get '/accredited-body', on: :member, to: 'courses/accredited_body#edit'
         put '/accredited-body', on: :member, to: 'courses/accredited_body#update'
+        get '/accredited-body/search', on: :member, to: 'courses/accredited_body#search'
 
         get '/age-range', on: :member, to: 'courses/age_range#edit'
         put '/age-range', on: :member, to: 'courses/age_range#update'

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ProvidersController, type: :controller do
+describe ProvidersController, type: :controller do
   context "with authenticated user" do
     before do
       stub_omniauth

--- a/spec/factories/provider_suggestion.rb
+++ b/spec/factories/provider_suggestion.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :provider_suggestion do
+    skip_create
+
+    sequence(:id)
+    sequence(:provider_code) { |n| "A#{n}" }
+    provider_name { "ACME SCITT #{provider_code}" }
+  end
+end

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'View providers', type: :feature do
+feature 'View providers', type: :feature do
   let(:organisation_page) { PageObjects::Page::Organisations::OrganisationPage.new }
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
   let(:provider_1) { build :provider, provider_code: 'A0', include_counts: [:courses] }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 describe Course do
   describe '#build_new' do

--- a/spec/models/provider_suggestion_spec.rb
+++ b/spec/models/provider_suggestion_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe ProviderSuggestion do
+  describe '#suggest' do
+    let(:provider)          { build :provider }
+    let(:recruitment_cycle) { provider.recruitment_cycle }
+    let(:new_resource_stub) { stub_api_v2_new_resource(provider) }
+
+    def stub_suggestion(query, stub)
+      stub_api_v2_request(
+        "/providers/suggest?query=#{query}",
+        stub
+      )
+    end
+
+    before do
+      allow(Thread.current).to receive(:fetch).and_return('token')
+
+      stub_omniauth
+      new_resource_stub
+    end
+
+    it 'requests suggestions' do
+      provider_suggestion1 = build(:provider_suggestion)
+      provider_suggestion2 = build(:provider_suggestion)
+      query_stub = stub_suggestion('query', resource_list_to_jsonapi([provider_suggestion1, provider_suggestion2]))
+      ProviderSuggestion.suggest('query')
+      expect(query_stub).to have_been_requested
+    end
+
+
+    it 'returns the result' do
+      provider_suggestion1 = build(:provider_suggestion)
+      provider_suggestion2 = build(:provider_suggestion)
+      stub_suggestion('query', resource_list_to_jsonapi([provider_suggestion1, provider_suggestion2]))
+      result = ProviderSuggestion.suggest('query')
+
+      expect(result.length).to eq(2)
+      expect(result.first.attributes[:type]).to eq('provider')
+      expect(result.first.attributes[:provider_code]).to eq(provider_suggestion1.provider_code)
+      expect(result.first.attributes[:provider_name]).to eq(provider_suggestion1.provider_name)
+
+      expect(result.second.attributes[:type]).to eq('provider')
+      expect(result.second.attributes[:provider_code]).to eq(provider_suggestion2.provider_code)
+      expect(result.second.attributes[:provider_name]).to eq(provider_suggestion2.provider_name)
+    end
+  end
+end

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -16,6 +16,25 @@ describe 'Courses' do
       )
     end
 
+    describe 'GET search' do
+      it 'renders providers search' do
+        stub_api_v2_request(
+          "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=accrediting_provider",
+          course.to_jsonapi(include: %i[accrediting_provider]),
+        )
+        current_recruitment_cycle = build(:recruitment_cycle, year: '2019')
+        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
+        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}", provider.to_jsonapi)
+
+        provider1 = build(:provider, provider_name: 'asd')
+        provider2 = build(:provider, provider_name: 'aoe')
+        stub_api_v2_request("/providers/suggest?query=a", resource_list_to_jsonapi([provider1, provider2]))
+        get(accredited_body_search_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code, query: 'a'))
+        expect(response.body).to include('asd')
+        expect(response.body).to include('aoe')
+      end
+    end
+
     context "without errors" do
       before do
         stub_api_v2_request(

--- a/spec/site_prism/page_objects/page/organisations/course_accredited_body_search.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_accredited_body_search.rb
@@ -1,0 +1,12 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseAccreditedBodySearch < CourseBase
+        set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/accredited-body/search{?query*}'
+
+        elements :accredited_body_options, '[data-qa="course__accredited_body_option"]'
+        element :save, '[data-qa="course__save"]'
+      end
+    end
+  end
+end

--- a/spec/support/define_factory_jsonapi_render_methods.rb
+++ b/spec/support/define_factory_jsonapi_render_methods.rb
@@ -14,12 +14,14 @@ FactoryBot.define do
           # serializer class.
           #
           # For example: User: UserSerializer
+          # This is done in two places, perhaps they should be unified?
           Course: CourseSerializer,
           Provider: ProviderSerializer,
           RecruitmentCycle: RecruitmentCycleSerializer,
           Site: SiteSerializer,
           SiteStatus: SiteStatusSerializer,
-          User: UserSerializer
+          User: UserSerializer,
+          ProviderSuggestion: ProviderSuggestionSerializer
         },
         include: opts[:include]
       )

--- a/spec/support/resource_list_to_jstonapi.rb
+++ b/spec/support/resource_list_to_jstonapi.rb
@@ -12,7 +12,8 @@ def resource_list_to_jsonapi(resource_list, **opts)
       RecruitmentCycle: RecruitmentCycleSerializer,
       Site: SiteSerializer,
       SiteStatus: SiteStatusSerializer,
-      User: UserSerializer
+      User: UserSerializer,
+      ProviderSuggestion: ProviderSuggestionSerializer
     },
     include: opts[:include],
     meta: opts[:meta]

--- a/spec/support/serializers/provider_suggestion_serializer.rb
+++ b/spec/support/serializers/provider_suggestion_serializer.rb
@@ -1,0 +1,5 @@
+class ProviderSuggestionSerializer < JSONAPI::Serializable::Resource
+  type 'provider'
+
+  attributes(*FactoryBot.attributes_for('provider_suggestion').keys)
+end


### PR DESCRIPTION
### Context
As part of adding provider suggestions and searching we'd like to search for providers from the frontend.  

### Changes proposed in this pull request  
Add a nojs provider search.  

### Screenshots

#### New accredited bodies page

![Screenshot 2019-09-16 at 12 54 45](https://user-images.githubusercontent.com/1650875/64955900-50d49280-d881-11e9-98d1-84d421ab4e55.png)

#### Selecting the last option
![Screenshot 2019-09-16 at 12 54 50](https://user-images.githubusercontent.com/1650875/64955901-50d49280-d881-11e9-98bf-6ef898ddf0e9.png)

#### Selecting from the results

![Screenshot 2019-09-16 at 12 55 01](https://user-images.githubusercontent.com/1650875/64955902-50d49280-d881-11e9-8db2-f867b918663f.png)

#### No results

![Screenshot 2019-09-16 at 12 55 11](https://user-images.githubusercontent.com/1650875/64955903-516d2900-d881-11e9-8b5e-350fb13c7fb4.png)

#### Validation

![Screenshot 2019-09-16 at 12 56 30](https://user-images.githubusercontent.com/1650875/64955963-76fa3280-d881-11e9-9283-9d94c63c66e4.png)
