### PR TITLE
[2036] Redirect education domain users to service domain

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
-  constraints(host: /www2\./) do
+  constraints(host: /www2\.|\.education\./) do
     match "/(*path)" => redirect { |_, req| "#{Settings.dfe_signin.base_url}#{req.fullpath}" },
       via: %i[get post put]
   end


### PR DESCRIPTION
### Context

We forgot to add the education domain, which UCAS still point to.

### Changes proposed in this pull request

Adds another case for the host regex for the redirect.

### Guidance to review

:ship: :fire: