### PR TITLE
[2117] Add accept terms page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, except: :not_found
   rescue_from JsonApiClient::Errors::NotAuthorized, with: :render_unauthorized
-  rescue_from JsonApiClient::Errors::AccessDenied, with: :render_unauthorized
+  rescue_from JsonApiClient::Errors::AccessDenied, with: :render_accept_terms
 
   before_action :authenticate
 
@@ -15,6 +15,10 @@ class ApplicationController < ActionController::Base
 
   def render_unauthorized
     redirect_to unauthorized_path
+  end
+
+  def render_accept_terms
+    redirect_to accept_terms_path
   end
 
   helper_method :current_user

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,4 +14,6 @@ class PagesController < ApplicationController
   def transition_info; end
 
   def rollover; end
+
+  def accept_terms; end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,10 @@ class UsersController < ApplicationController
     accept_screen('accept_rollover_screen', providers_path)
   end
 
+  def accept_terms
+    accept_screen('accept_terms', providers_path)
+  end
+
 private
 
   def accept_screen(method, path)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < Base
   custom_endpoint :accept_transition_screen, on: :member, request_method: :patch
   custom_endpoint :accept_rollover_screen, on: :member, request_method: :patch
+  custom_endpoint :accept_terms, on: :member, request_method: :patch
 
   def self.member(id)
     new(id: id)

--- a/app/views/pages/accept_terms.html.erb
+++ b/app/views/pages/accept_terms.html.erb
@@ -1,0 +1,29 @@
+<%= content_for :page_title, "Accept Terms and Conditions" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Before you begin</h1>
+    <p class="govuk-body">We need you to read and agree to our terms and conditions.</p>
+    <p class="govuk-body">These set out your responsibilities when publishing content to Publish teacher training courses. This includes making sure your content:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>is relevant to the service and accurate</li>
+      <li>is not offensive, inappropriate or discriminatory</li>
+      <li>belongs to you</li>
+    </ul>
+    <p class="govuk-body">Read our full <%= govuk_link_to "terms and conditions", terms_path %>.</p>
+
+    <hr class="govuk-footer__section-break">
+
+    <%= form_for :user, url: accept_terms_path, method: :patch do |f| %>
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <%= f.check_box :terms_accepted, class: 'govuk-checkboxes__input' %>
+            <%= f.label :terms_accepted, "I agree to the terms and conditions", class: 'govuk-label govuk-checkboxes__label' %>
+          </div>
+        </div>
+      </div>
+      <%= f.submit "Continue", class: "govuk-button", data: { qa: 'terms__continue' } %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,8 @@ Rails.application.routes.draw do
   patch '/accept-transition-info', to: 'users#accept_transition_info'
   get "/rollover", to: "pages#rollover", as: :rollover
   patch '/accept-rollover', to: 'users#accept_rollover'
+  get "/accept-terms", to: "pages#accept_terms"
+  patch '/accept-terms', to: 'users#accept_terms'
 
   # redirect URL's from legacy c# app
   get '/organisation/:provider_code', to: redirect('/organisations/%{provider_code}', status: 301)

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe SessionsController, type: :controller do
       it "redirects to unauthorized" do
         get :create
 
-        expect(subject).to redirect_to(unauthorized_path)
+        expect(subject).to redirect_to(accept_terms_path)
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -95,4 +95,29 @@ describe UsersController, type: :controller do
       end
     end
   end
+
+  describe 'GET #accept_terms' do
+    context "with working request" do
+      before do
+        stub_api_v2_request("/users/#{user.id}/accept_terms", {}, :patch, 200)
+      end
+
+      it "redirects to providers index" do
+        get :accept_terms
+        expect(response).to redirect_to(providers_path)
+      end
+    end
+
+    context "with client error" do
+      before do
+        stub_api_v2_request("/users/#{user.id}/accept_terms", {}, :patch, 400)
+      end
+
+      it "redirects to providers index" do
+        get :accept_terms
+        expect(Raven).to have_received(:capture_exception).with(instance_of(JsonApiClient::Errors::ClientError))
+        expect(response).to redirect_to(providers_path)
+      end
+    end
+  end
 end

--- a/spec/site_prism/page_objects/page/accept_terms.rb
+++ b/spec/site_prism/page_objects/page/accept_terms.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module Page
+    class AcceptTerms < PageObjects::Base
+      set_url '/accept-terms'
+
+      element :title, 'h1'
+      element :continue, '[data-qa=terms__continue]'
+    end
+  end
+end


### PR DESCRIPTION
### Context

Users who log in and have not accepted terms and conditions get a "We don't know which org you're part of" page.

### Changes proposed in this pull request

Implement the terms page.

### Guidance to review

🚢 