### PR TITLE
[2075] Setup UCAS contacts page

### DIFF
--- a/app/controllers/ucas_contacts_controller.rb
+++ b/app/controllers/ucas_contacts_controller.rb
@@ -1,0 +1,8 @@
+class UcasContactsController < ApplicationController
+  def index
+    @provider = Provider
+      .where(recruitment_cycle_year: Settings.current_cycle)
+      .find(params[:code])
+      .first
+  end
+end

--- a/app/views/ucas_contacts/index.html.erb
+++ b/app/views/ucas_contacts/index.html.erb
@@ -1,0 +1,197 @@
+<%= content_for :page_title, "UCAS contacts" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(provider_path(@provider.provider_code)) %>
+<% end %>
+
+<h1 class="govuk-heading-xl">UCAS contacts</h1>
+
+<div class="govuk-grid-row add-top-margin">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">These are contacts that were set in UCAS NetUpdate.</p>
+
+    <p class="govuk-body">You can no longer change these contacts in NetUpdate, as NetUpdate has now been turned off.</p>
+
+    <div class="govuk-inset-text">
+      <h2 class="govuk-heading-m">What does ‘information unknown’ mean?</h2>
+
+      <p class="govuk-body">Some of the contacts below are labelled ‘Information unknown’. This is because UCAS doesn’t have permission under the <%= link_to "General Data Protection Regulation", "https://www.gov.uk/government/publications/guide-to-the-general-data-protection-regulation", class: "govuk-link" %> (GDPR) to share these details with us.</p>
+
+      <p class="govuk-body">You can get hold of these details by contacting the UCAS Higher Education Provider Team (HEP Team) on 0344 984 1111 or at <%= mail_to "help_team@ucas.ac.uk", "help_team@ucas.ac.uk", class: "govuk-link" %>.</p>
+
+      <p class="govuk-body">Alternatively you can choose new contacts and we will send them to UCAS to update.</p>
+    </div>
+
+    <hr class="govuk-section-break govuk-section-break--l" />
+  </div>
+</div>
+
+<div class="govuk-grid-row add-top-margin">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">Who will UCAS contact?</h2>
+
+    <p class="govuk-body">UCAS will contact these people at your organisation:</p>
+
+    <dl class="govuk-summary-list govuk-!-margin-top-6 govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          UCAS Teacher Training (UTT) correspondent
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body" data-qa="provider__utt_contact">
+            <% if @provider.utt_contact.present? %>
+              <%= @provider.utt_contact[:name] %>
+              <%= @provider.utt_contact[:email] %>
+              <%= @provider.utt_contact[:telephone] %>
+            <% else %>
+              Information unknown
+            <% end %>
+          </p>
+          <p class="govuk-body-s">
+            This person will receive the UCAS monthly bulletin, which includes information about deadlines for application decisions
+          </p>
+        </dd>
+        <dd class="govuk-summary-list__actions"></dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          web-link correspondent
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body" data-qa="provider__web_link_contact">
+            <% if @provider.web_link_contact.present? %>
+              <%= @provider.web_link_contact[:name] %>
+              <%= @provider.web_link_contact[:email] %>
+              <%= @provider.web_link_contact[:telephone] %>
+            <% else %>
+              Information unknown
+            <% end %>
+          </p>
+          <p class="govuk-body-s">
+            This person will receive notices about UCAS systems and planned downtime
+          </p>
+        </dd>
+        <dd class="govuk-summary-list__actions"></dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Finance contact
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body" data-qa="provider__finance_contact">
+            <% if @provider.finance_contact.present? %>
+              <%= @provider.finance_contact[:name] %>
+              <%= @provider.finance_contact[:email] %>
+              <%= @provider.finance_contact[:telephone] %>
+            <% else %>
+              Information unknown
+            <% end %>
+          </p>
+          <p class="govuk-body-s">
+            This person will receive invoices from UCAS for payment of fees
+          </p>
+        </dd>
+        <dd class="govuk-summary-list__actions"></dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Fraud contact
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body" data-qa="provider__fraud_contact">
+            <% if @provider.fraud_contact.present? %>
+              <%= @provider.fraud_contact[:name] %>
+              <%= @provider.fraud_contact[:email] %>
+              <%= @provider.fraud_contact[:telephone] %>
+            <% else %>
+              Information unknown
+            <% end %>
+          </p>
+          <p class="govuk-body-s">
+            This person will receive alerts about fradulent activity (for example when a plagiarised personal statement is detected)
+          </p>
+        </dd>
+        <dd class="govuk-summary-list__actions"></dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          UCAS Administrator
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body" data-qa="provider__admin_contact">
+            <% if @provider.admin_contact.present? %>
+              <%= @provider.admin_contact[:name] %>
+              <%= @provider.admin_contact[:email] %>
+              <%= @provider.admin_contact[:telephone] %>
+            <% else %>
+              Information unknown
+            <% end %>
+          </p>
+          <p class="govuk-body-s">
+            This person is responsible for setting up and maintaining UCAS user accounts.
+          </p>
+        </dd>
+        <dd class="govuk-summary-list__actions"></dd>
+      </div>
+    </dl>
+
+    <hr class="govuk-section-break govuk-section-break--l" />
+
+    <h2 class="govuk-heading-l">Letters for successful applicants</h2>
+    <p class="govuk-body">UCAS sends all successful applicants a letter – this is known as a ‘GT12&nbsp;letter’.</p>
+
+    <dl class="govuk-summary-list govuk-!-margin-top-6 govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Email address (or URL) printed in the letter
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body" data-qa="provider__gt12_contact">
+            <% if @provider.gt12_contact.present? %>
+              <%= @provider.gt12_contact %>
+            <% else %>
+              Information unknown
+            <% end %>
+          </p>
+          <p class="govuk-body-s">
+            This person or website will receive responses from successful applicants replying to a GT12 letter.
+          </p>
+        </dd>
+        <dd class="govuk-summary-list__actions"></dd>
+      </div>
+    </dl>
+
+    <hr class="govuk-section-break govuk-section-break--l" />
+
+    <h2 class="govuk-heading-l">Email alerts for new applications</h2>
+
+    <dl class="govuk-summary-list govuk-!-margin-top-6 govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Email address (or URL) printed in the letter
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body" data-qa="provider__application_alert_contact">
+            <% if @provider.application_alert_contact.present? %>
+              <%= @provider.application_alert_contact %>
+            <% else %>
+              Information unknown
+            <% end %>
+          </p>
+        </dd>
+        <dd class="govuk-summary-list__actions"></dd>
+      </div>
+    </dl>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <div class="app-related">
+      <h2 class="govuk-heading-m">Changing your contact details</h2>
+      <p class="govuk-body">To request changes to your UCAS contact details email the Becoming a Teacher team:<br><a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Edit%20Primary%20%282C4%2F2XNM%29">becomingateacher<wbr>@digital.education.gov.uk</a></p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
     get '/request-access', on: :member, to: 'access_requests#new'
     post '/request-access', on: :member, to: 'access_requests#create'
 
+    get '/ucas-contacts', on: :member, to: 'ucas_contacts#index'
+
     # TODO: Extract year constraint to future proof for future cycles
     resources :recruitment_cycles, param: :year, constraints: { year: /2019|2020/ }, path: '', only: :show do
       get '/details', on: :member, to: 'providers#details'

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -26,6 +26,43 @@ FactoryBot.define do
     recruitment_cycle_year { '2019' }
     last_published_at { DateTime.new(2019).utc.iso8601 }
     content_status { 'Published' }
+    utt_contact do
+      {
+        name: "utt_contact@acme-scitt.org",
+        email: "utt_contact@acme-scitt.org",
+        telephone: "utt_contact@acme-scitt.org",
+      }
+    end
+    web_link_contact do
+      {
+        name: "web_link_contact@acme-scitt.org",
+        email: "web_link_contact@acme-scitt.org",
+        telephone: "web_link_contact@acme-scitt.org",
+      }
+    end
+    finance_contact do
+      {
+        name: "finance_contact@acme-scitt.org",
+        email: "finance_contact@acme-scitt.org",
+        telephone: "finance_contact@acme-scitt.org",
+      }
+    end
+    fraud_contact do
+      {
+        name: "fraud_contact@acme-scitt.org",
+        email: "fraud_contact@acme-scitt.org",
+        telephone: "fraud_contact@acme-scitt.org",
+      }
+    end
+    admin_contact do
+      {
+        name: "admin_contact@acme-scitt.org",
+        email: "admin_contact@acme-scitt.org",
+        telephone: "admin_contact@acme-scitt.org",
+      }
+    end
+    gt12_contact { "gt12_contact@acme-scitt.org" }
+    application_alert_contact { "application_alert_contact@acme-scitt.org" }
 
     after :build do |provider, evaluator|
       # Necessary gubbins necessary to make JSONAPIClient's associations work.

--- a/spec/features/providers/ucas_contacts_spec.rb
+++ b/spec/features/providers/ucas_contacts_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+feature 'View provider UCAS contact', type: :feature do
+  let(:org_ucas_contacts_page) { PageObjects::Page::Organisations::UcasContacts.new }
+  let(:provider) do
+    build :provider,
+          provider_code: 'A0'
+  end
+
+  before do
+    stub_omniauth
+
+    stub_api_v2_resource(provider)
+  end
+
+  scenario 'viewing organisation UCAS contacts page' do
+    visit ucas_contacts_provider_path(provider.provider_code)
+
+    expect(current_path).to eq ucas_contacts_provider_path(provider.provider_code)
+
+    expect(org_ucas_contacts_page.title).to have_content('UCAS contacts')
+
+    expect(org_ucas_contacts_page.utt_contact).to have_content(provider.utt_contact[:name])
+    expect(org_ucas_contacts_page.web_link_contact).to have_content(provider.web_link_contact[:name])
+    expect(org_ucas_contacts_page.finance_contact).to have_content(provider.finance_contact[:name])
+    expect(org_ucas_contacts_page.fraud_contact).to have_content(provider.fraud_contact[:name])
+    expect(org_ucas_contacts_page.admin_contact).to have_content(provider.admin_contact[:name])
+    expect(org_ucas_contacts_page.gt12_contact).to have_content(provider.gt12_contact)
+    expect(org_ucas_contacts_page.application_alert_contact).to have_content(provider.application_alert_contact)
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/ucas_contacts.rb
+++ b/spec/site_prism/page_objects/page/organisations/ucas_contacts.rb
@@ -1,0 +1,17 @@
+module PageObjects
+  module Page
+    module Organisations
+      class UcasContacts < PageObjects::Base
+        set_url '/organisations/{provider_code}/ucas-contacts'
+
+        element :utt_contact, '[data-qa="provider__utt_contact"]'
+        element :web_link_contact, '[data-qa="provider__web_link_contact"]'
+        element :finance_contact, '[data-qa="provider__finance_contact"]'
+        element :fraud_contact, '[data-qa="provider__fraud_contact"]'
+        element :admin_contact, '[data-qa="provider__admin_contact"]'
+        element :gt12_contact, '[data-qa="provider__gt12_contact"]'
+        element :application_alert_contact, '[data-qa="provider__application_alert_contact"]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
UCAS contacts

### Changes proposed in this pull request
Add `/ucas-contacts` and page

### Guidance to review
Manually navigate to `/organisations/XXX/ucas-contacts`

# After
![localhost_3000_organisations_2C4_ucas-contacts(Laptop with MDPI screen) (2)](https://user-images.githubusercontent.com/3071606/65264879-7bd01800-db07-11e9-892a-083591808363.png)