### PR TITLE
[2117] check current user present in authenticate

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
   end
 
   def authenticate
-    if current_user
+    if current_user.present?
       assign_sentry_contexts
       add_token_to_connection
       set_has_multiple_providers

--- a/app/controllers/courses/fee_or_salary_controller.rb
+++ b/app/controllers/courses/fee_or_salary_controller.rb
@@ -21,7 +21,11 @@ module Courses
     def errors; end
 
     def course_params
-      params.require(:course).permit(:program_type)
+      if params.key?(:course)
+        params.require(:course).permit(:program_type)
+      else
+        ActionController::Parameters.new({}).permit
+      end
     end
   end
 end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,8 +41,11 @@ steps:
     runInBackground: false
 
 - bash: |
-    docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter' | tee rspec-results.xml
+    docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
+    test_result=$?
+    cat rspec-results.xml
     sed -i '$d;1,5d' rspec-results.xml
+    if [ "$test_result" == "0" ] ; then true ; else false ; fi
   displayName: 'Run tests'
 
 - task: Docker@1

--- a/spec/features/courses/fee_or_salary/new_spec.rb
+++ b/spec/features/courses/fee_or_salary/new_spec.rb
@@ -5,12 +5,15 @@ feature 'new course fee or salary', type: :feature do
     PageObjects::Page::Organisations::Courses::NewFeeOrSalaryPage.new
   end
 
+  let(:course) { build(:course, :new, provider: provider) }
   let(:provider) { build(:provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
   before do
     stub_omniauth
     stub_api_v2_resource(provider)
+    stub_api_v2_build_course
+    stub_api_v2_build_course(program_type: 'pg_teaching_apprenticeship')
     new_course = build(:course, :new, provider: provider)
     stub_api_v2_new_resource(new_course)
     stub_api_v2_resource(recruitment_cycle)


### PR DESCRIPTION
### Context

We are getting an error with some users where they can't access their organisations because the system does not recognise them as belonging to any organisation. We think this is actually a flaw in how we handle authentication, but we can't reproduce this reliably yet so aren't quite sure.

### Changes proposed in this pull request

Synchronise how we authenticate a user with how we decide whether to present them with a "Sign Out" or a "Sign In" link on the view page. The thinking being that the problem reports we've seen so far have shown a "Sign In" link for the user.

### Guidance to review

There are fixes for other test failures that seem to have gone undetected in our CI in this PR.
