### PR TITLE
[2152] Allow providers to publish details for next recruitment cycle

### DIFF
--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -79,15 +79,18 @@
 
       <% unless @provider.is_published? %>
         <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
-        <% if @recruitment_cycle.current? %>
           <h2 class="govuk-heading-m">Publish</h2>
-          <p class="govuk-body">You can make changes to this after publishing it.</p>
-          <%= form_for provider, url: publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year), method: :post do |f| %>
-            <%= f.submit "Publish", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: 'provider__publish' } %>
+          <% if @recruitment_cycle.current? %>
+            <p class="govuk-body">You can make changes to this after publishing it.</p>
+            <%= form_for provider, url: publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year), method: :post do |f| %>
+              <%= f.submit "Publish", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: 'provider__publish' } %>
+            <% end %>
+          <% else %>
+            <p class="govuk-body" data-qa="provider__next_cycle_publish_help_text">This will appear on all your courses on Find in October, when the new cycle opens.</p>
+            <%= form_for provider, url: publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year), method: :post do |f| %>
+              <%= f.submit "Publish in October", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: 'provider__publish_next_cycle' } %>
+            <% end %>
           <% end %>
-        <% else %>
-          <p class="govuk-body">You will be able to publish your changes in September before the next cycle opens.</p>
-        <% end %>
       <% end %>
     </div>
   </aside>

--- a/spec/site_prism/page_objects/page/organisations/organisation_details.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_details.rb
@@ -2,7 +2,7 @@ module PageObjects
   module Page
     module Organisations
       class OrganisationDetails < PageObjects::Base
-        set_url '/organisations/{provider_code}/details'
+        set_url '/organisations/{provider_code}/{recruitment_cycle_year}/details'
 
         element :title, '.govuk-heading-xl'
         element :caption, '.govuk-caption-xl'
@@ -16,6 +16,9 @@ module PageObjects
         element :content_status, '[data-qa=provider__content-status]'
         element :flash, '.govuk-success-summary'
         elements :breadcrumbs, '.govuk-breadcrumbs__link'
+        element :publish_button, '[data-qa=provider__publish]'
+        element :publish_in_next_cycle_button, '[data-qa=provider__publish_next_cycle]'
+        element :next_recruitment_cycle_publishing_information, '[data-qa=provider__next_cycle_publish_help_text]'
       end
     end
   end


### PR DESCRIPTION
### Context
Allow providers to publish their information (enrichment) info in advance of the next cycle so that providers can confirm they are satisfied their provider information is publishable and spread their workload before the start of the next cycle

### Changes proposed in this pull request
![image](https://user-images.githubusercontent.com/976254/65026432-74a2e180-d930-11e9-9edc-c5b09ecceca5.png)

- Add the publish button to the page following the designs outlined


### Guidance to review

- Checkout the branch
- Ensure you have "Search and Compare API" running
- Navigate to the "About your org" page for the next recruitment cycle
- Click "Publish in October" 