### PR TITLE
[2157] Don't redirect on 401 from backend

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,15 +6,11 @@ class ApplicationController < ActionController::Base
   before_action :authenticate
 
   def not_found
-    respond_to do |format|
-      format.html { render 'errors/not_found', status: :not_found }
-      format.json { render json: { error: 'Resource not found' }, status: :not_found }
-      format.all { render status: :not_found, body: nil }
-    end
+    respond_with_error(template: 'errors/not_found', status: :not_found, error_text: 'Resource not found')
   end
 
   def render_unauthorized
-    redirect_to unauthorized_path
+    respond_with_error(template: 'errors/unauthorized', status: :unauthorized, error_text: 'Unauthorized request')
   end
 
   def render_accept_terms
@@ -61,6 +57,14 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def respond_with_error(template:, status:, error_text:)
+    respond_to do |format|
+      format.html { render template, status: status }
+      format.json { render json: { error: error_text }, status: status }
+      format.all { render status: status, body: nil }
+    end
+  end
 
   def set_user_session
     # TODO: we should return a session object here with a 'user' attached to id.

--- a/app/views/errors/unauthorized.html.erb
+++ b/app/views/errors/unauthorized.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "We don’t know which organisation you’re part of" %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" data-qa="errors__unauthorized">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">We don’t know which organisation you’re part of</h1>
     <p class="govuk-body">You have successfully signed in with your DfE account but we don’t recognise the email address you’ve used. This might have happened if you were forwarded the original invitation email or if you’ve recently updated your email address.</p>

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -82,10 +82,10 @@ RSpec.describe SessionsController, type: :controller do
         allow(Base).to receive(:connection)
       end
 
-      it "redirects to unauthorized" do
+      it "Returns unauthorized status" do
         get :create
 
-        expect(subject).to redirect_to(unauthorized_path)
+        expect(response.status).to be(401)
       end
     end
 

--- a/spec/features/unauthorized_api_requests_spec.rb
+++ b/spec/features/unauthorized_api_requests_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+feature 'Handling Unauthorized responses from the backend', type: :feature do
+  let(:unauthorized_page) { PageObjects::Page::Unauthorized.new }
+
+  before do
+    stub_omniauth
+    stub_api_v2_request("/recruitment_cycles/2019", {}, :get, 401)
+  end
+
+  it 'Does not redirect the page' do
+    visit "/organisations/A0/"
+    expect(page.current_path).to eq("/organisations/A0")
+  end
+
+  it 'Renders the unauthorized page' do
+    visit "/organisations/A0/"
+    expect(unauthorized_page.unauthorized_text).to be_visible
+  end
+end

--- a/spec/site_prism/page_objects/page/unauthorized.rb
+++ b/spec/site_prism/page_objects/page/unauthorized.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module Page
+    class Unauthorized < PageObjects::Base
+      element :unauthorized_text, '[data-qa=errors__unauthorized]'
+    end
+  end
+end


### PR DESCRIPTION
### Context

We need to render errors rather than redirect when the API returns unauthorized