### PR TITLE
[2137] Don't redirect 403 errors from backend when terms have been accepted

### DIFF
--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -91,8 +91,10 @@ RSpec.describe SessionsController, type: :controller do
 
     context "if user has not accepted terms and conditions" do
       before do
+        env_double = double(body: { "meta" => { "error_type" => "user_not_accepted_terms_and_conditions" } })
+
         allow(Session).to receive(:create)
-          .and_raise(JsonApiClient::Errors::AccessDenied, "forbidden")
+          .and_raise(JsonApiClient::Errors::AccessDenied, env_double)
         allow(Base).to receive(:connection)
       end
 

--- a/spec/features/forbidden_api_requests_spec.rb
+++ b/spec/features/forbidden_api_requests_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+feature 'Handling Forbidden responses from the backend', type: :feature do
+  let(:unauthorized_page) { PageObjects::Page::Unauthorized.new }
+
+  before do
+    stub_omniauth
+    stub_api_v2_request("/recruitment_cycles/2019", {}, :get, 403)
+  end
+
+  it 'Does not redirect the page' do
+    visit "/organisations/A0/"
+    expect(page.current_path).to eq("/organisations/A0")
+  end
+
+  it 'Renders the unauthorized page' do
+    visit "/organisations/A0/"
+    expect(unauthorized_page.unauthorized_text).to be_visible
+  end
+end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -103,7 +103,11 @@ feature 'Sign in', type: :feature do
 
     stub_api_v2_request(
       "/recruitment_cycles/2019",
-      current_recruitment_cycle.to_jsonapi,
+      {
+        meta: {
+          error_type: 'user_not_accepted_terms_and_conditions'
+        }
+      },
       :get, 403
     )
 


### PR DESCRIPTION
### Context
403 responses from the backend shouldn't always redirect users to the `/accept-terms` page, due to overloading from the API that happens.

### Changes proposed in this pull request

This adds in a check for some meta information provided by the backend (https://github.com/DFE-Digital/manage-courses-backend/pull/817) and redirects/renders accordingly.