### PR TITLE
Added env variable to stop slot swap failures

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -236,6 +236,10 @@
               {
                 "name": "SENTRY_DSN",
                 "value": "[parameters('sentryDSN')]"
+              },
+              {
+                "name": "WEBSITE_SLOT_POLL_WORKER_FOR_CHANGE_NOTIFICATION",
+                "value": "0"
               }
             ]
           },


### PR DESCRIPTION
### Context
On random occasions, Azure Pipeline Release fails on swapping of deployment slots.
Microsoft engineer has provided an environmental variable that may prevent these failures when added to the app settings.  I have tested it in QA and didn't see any issue.

### Changes proposed in this pull request
Create and set following app setting with value=0
`WEBSITE_SLOT_POLL_WORKER_FOR_CHANGE_NOTIFICATION`

