### PR TITLE
[2119] Update course build_new to match new API shape

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -34,22 +34,11 @@ module CourseBasicDetailConcern
 private
 
   def build_new_course
-    course = Course.build_new(
+    @course = Course.build_new(
       recruitment_cycle_year: @provider.recruitment_cycle_year,
       provider_code: @provider.provider_code,
-      attrs: {
-        course: course_params.to_unsafe_hash
-      }
+      course: course_params.to_unsafe_hash
     )
-
-    @course = if course.errors.any?
-                Course.new(
-                  attributes: course_params.to_h,
-                  meta: { edit_options: course.meta['edit_options'] }
-                )
-              else
-                @course = course.first
-              end
   end
 
   def build_provider

--- a/app/controllers/courses/age_range_controller.rb
+++ b/app/controllers/courses/age_range_controller.rb
@@ -54,7 +54,11 @@ module Courses
   private
 
     def course_params
-      params.require(:course).permit(:age_range_in_years)
+      if params.key? :course
+        params.require(:course).permit(:age_range_in_years)
+      else
+        ActionController::Parameters.new({}).permit(:course)
+      end
     end
 
     def build_provider
@@ -76,7 +80,7 @@ module Courses
       @course = Course.build_new(
         recruitment_cycle_year: @provider.recruitment_cycle_year,
         provider_code: @provider.provider_code
-      ).first
+      )
     end
   end
 end

--- a/app/controllers/courses/fee_or_salary_controller.rb
+++ b/app/controllers/courses/fee_or_salary_controller.rb
@@ -19,13 +19,5 @@ module Courses
   private
 
     def errors; end
-
-    def course_params
-      if params.key?(:course)
-        params.require(:course).permit(:program_type)
-      else
-        ActionController::Parameters.new({}).permit
-      end
-    end
   end
 end

--- a/spec/features/courses/fee_or_salary/new_spec.rb
+++ b/spec/features/courses/fee_or_salary/new_spec.rb
@@ -7,6 +7,7 @@ feature 'new course fee or salary', type: :feature do
 
   let(:course) { build(:course, :new, provider: provider) }
   let(:provider) { build(:provider) }
+  let(:course) { build(:course, :new, provider: provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
   before do
@@ -14,10 +15,9 @@ feature 'new course fee or salary', type: :feature do
     stub_api_v2_resource(provider)
     stub_api_v2_build_course
     stub_api_v2_build_course(program_type: 'pg_teaching_apprenticeship')
-    new_course = build(:course, :new, provider: provider)
-    stub_api_v2_new_resource(new_course)
     stub_api_v2_resource(recruitment_cycle)
-    stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_build_course
   end
 
   scenario "sends user to confirmation page" do

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -13,6 +13,7 @@ feature 'Course show', type: :feature do
   let(:next_recruitment_cycle) { build :recruitment_cycle, :next_cycle }
   let(:course) do
     build :course,
+          :with_fees,
           has_vacancies?: true,
           course_code: 'C1',
           open_for_applications?: true,
@@ -23,6 +24,12 @@ feature 'Course show', type: :feature do
           provider_code: provider.provider_code,
           recruitment_cycle: current_recruitment_cycle,
           site_statuses: [site_status],
+          about_course: 'Foo',
+          interview_process: 'Foo',
+          how_school_placements_work: 'Foo',
+          required_qualifications: 'Foo',
+          personal_qualities: 'Foo',
+          other_requirements: 'Foo',
           sites: [site]
   end
   let(:site) { build :site, code: 'Z' }
@@ -72,13 +79,13 @@ feature 'Course show', type: :feature do
         course.how_school_placements_work
       )
       expect(course_page.length).to have_content(
-        course.course_length
+        "Up to 2 years"
       )
       expect(course_page.uk_fees).to have_content(
         '£9,250'
       )
       expect(course_page.international_fees).to have_content(
-        course.fee_international
+        "£14,000"
       )
       expect(course_page.fee_details).to have_content(
         course.fee_details
@@ -115,10 +122,18 @@ feature 'Course show', type: :feature do
   describe 'with a salaried course' do
     let(:course) {
       build :course,
+            :with_fees,
             funding: 'salary',
             sites: [site],
             provider: provider,
-            accrediting_provider: provider
+            accrediting_provider: provider,
+            about_course: 'Foo',
+            interview_process: 'Foo',
+            how_school_placements_work: 'Foo',
+            required_qualifications: 'Foo',
+            personal_qualities: 'Foo',
+            salary_details: 'Foo',
+            other_requirements: 'Foo'
     }
 
     scenario 'it shows the course show page' do
@@ -138,7 +153,7 @@ feature 'Course show', type: :feature do
         course.how_school_placements_work
       )
       expect(course_page.length).to have_content(
-        course.course_length
+        "Up to 2 years"
       )
       expect(course_page.salary).to have_content(
         course.salary_details

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -18,7 +18,7 @@ describe Course do
       Course.build_new(
         recruitment_cycle_year: recruitment_cycle.year,
         provider_code: provider.provider_code
-      ).first
+      )
     end
 
     it 'makes a request to the api' do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -95,9 +95,12 @@ module Helpers
   end
 
   def stub_api_v2_build_course(params = {})
+    jsonapi_response = course.to_jsonapi
+    jsonapi_response[:data][:meta] = course.meta
+    jsonapi_response[:data][:errors] = []
     stub_api_v2_request(
       url_for_build_course_with_params(params),
-      course.to_jsonapi
+      jsonapi_response
     )
   end
 
@@ -133,11 +136,10 @@ private
   def url_for_build_course_with_params(params)
     provider_code = provider.provider_code
     recruitment_cycle_year = provider.recruitment_cycle_year
-    url = "/recruitment_cycles/#{recruitment_cycle_year}" \
-      "/providers/#{provider_code}/courses/build_new?" \
+    url = "/build_new_course?" \
       "provider_code=#{provider_code}&recruitment_cycle_year=#{recruitment_cycle_year}&"
 
-    url_params = params.map { |k, v| "attrs[course][#{k}]=#{v}" }.join("&")
+    url_params = params.map { |k, v| "course[#{k}]=#{v}" }.join("&")
     url + url_params
   end
 end


### PR DESCRIPTION
### Context

The API is being updated for this to not match the JSONAPI schema exactly, so we need to update the frontend.

### Changes proposed in this pull request

Implement `Course.build_new` and update all the relevant tests and places it's used.

### Guidance to review

Ignore the first commit, it's unrelated and only meant to fix the nil warnings we were getting before.

🖌 