### PR TITLE
[2036] Redirect www2 requests to www

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
-  constraints(host: /www\./) do
+  constraints(host: /www2\./) do
     match "/(*path)" => redirect { |_, req| "#{Settings.dfe_signin.base_url}#{req.fullpath}" },
       via: %i[get post put]
   end

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,7 +2,7 @@ dfe_signin:
   issuer: https://oidc.signin.education.gov.uk
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   profile: https://profile.signin.education.gov.uk
-  base_url: https://www2.publish-teacher-training-courses.service.gov.uk
+  base_url: https://www.publish-teacher-training-courses.service.gov.uk
 manage_backend:
   base_url: https://api2.publish-teacher-training-courses.service.gov.uk
 search_ui:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -2,7 +2,7 @@ dfe_signin:
   issuer: https://signin-test-oidc-as.azurewebsites.net
   profile: https://signin-test-pfl-as.azurewebsites.net
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
-  base_url: https://www2.qa.publish-teacher-training-courses.service.gov.uk
+  base_url: https://www.qa.publish-teacher-training-courses.service.gov.uk
 manage_backend:
   base_url: https://api2.qa.publish-teacher-training-courses.service.gov.uk
 search_ui:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -2,7 +2,7 @@ dfe_signin:
   issuer: https://pp-oidc.signin.education.gov.uk
   profile: https://pp-profile.signin.education.gov.uk
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
-  base_url: https://www2.staging.publish-teacher-training-courses.service.gov.uk
+  base_url: https://www.staging.publish-teacher-training-courses.service.gov.uk
 manage_backend:
   base_url: https://api2.staging.publish-teacher-training-courses.service.gov.uk
 search_ui:


### PR DESCRIPTION
### Context

Once DfE Signin have whitelisted the domain on the `bats2` identifier, and the CNAME is in place with Rails serving both `www2` and `www`, we can release this change to flip all users back to `www`.

### Changes proposed in this pull request

Flips the redirect around and updates the signin `base_url`s.

### Guidance to review

This will be tested in both QA and Staging before going live.