### PR TITLE
[2159] Use funding_type instead of program_type

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -76,7 +76,8 @@ private
         :qualification, # qualification is actually "outcome"
         :maths,
         :english,
-        :science
+        :science,
+        :funding_type
       )
     else
       ActionController::Parameters.new({}).permit(:course)

--- a/app/controllers/courses/age_range_controller.rb
+++ b/app/controllers/courses/age_range_controller.rb
@@ -55,7 +55,12 @@ module Courses
 
     def course_params
       if params.key? :course
-        params.require(:course).permit(:age_range_in_years)
+        params.require(:course)
+          .except(
+            :course_age_range_in_years_other_from,
+            :course_age_range_in_years_other_to
+)
+          .permit(:age_range_in_years)
       else
         ActionController::Parameters.new({}).permit(:course)
       end

--- a/app/controllers/courses/apprenticeship_controller.rb
+++ b/app/controllers/courses/apprenticeship_controller.rb
@@ -16,7 +16,7 @@ module Courses
 
     def course_params
       if params.key?(:course)
-        params.require(:course).permit(:program_type)
+        params.require(:course).permit(:funding_type)
       else
         ActionController::Parameters.new({}).permit
       end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -36,7 +36,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def funding
-    case object.funding
+    case object.funding_type
     when 'salary'
       'Salaried'
     when 'apprenticeship'
@@ -47,7 +47,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def apprenticeship?
-    object.funding == 'apprenticeship' ? 'Yes' : 'No'
+    object.funding_type == 'apprenticeship' ? 'Yes' : 'No'
   end
 
   def sorted_subjects
@@ -98,7 +98,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def funding_option
-    if object.funding == 'salary'
+    if object.funding_type == 'salary'
       "Salary"
     elsif object.has_scholarship_and_bursary?
       "Scholarship, bursary or student finance if you’re eligible"

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -61,7 +61,7 @@ class Course < Base
   end
 
   def has_fees?
-    funding == 'fee'
+    funding_type == 'fee'
   end
 
   def has_unpublished_changes?

--- a/app/views/courses/apprenticeship/_form_fields.html.erb
+++ b/app/views/courses/apprenticeship/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <div
-  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:program_type]&.any?) %>"
-  data-qa="course__program_type">
+  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:funding_type]&.any?) %>"
+  data-qa="course__funding_type">
 
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
@@ -9,19 +9,29 @@
       </h1>
     </legend>
 
-    <%= render "shared/error_messages", field: :program_type if @errors %>
+    <%= render "shared/error_messages", field: :funding_type if @errors %>
     <div class="govuk-radios" data-module="govuk-radios">
-      <% @course.meta['edit_options']['program_type'].each do |value| %>
-        <div class="govuk-radios__item">
-          <%= form.radio_button :program_type,
-                  value,
-                  class: 'govuk-radios__input' %>
-          <%= form.label :program_type,
-                  t("edit_options.apprenticeship.#{value}.label"),
-                  value: value,
-                  class: 'govuk-label govuk-radios__label' %>
-        </div>
-      <% end %>
+      <div class="govuk-radios__item">
+        <%= form.radio_button :funding_type,
+                'apprenticeship',
+                class: 'govuk-radios__input' %>
+        <%= form.label :funding_type,
+                'Yes',
+                value: 'apprenticeship',
+                class: 'govuk-label govuk-radios__label',
+                data: { qa: 'course__funding_type_apprenticeship' }%>
+      </div>
+
+      <div class="govuk-radios__item">
+        <%= form.radio_button :funding_type,
+                'fee',
+                class: 'govuk-radios__input' %>
+        <%= form.label :funding_type,
+                'No',
+                value: 'fee',
+                class: 'govuk-label govuk-radios__label',
+                data: { qa: 'course__funding_type_fee' }%>
+      </div>
     </div>
   </fieldset>
 </div>

--- a/app/views/courses/fee_or_salary/_form_fields.html.erb
+++ b/app/views/courses/fee_or_salary/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <div
-  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:program_type]&.any?) %>"
-  data-qa="course__program_type">
+  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:funding_type]&.any?) %>"
+  data-qa="course__funding_type">
 
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
@@ -9,20 +9,41 @@
       </h1>
     </legend>
 
-    <%= render "shared/error_messages", field: :program_type if @errors %>
+    <%= render "shared/error_messages", field: :funding_type if @errors %>
     <div class="govuk-radios" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <%= form.radio_button :funding_type,
+                'apprenticeship',
+                class: 'govuk-radios__input' %>
+        <%= form.label :funding_type,
+                'Teaching apprenticeship (with salary)',
+                value: 'apprenticeship',
+                class: 'govuk-label govuk-radios__label',
+                data: { qa: 'course__funding_type_apprenticeship' } %>
+      </div>
 
-      <% program_types.each do |value| %>
-        <div class="govuk-radios__item">
-          <%= form.radio_button :program_type,
-                  value,
-                  class: 'govuk-radios__input' %>
-          <%= form.label :program_type,
-                  t("edit_options.fee_or_salary.#{value}.label"),
-                  value: value,
-                  class: 'govuk-label govuk-radios__label' %>
-        </div>
-      <% end %>
+      <div class="govuk-radios__item">
+        <%= form.radio_button :funding_type,
+                'fee',
+                class: 'govuk-radios__input' %>
+        <%= form.label :funding_type,
+                'Fee paying (no salary)',
+                value: 'fee',
+                class: 'govuk-label govuk-radios__label',
+                data: { qa: 'course__funding_type_fee' } %>
+      </div>
+
+
+      <div class="govuk-radios__item">
+        <%= form.radio_button :funding_type,
+                'salary',
+                class: 'govuk-radios__input' %>
+        <%= form.label :funding_type,
+                'Salaried',
+                value: 'salary',
+                class: 'govuk-label govuk-radios__label',
+                data: { qa: 'course__funding_type_salary' } %>
+      </div>
     </div>
   </fieldset>
 </div>

--- a/app/views/courses/fee_or_salary/edit.html.erb
+++ b/app/views/courses/fee_or_salary/edit.html.erb
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-full">
     <%= form_with model: course, url: fee_or_salary_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code), method: :put do |form| %>
 
-      <%= render 'form_fields', form: form, program_types: @course.meta['edit_options']['program_type'] %>
+      <%= render 'form_fields', form: form %>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
         class: "govuk-button", data: { qa: 'course__save' }
@@ -23,4 +23,3 @@
     <% end %>
   </div>
 </div>
-

--- a/app/views/courses/preview/financial_support/_financial_support.html.erb
+++ b/app/views/courses/preview/financial_support/_financial_support.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-financial-support">Financial support</h2>
 
-  <% if course.funding == 'salary' %>
+  <% if course.funding_type == 'salary' %>
     <%= render partial: 'courses/preview/financial_support/salaried' %>
   <% else %>
 

--- a/app/views/courses/preview/financial_support/_financial_support.html.erb
+++ b/app/views/courses/preview/financial_support/_financial_support.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-financial-support">Financial support</h2>
 
-  <% if course.funding == 'salaried' %>
+  <% if course.funding == 'salary' %>
     <%= render partial: 'courses/preview/financial_support/salaried' %>
   <% else %>
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -7,3 +7,7 @@ Rails.application.initialize!
 ActionView::Base.field_error_proc = Proc.new do |html_tag, _instance|
   html_tag.html_safe
 end
+
+Rails.application.configure do
+  config.action_controller.action_on_unpermitted_parameters = :raise
+end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -63,7 +63,7 @@ FactoryBot.define do
                         "June #{recruitment_cycle.year.to_i + 1}",
                         "July #{recruitment_cycle.year.to_i + 1}"],
           study_modes: %w[full_time part_time full_time_or_part_time],
-          program_type: %w[pg_teaching_apprenticeship higher_education_programme]
+          funding_type: %w[fee apprenticeship salary]
         }
       end
       gcse_subjects_required_using_level { false }
@@ -86,7 +86,7 @@ FactoryBot.define do
     accrediting_provider { nil }
     qualification { 'pgce_with_qts' }
     start_date     { Time.zone.local(2019) }
-    funding        { 'fee' }
+    funding_type { 'fee' }
     applications_open_from { DateTime.new(2019).utc.iso8601 }
     is_send? { false }
     level { "secondary" }

--- a/spec/features/courses/apprenticeship/edit_spec.rb
+++ b/spec/features/courses/apprenticeship/edit_spec.rb
@@ -24,15 +24,11 @@ feature 'Edit course apprenticeship status', type: :feature do
   end
 
   context 'A course that can be an apprenticeship' do
-    let(:program_type) { 'pg_teaching_apprenticeship' }
-    let(:program_types) { %w[pg_teaching_apprenticeship higher_education_programme] }
+    let(:funding_type) { 'apprenticeship' }
     let(:course) do
       build(
         :course,
-        program_type: program_type,
-        edit_options: {
-          program_type: program_types
-        },
+        funding_type: funding_type,
         provider: provider
       )
     end
@@ -50,100 +46,36 @@ feature 'Edit course apprenticeship status', type: :feature do
       expect(course_details_page).to be_displayed
     end
 
-    context 'with pg_teaching_apprenticeship and higher_education_programme' do
-      scenario 'presents the correct choices for each study mode' do
-        expect(apprenticeship_page).to have_program_type_fields
-        expect(apprenticeship_page.program_type_fields)
-          .to have_selector('[for="course_program_type_pg_teaching_apprenticeship"]', text: 'Yes')
-        expect(apprenticeship_page.program_type_fields)
-          .to have_selector('[for="course_program_type_higher_education_programme"]', text: 'No')
-      end
-
-      context 'and it is an apprenticeship' do
-        scenario 'it has the correct value selected' do
-          expect(apprenticeship_page.program_type_fields)
-            .to have_field('course_program_type_pg_teaching_apprenticeship', checked: true)
-          expect(apprenticeship_page.program_type_fields)
-            .to have_field('course_program_type_higher_education_programme', checked: false)
-        end
-      end
-
-      context 'and it is not an apprenticeship' do
-        let(:program_type) { 'higher_education_programme' }
-
-        scenario 'it has the correct value selected' do
-          expect(apprenticeship_page.program_type_fields)
-            .to have_field('course_program_type_pg_teaching_apprenticeship', checked: false)
-          expect(apprenticeship_page.program_type_fields)
-            .to have_field('course_program_type_higher_education_programme', checked: true)
-        end
-      end
-
-      scenario 'it can be updated to a higher education program' do
-        update_course_stub = stub_api_v2_request(
-          "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-          "/providers/#{provider.provider_code}" \
-          "/courses/#{course.course_code}",
-          course.to_jsonapi,
-          :patch, 200
-        )
-
-        choose('course_program_type_higher_education_programme')
-        click_on 'Save'
-
-        expect(course_details_page).to be_displayed
-        expect(course_details_page.flash).to have_content('Your changes have been saved')
-        expect(update_course_stub).to have_been_requested
-      end
+    scenario 'presents the correct choices' do
+      expect(apprenticeship_page).to have_funding_type_fields
+      expect(apprenticeship_page.funding_type_fields)
+        .to have_selector('[for="course_funding_type_apprenticeship"]', text: 'Yes')
+      expect(apprenticeship_page.funding_type_fields)
+        .to have_selector('[for="course_funding_type_fee"]', text: 'No')
     end
 
-    context 'with pg_teaching_apprenticeship and scitt_programme' do
-      let(:program_types) { %w[pg_teaching_apprenticeship scitt_programme] }
+    scenario 'clicking no sets funding type to fee' do
+      patch_stub = stub_api_v2_request(
+        "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+        "/providers/#{provider.provider_code}/courses" \
+        "/#{course.course_code}",
+        {},
+        :patch,
+        body: {
+          data: {
+            course_code: course.course_code,
+            type: 'courses',
+            attributes: {
+              funding_type: 'fee'
+            }
+          }
+        }.to_json
+      )
 
-      scenario 'presents the correct choices for each study mode' do
-        expect(apprenticeship_page).to have_program_type_fields
-        expect(apprenticeship_page.program_type_fields)
-          .to have_selector('[for="course_program_type_pg_teaching_apprenticeship"]', text: 'Yes')
-        expect(apprenticeship_page.program_type_fields)
-          .to have_selector('[for="course_program_type_scitt_programme"]', text: 'No')
-      end
+      apprenticeship_page.funding_type_fee.click
+      apprenticeship_page.save.click
 
-      context 'and it is an apprenticeship' do
-        scenario 'it has the correct value selected' do
-          expect(apprenticeship_page.program_type_fields)
-            .to have_field('course_program_type_pg_teaching_apprenticeship', checked: true)
-          expect(apprenticeship_page.program_type_fields)
-            .to have_field('course_program_type_scitt_programme', checked: false)
-        end
-      end
-
-      context 'and it is not an apprenticeship' do
-        let(:program_type) { 'scitt_programme' }
-
-        scenario 'it has the correct value selected' do
-          expect(apprenticeship_page.program_type_fields)
-            .to have_field('course_program_type_pg_teaching_apprenticeship', checked: false)
-          expect(apprenticeship_page.program_type_fields)
-            .to have_field('course_program_type_scitt_programme', checked: true)
-        end
-      end
-
-      scenario 'it can be updated to a scitt programme' do
-        update_course_stub = stub_api_v2_request(
-          "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-          "/providers/#{provider.provider_code}" \
-          "/courses/#{course.course_code}",
-          course.to_jsonapi,
-          :patch, 200
-        )
-
-        choose('course_program_type_scitt_programme')
-        click_on 'Save'
-
-        expect(course_details_page).to be_displayed
-        expect(course_details_page.flash).to have_content('Your changes have been saved')
-        expect(update_course_stub).to have_been_requested
-      end
+      expect(patch_stub).to have_been_requested
     end
   end
 

--- a/spec/features/courses/apprenticeship/new_spec.rb
+++ b/spec/features/courses/apprenticeship/new_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 feature 'new course apprenticeship', type: :feature do
   let(:new_apprenticeship_page) do
@@ -14,14 +14,20 @@ feature 'new course apprenticeship', type: :feature do
     stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
     stub_api_v2_build_course
-    stub_api_v2_build_course(program_type: 'higher_education_programme')
+    stub_api_v2_build_course(funding_type: 'apprenticeship')
+
+    visit new_provider_recruitment_cycle_courses_apprenticeship_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
-  scenario "sends user to entry requirements" do
-    visit new_provider_recruitment_cycle_courses_apprenticeship_path(provider.provider_code, provider.recruitment_cycle_year)
+  scenario 'presents the correct choices' do
+    expect(new_apprenticeship_page).to have_funding_type_fields
+    expect(new_apprenticeship_page.funding_type_fields).to have_apprenticeship
+    expect(new_apprenticeship_page.funding_type_fields).to have_fee
+  end
 
-    choose('course_program_type_higher_education_programme')
-    click_on 'Continue'
+  scenario 'sends user to entry requirements' do
+    new_apprenticeship_page.funding_type_fields.apprenticeship.click
+    new_apprenticeship_page.save.click
 
     expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
   end

--- a/spec/features/courses/fee_or_salary/new_spec.rb
+++ b/spec/features/courses/fee_or_salary/new_spec.rb
@@ -14,29 +14,24 @@ feature 'new course fee or salary', type: :feature do
     stub_omniauth
     stub_api_v2_resource(provider)
     stub_api_v2_build_course
-    stub_api_v2_build_course(program_type: 'pg_teaching_apprenticeship')
+    stub_api_v2_build_course(funding_type: 'fee')
     stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
     stub_api_v2_build_course
+
+    visit new_provider_recruitment_cycle_courses_fee_or_salary_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
-  scenario "sends user to confirmation page" do
-    visit new_provider_recruitment_cycle_courses_fee_or_salary_path(provider.provider_code, provider.recruitment_cycle_year)
+  scenario 'presents the correct choices' do
+    expect(new_fee_or_salary_page).to have_funding_type_fields
+    expect(new_fee_or_salary_page.funding_type_fields).to have_apprenticeship
+    expect(new_fee_or_salary_page.funding_type_fields).to have_fee
+    expect(new_fee_or_salary_page.funding_type_fields).to have_salaried
+  end
 
-    expect(new_fee_or_salary_page).to have_program_type_fields
-
-
-    expect(new_fee_or_salary_page.program_type_fields)
-      .to have_selector('[for="course_program_type_pg_teaching_apprenticeship"]', text: 'Teaching apprenticeship (with salary)')
-    expect(new_fee_or_salary_page.program_type_fields)
-      .to have_selector('[for="course_program_type_school_direct_training_programme"]', text: 'Fee paying (no salary)')
-    expect(new_fee_or_salary_page.program_type_fields)
-      .to have_selector('[for="course_program_type_school_direct_salaried_training_programme"]', text: 'Salaried')
-
-    new_fee_or_salary_page.program_type_fields.pg_teaching_apprenticeship.click
-
-    click_on 'Continue'
-
+  scenario 'sends user to confirmation page' do
+    new_fee_or_salary_page.funding_type_fields.fee.click
+    new_fee_or_salary_page.save.click
     expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 end

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -12,7 +12,7 @@ feature 'Course salary', type: :feature do
           provider: provider,
           course_length: 'OneYear',
           salary_details: 'Salary details',
-          funding: 'salary',
+          funding_type: 'salary',
           recruitment_cycle: current_recruitment_cycle
   end
 

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -50,7 +50,7 @@ feature 'Course salary', type: :feature do
       "#{course.name} (#{course.course_code})"
     )
     expect(course_salary_page.title).to have_content(
-      "Course length and salary"
+      'Course length and salary'
     )
     expect(course_salary_page).to have_enrichment_form
     expect(course_salary_page.course_length_one_year).to be_checked

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -17,7 +17,7 @@ feature 'Course show', type: :feature do
           has_vacancies?: true,
           course_code: 'C1',
           open_for_applications?: true,
-          funding: 'fee',
+          funding_type: 'fee',
           fee_uk_eu: 9250,
           last_published_at: '2019-03-05T14:42:34Z',
           provider: provider,

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -123,7 +123,7 @@ feature 'Course show', type: :feature do
     let(:course) {
       build :course,
             :with_fees,
-            funding: 'salary',
+            funding_type: 'salary',
             sites: [site],
             provider: provider,
             accrediting_provider: provider,

--- a/spec/site_prism/page_objects/page/organisations/course_apprenticeship.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_apprenticeship.rb
@@ -4,7 +4,10 @@ module PageObjects
       class CourseApprenticeship < CourseBase
         set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/apprenticeship'
 
-        element :program_type_fields, '[data-qa="course__program_type"]'
+        element :funding_type_fields, '[data-qa="course__funding_type"]'
+        element :funding_type_apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'
+        element :funding_type_fee, '[data-qa="course__funding_type_fee"]'
+        element :save, '[data-qa="course__save"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_fee_or_salary.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_fee_or_salary.rb
@@ -4,7 +4,12 @@ module PageObjects
       class CourseFeeOrSalary < CourseBase
         set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/fee-or-salary'
 
-        element :program_type_fields, '[data-qa="course__program_type"]'
+        section :funding_type_fields, '[data-qa="course__funding_type"]' do
+          element :apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'
+          element :fee, '[data-qa="course__funding_type_fee"]'
+          element :salary, '[data-qa="course__funding_type_salary"]'
+        end
+        element :save, '[data-qa="course__save"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
@@ -4,6 +4,12 @@ module PageObjects
       module Courses
         class NewApprenticeshipPage < CourseBase
           set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/apprenticeship/new'
+
+          section :funding_type_fields, '[data-qa="course__funding_type"]' do
+            element :apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'
+            element :fee, '[data-qa="course__funding_type_fee"]'
+          end
+          element :save, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_fee_or_salary_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_fee_or_salary_page.rb
@@ -5,11 +5,12 @@ module PageObjects
         class NewFeeOrSalaryPage < CourseBase
           set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/fee-or-salary/new'
 
-          section :program_type_fields, '[data-qa="course__program_type"]' do
-            element :pg_teaching_apprenticeship, '#course_program_type_pg_teaching_apprenticeship'
-            element :school_direct_training_programme, '#course_program_type_school_direct_training_programme'
-            element :school_direct_salaried_training_programme, '#course_program_type_school_direct_salaried_training_programme'
+          section :funding_type_fields, '[data-qa="course__funding_type"]' do
+            element :apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'
+            element :fee, '[data-qa="course__funding_type_fee"]'
+            element :salaried, '[data-qa="course__funding_type_salary"]'
           end
+          element :save, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -28,7 +28,7 @@ module Helpers
     stub_api_v2_request('/sessions', user.to_jsonapi, :post)
   end
 
-  def stub_api_v2_request(url_path, stub, method = :get, status = 200, token: nil)
+  def stub_api_v2_request(url_path, stub, method = :get, status = 200, token: nil, body: nil)
     url = "#{Settings.manage_backend.base_url}/api/v2#{url_path}"
 
     stubbed_request = stub_request(method, url)
@@ -37,6 +37,10 @@ module Helpers
                           body: stub.to_json,
                           headers: { 'Content-Type': 'application/vnd.api+json' }
                         )
+    if body
+      stubbed_request.with(body: body)
+    end
+
     if token
       stubbed_request.with(
         headers: {

--- a/spec/support/serializers/course_serializer.rb
+++ b/spec/support/serializers/course_serializer.rb
@@ -16,4 +16,5 @@ class CourseSerializer < JSONAPI::Serializable::Resource
   attribute :provider_code
   attribute :recruitment_cycle
   attribute :recruitment_cycle_year
+  attribute :funding_type
 end


### PR DESCRIPTION
### Context
This is the frontend counterpart to https://github.com/DFE-Digital/manage-courses-backend/pull/787, we want to switch away from feeding `program_type` and then using a translations file to determine how to present it to the user.

### Changes proposed in this pull request
Change instances of `funding` to `funding_type`, also use new `funding_type` values. Also enable strict parameters.

### Guidance to review