### PR TITLE
[2069] Allow publishing of courses in next cycle

### DIFF
--- a/app/views/courses/status_panel/_unpublished.html.erb
+++ b/app/views/courses/status_panel/_unpublished.html.erb
@@ -16,5 +16,12 @@
     <%= f.submit "Publish", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: 'course__publish' } %>
   <% end %>
 <% else %>
-  <p class="govuk-body">You will be able to publish your courses in September before the next cycle opens.</p>
+  <% if course.is_published? %>
+    <p class="govuk-body">Publish your changes and they will appear on Find when the cycle opens in October.</p>
+  <% else %>
+    <p class="govuk-body">Publish this course and it will appear on Find when the cycle opens in October.</p>
+  <% end %>
+  <%= form_for course, url: publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :post do |f| %>
+    <%= f.submit "Publish in October", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: 'course__publish' } %>
+  <% end %>
 <% end %>

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -199,6 +199,7 @@ feature 'Course show', type: :feature do
       expect(course_page).to have_status_panel
       expect(course_page.is_findable).to have_content('No')
       expect(course_page.status_tag).to have_content('Rolled over')
+      expect(course_page.publish).to have_content('Publish in October')
     end
   end
 


### PR DESCRIPTION
### Context
Allow publishing of courses in the next recruitment cycle

### Changes proposed in this pull request
Render form to publish courses in the next recruitment cycle

### Guidance to review
🚢 

# After
![localhost_3000_organisations_2CG_2020_courses_2Z4R(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/64428940-d64f8a00-d0ac-11e9-96ad-440230a65fb5.png)
