### PR TITLE
[2036] Redirect www. to www2.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
+  constraints(host: /www\./) do
+    match "/(*path)" => redirect { |_, req| "#{Settings.dfe_signin.base_url}#{req.fullpath}" },
+      via: %i[get post put]
+  end
+
   # DfE Sign In
   get "/signin", to: "sessions#new", as: "signin"
   get "/signout", to: "sessions#signout", as: "signout"


### PR DESCRIPTION
### Context

This is in preparation of decomissioning the C# version of Publish. This is meant to be combined with a `CNAME`, pointing from `www.publish` to `mcfe`.

### Changes proposed in this pull request

Adds a redirect to the routes file.

### Guidance to review

I've tested this locally by briefly changing the `host =>` check to `127.0.0.1` and doing a few `curl`s. Seems to work great, but the redirect is a 301 and not a 302. I haven't found the right place to put the `status: 302` argument that should fix this because the syntax is a bit kludgy / hard to wrap my head around with the proc and everything.

### Local test

```diff
$ git diff
-  constraints(host: /www\./) do
+  constraints(host: /127\./) do
```

```bash
$ curl -ik "https://127.0.0.1:3000/foo?bar=baz"
HTTP/1.1 301 Moved Permanently
Location: https://localhost:3000/foo?bar=baz
Content-Type: text/html
Cache-Control: no-cache
X-Request-Id: 2919e5ce-cc47-4685-b6f9-17f5d9e97e46
X-Runtime: 0.001065
Strict-Transport-Security: max-age=31536000; includeSubDomains
Content-Length: 100

<html><body>You are being <a href="https://localhost:3000/foo?bar=baz">redirected</a>.</body></html>
```