### PR TITLE
[2026] Hook up course creation

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -63,6 +63,8 @@ private
           :day,
           :month,
           :year,
+          :course_age_range_in_years_other_from,
+          :course_age_range_in_years_other_to,
         )
         .permit(
           :page,
@@ -90,6 +92,7 @@ private
           :study_mode,
           :applications_open_from,
           :start_date,
+          :age_range_in_years,
         )
     else
       ActionController::Parameters.new({}).permit(:course)
@@ -144,6 +147,11 @@ private
         course: course_params,
       ),
       start_date: new_provider_recruitment_cycle_courses_start_date_path(
+        params[:provider_code],
+        params[:recruitment_cycle_year],
+        course: course_params,
+      ),
+      age_range: new_provider_recruitment_cycle_courses_age_range_path(
         params[:provider_code],
         params[:recruitment_cycle_year],
         course: course_params,

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -31,6 +31,16 @@ module CourseBasicDetailConcern
     end
   end
 
+  def continue
+    @errors = errors
+
+    if @errors.present?
+      render :new
+    else
+      redirect_to next_step
+    end
+  end
+
 private
 
   def build_new_course
@@ -103,7 +113,7 @@ private
     @course_creation_params = course_params
   end
 
-  def next_step(current_step:)
+  def next_step
     next_step = NextCourseCreationStepService.new.execute(current_step: current_step)
     next_page = course_creation_path_for(next_step)
 

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -78,6 +78,9 @@ private
         :english,
         :science,
         :funding_type,
+        :level,
+        :is_send,
+        :program_type
       )
     else
       ActionController::Parameters.new({}).permit(:course)
@@ -90,10 +93,22 @@ private
 
   def next_step(current_step:)
     if current_step == :outcome
+      new_provider_recruitment_cycle_courses_apprenticeship_path(
+        params[:provider_code],
+        params[:recruitment_cycle_year],
+        course: course_params
+      )
+    elsif current_step == :apprenticeship
       new_provider_recruitment_cycle_courses_entry_requirements_path(
         params[:provider_code],
         params[:recruitment_cycle_year],
         course: course_params,
+      )
+    elsif current_step == :level
+      new_provider_recruitment_cycle_courses_outcome_path(
+        params[:provider_code],
+        params[:recruitment_cycle_year],
+        course: course_params
       )
     elsif current_step == :entry_requirements
       new_provider_recruitment_cycle_courses_outcome_path(

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -105,62 +105,39 @@ private
 
   def next_step(current_step:)
     next_step = NextCourseCreationStepService.new.execute(current_step: current_step)
+    next_page = course_creation_path_for(next_step)
 
-    if course_creation_paths.key?(next_step)
-      course_creation_paths[next_step]
-    else
+    if next_page.nil?
       raise "No path defined for next step: #{next_step}"
     end
+
+    next_page
   end
 
-  def course_creation_paths
-    {
-      apprenticeship:  new_provider_recruitment_cycle_courses_apprenticeship_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course: course_params,
-      ),
-      # Currently the page isnt built - so skip
-      location: new_provider_recruitment_cycle_courses_entry_requirements_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course: course_params,
-      ),
-      entry_requirements: new_provider_recruitment_cycle_courses_entry_requirements_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course: course_params,
-      ),
-      outcome: new_provider_recruitment_cycle_courses_outcome_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course: course_params,
-      ),
-      full_or_part_time: new_provider_recruitment_cycle_courses_study_mode_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course: course_params,
-      ),
-      applications_open: new_provider_recruitment_cycle_courses_applications_open_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course: course_params,
-      ),
-      start_date: new_provider_recruitment_cycle_courses_start_date_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course: course_params,
-      ),
-      age_range: new_provider_recruitment_cycle_courses_age_range_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course: course_params,
-      ),
-      confirmation: confirmation_provider_recruitment_cycle_courses_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course: course_params,
-      ),
-    }
+  def course_creation_path_for(page)
+    path_params = { course: course_params }
+
+    case page
+    when :apprenticeship
+      new_provider_recruitment_cycle_courses_apprenticeship_path(path_params)
+    # Currently the location page isnt built - so we skip that step
+    # and go to the entry_requirements for now
+    when :location
+      new_provider_recruitment_cycle_courses_entry_requirements_path(path_params)
+    when :entry_requirements
+      new_provider_recruitment_cycle_courses_entry_requirements_path(path_params)
+    when :outcome
+      new_provider_recruitment_cycle_courses_outcome_path(path_params)
+    when :full_or_part_time
+      new_provider_recruitment_cycle_courses_study_mode_path(path_params)
+    when :applications_open
+      new_provider_recruitment_cycle_courses_applications_open_path(path_params)
+    when :start_date
+      new_provider_recruitment_cycle_courses_start_date_path(path_params)
+    when :age_range
+      new_provider_recruitment_cycle_courses_age_range_path(path_params)
+    when :confirmation
+      confirmation_provider_recruitment_cycle_courses_path(path_params)
+    end
   end
 end

--- a/app/controllers/courses/age_range_controller.rb
+++ b/app/controllers/courses/age_range_controller.rb
@@ -4,10 +4,6 @@ module Courses
     decorates_assigned :course
     before_action :build_course, only: %i[edit update]
 
-    def continue
-      redirect_to next_step(current_step: :age_range)
-    end
-
     def update
       # Age range 'other' override
       course = params.dig(:course)
@@ -46,6 +42,12 @@ module Courses
     end
 
   private
+
+    def current_step
+      :age_range
+    end
+
+    def errors; end
 
     def build_course
       @course = Course

--- a/app/controllers/courses/age_range_controller.rb
+++ b/app/controllers/courses/age_range_controller.rb
@@ -1,17 +1,11 @@
 module Courses
   class AgeRangeController < ApplicationController
+    include CourseBasicDetailConcern
     decorates_assigned :course
     before_action :build_course, only: %i[edit update]
-    before_action :build_provider, :build_new_course, only: %i[new continue]
-
-    def new; end
 
     def continue
-      redirect_to confirmation_provider_recruitment_cycle_courses_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course_params,
-      )
+      redirect_to next_step(current_step: :age_range)
     end
 
     def update
@@ -53,39 +47,12 @@ module Courses
 
   private
 
-    def course_params
-      if params.key? :course
-        params.require(:course)
-          .except(
-            :course_age_range_in_years_other_from,
-            :course_age_range_in_years_other_to,
-)
-          .permit(:age_range_in_years)
-      else
-        ActionController::Parameters.new({}).permit(:course)
-      end
-    end
-
-    def build_provider
-      @provider = Provider
-                    .where(recruitment_cycle_year: params[:recruitment_cycle_year])
-                    .find(params[:provider_code])
-                    .first
-    end
-
     def build_course
       @course = Course
         .where(recruitment_cycle_year: params[:recruitment_cycle_year])
         .where(provider_code: params[:provider_code])
         .find(params[:code])
         .first
-    end
-
-    def build_new_course
-      @course = Course.build_new(
-        recruitment_cycle_year: @provider.recruitment_cycle_year,
-        provider_code: @provider.provider_code,
-      )
     end
   end
 end

--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -31,6 +31,7 @@ module Courses
           :level,
           :is_send,
           :study_mode,
+          :age_range_in_years,
         )
         .permit(
           :applications_open_from,

--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -41,6 +41,8 @@ module Courses
         )
     end
 
+    # This is needed to handle the fact that dates are optionally specified as year/month/day in the UI
+    # This method assigns the params to the correct YYYY-MM-DD value given what is selected
     def build_course_params
       if params.key?(:course)
         applications_open_from =

--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -12,7 +12,7 @@ module Courses
       if @errors.present?
         render :new
       else
-        redirect_to next_step(current_step: :applications_open)
+        redirect_to next_step
       end
     end
 
@@ -64,6 +64,10 @@ module Courses
       )
 
       @recruitment_cycle = RecruitmentCycle.find(cycle_year).first
+    end
+
+    def current_step
+      :applications_open
     end
   end
 end

--- a/app/controllers/courses/apprenticeship_controller.rb
+++ b/app/controllers/courses/apprenticeship_controller.rb
@@ -2,17 +2,11 @@ module Courses
   class ApprenticeshipController < ApplicationController
     include CourseBasicDetailConcern
 
-    def continue
-      @errors = errors
-
-      if @errors.present?
-        render :new
-      else
-        redirect_to next_step(current_step: :apprenticeship)
-      end
-    end
-
   private
+
+    def current_step
+      :apprenticeship
+    end
 
     def errors; end
   end

--- a/app/controllers/courses/apprenticeship_controller.rb
+++ b/app/controllers/courses/apprenticeship_controller.rb
@@ -3,23 +3,17 @@ module Courses
     include CourseBasicDetailConcern
 
     def continue
-      redirect_to confirmation_provider_recruitment_cycle_courses_path(
-        params[:provider_code],
-        params[:recruitment_cycle_year],
-        course_params,
-      )
+      @errors = errors
+
+      if @errors.present?
+        render :new
+      else
+        redirect_to next_step(current_step: :apprenticeship)
+      end
     end
 
   private
 
     def errors; end
-
-    def course_params
-      if params.key?(:course)
-        params.require(:course).permit(:funding_type)
-      else
-        ActionController::Parameters.new({}).permit
-      end
-    end
   end
 end

--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -4,11 +4,11 @@ module Courses
 
     before_action :not_found_if_no_gcse_subjects_required, except: :continue
 
-    def continue
-      redirect_to next_step(current_step: :entry_requirements)
-    end
-
   private
+
+    def current_step
+      :entry_requirements
+    end
 
     def errors
       course.gcse_subjects_required

--- a/app/controllers/courses/level_controller.rb
+++ b/app/controllers/courses/level_controller.rb
@@ -8,24 +8,12 @@ module Courses
       if @errors.present?
         render :new
       else
-        redirect_to new_provider_recruitment_cycle_courses_entry_requirements_path(
-          params[:provider_code],
-          params[:recruitment_cycle_year],
-          course_params,
-        )
+        redirect_to next_step(current_step: :level)
       end
     end
 
   private
 
     def errors; end
-
-    def course_params
-      if params.key?(:course)
-        params.require(:course).permit(:level, :is_send)
-      else
-        ActionController::Parameters.new({}).permit
-      end
-    end
   end
 end

--- a/app/controllers/courses/level_controller.rb
+++ b/app/controllers/courses/level_controller.rb
@@ -2,18 +2,12 @@ module Courses
   class LevelController < ApplicationController
     include CourseBasicDetailConcern
 
-    def continue
-      @errors = errors
-
-      if @errors.present?
-        render :new
-      else
-        redirect_to next_step(current_step: :level)
-      end
-    end
-
   private
 
     def errors; end
+
+    def current_step
+      :level
+    end
   end
 end

--- a/app/controllers/courses/outcome_controller.rb
+++ b/app/controllers/courses/outcome_controller.rb
@@ -2,17 +2,11 @@ module Courses
   class OutcomeController < ApplicationController
     include CourseBasicDetailConcern
 
-    def continue
-      @errors = errors
-
-      if @errors.present?
-        render :new
-      else
-        redirect_to next_step(current_step: :outcome)
-      end
-    end
-
   private
+
+    def current_step
+      :outcome
+    end
 
     def errors
       params.dig(:course, :qualification) ? {} : { qualification: ["Pick an outcome"] }

--- a/app/controllers/courses/start_date_controller.rb
+++ b/app/controllers/courses/start_date_controller.rb
@@ -8,24 +8,12 @@ module Courses
       if @errors.present?
         render :new
       else
-        redirect_to confirmation_provider_recruitment_cycle_courses_path(
-          params[:provider_code],
-          params[:recruitment_cycle_year],
-          course_params,
-        )
+        redirect_to next_step(current_step: :start_date)
       end
     end
 
   private
 
     def errors; end
-
-    def course_params
-      if params.key?(:course)
-        params.require(:course).permit(:start_date)
-      else
-        ActionController::Parameters.new({}).permit
-      end
-    end
   end
 end

--- a/app/controllers/courses/start_date_controller.rb
+++ b/app/controllers/courses/start_date_controller.rb
@@ -2,17 +2,11 @@ module Courses
   class StartDateController < ApplicationController
     include CourseBasicDetailConcern
 
-    def continue
-      @errors = errors
-
-      if @errors.present?
-        render :new
-      else
-        redirect_to next_step(current_step: :start_date)
-      end
-    end
-
   private
+
+    def current_step
+      :start_date
+    end
 
     def errors; end
   end

--- a/app/controllers/courses/study_mode_controller.rb
+++ b/app/controllers/courses/study_mode_controller.rb
@@ -2,16 +2,6 @@ module Courses
   class StudyModeController < ApplicationController
     include CourseBasicDetailConcern
 
-    def continue
-      @errors = errors
-
-      if @errors.present?
-        render :new
-      else
-        redirect_to next_step(current_step: :full_or_part_time)
-      end
-    end
-
     def update
       if params[:course][:study_mode] == "full_time_or_part_time"
         redirect_to request_change_provider_recruitment_cycle_course_path(params[:provider_code], params[:recruitment_cycle_year], params[:code])
@@ -21,6 +11,10 @@ module Courses
     end
 
   private
+
+    def current_step
+      :full_or_part_time
+    end
 
     def errors
       params.dig(:course, :study_mode) ? {} : { study_mode: ["Pick full time, part time or full time and part time"] }

--- a/app/controllers/courses/study_mode_controller.rb
+++ b/app/controllers/courses/study_mode_controller.rb
@@ -8,11 +8,7 @@ module Courses
       if @errors.present?
         render :new
       else
-        redirect_to confirmation_provider_recruitment_cycle_courses_path(
-          params[:provider_code],
-          params[:recruitment_cycle_year],
-          course_params,
-        )
+        redirect_to next_step(current_step: :full_or_part_time)
       end
     end
 
@@ -28,14 +24,6 @@ module Courses
 
     def errors
       params.dig(:course, :study_mode) ? {} : { study_mode: ["Pick full time, part time or full time and part time"] }
-    end
-
-    def course_params
-      if params.key?(:course)
-        params.require(:course).permit(:study_mode)
-      else
-        ActionController::Parameters.new({}).permit
-      end
     end
   end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -20,6 +20,8 @@ class CoursesController < ApplicationController
       .where(recruitment_cycle_year: @recruitment_cycle.year)
       .find(params[:provider_code])
       .first
+
+    build_new_course
   end
 
   def new
@@ -136,21 +138,44 @@ class CoursesController < ApplicationController
 private
 
   def course_params
-    params.require(:course).permit(
-      :page,
-      :about_course,
-      :course_length,
-      :course_length_other_length,
-      :fee_details,
-      :fee_international,
-      :fee_uk_eu,
-      :financial_support,
-      :how_school_placements_work,
-      :interview_process,
-      :other_requirements,
-      :personal_qualities,
-      :salary_details,
-      :required_qualifications,
+    if params.key? :course
+      params.require(:course).permit(
+        :page,
+        :about_course,
+        :course_length,
+        :course_length_other_length,
+        :fee_details,
+        :fee_international,
+        :fee_uk_eu,
+        :financial_support,
+        :how_school_placements_work,
+        :interview_process,
+        :other_requirements,
+        :personal_qualities,
+        :salary_details,
+        :required_qualifications,
+        :qualification, # qualification is actually "outcome"
+        :maths,
+        :english,
+        :science,
+        :level,
+        :is_send,
+        :program_type,
+        :study_mode,
+        :applications_open_from,
+        :start_date,
+        :funding_type,
+      )
+    else
+      ActionController::Parameters.new({}).permit(:course)
+    end
+  end
+
+  def build_new_course
+    @course = Course.build_new(
+      recruitment_cycle_year: @provider.recruitment_cycle_year,
+      provider_code: @provider.provider_code,
+      course: course_params.to_unsafe_hash,
     )
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -23,7 +23,7 @@ class CoursesController < ApplicationController
   end
 
   def new
-    redirect_to new_provider_recruitment_cycle_courses_outcome_path(@course.provider_code, @course.recruitment_cycle_year)
+    redirect_to new_provider_recruitment_cycle_courses_level_path(@course.provider_code, @course.recruitment_cycle_year)
   end
 
   def update

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -165,6 +165,7 @@ private
         :applications_open_from,
         :start_date,
         :funding_type,
+        :age_range_in_years,
       )
     else
       ActionController::Parameters.new({}).permit(:course)

--- a/app/services/next_course_creation_step_service.rb
+++ b/app/services/next_course_creation_step_service.rb
@@ -1,0 +1,22 @@
+class NextCourseCreationStepService
+  def execute(current_step:)
+    case current_step
+    when :level
+      :outcome
+    when :outcome
+      :apprenticeship
+    when :apprenticeship
+      :full_or_part_time
+    when :full_or_part_time
+      :location
+    when :location
+      :entry_requirements
+    when :entry_requirements
+      :applications_open
+    when :applications_open
+      :start_date
+    when :start_date
+      :confirmation
+    end
+  end
+end

--- a/app/services/next_course_creation_step_service.rb
+++ b/app/services/next_course_creation_step_service.rb
@@ -2,6 +2,8 @@ class NextCourseCreationStepService
   def execute(current_step:)
     case current_step
     when :level
+      :age_range
+    when :age_range
       :outcome
     when :outcome
       :apprenticeship

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -27,6 +27,11 @@
             </h1>
           </legend>
           <%= render "shared/error_messages", field: :age_range_in_years if @errors %>
+          <%= render 'shared/course_creation_hidden_fields',
+            form: form,
+            course_creation_params: @course_creation_params,
+            except_keys: [:age_range_in_years]
+          %>
           <%= render 'form_fields', form: form %>
         </fieldset>
       </div>

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -21,6 +21,11 @@
                   ),
                   method: :get do |form| %>
 
+      <%= render 'shared/course_creation_hidden_fields',
+        form: form,
+        course_creation_params: @course_creation_params,
+        except_keys: [:applications_open_from, :month, :day, :year]
+      %>
       <%= render 'form_fields', form: form %>
 
       <%= form.submit "Continue",

--- a/app/views/courses/apprenticeship/new.html.erb
+++ b/app/views/courses/apprenticeship/new.html.erb
@@ -18,6 +18,11 @@
                   ),
                   method: :get do |form| %>
 
+      <%= render 'shared/course_creation_hidden_fields',
+        form: form,
+        course_creation_params: @course_creation_params,
+        except_keys: [:program_type]
+      %>
       <%= render 'form_fields', form: form %>
 
       <%= form.submit "Continue",

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -15,6 +15,11 @@
                   method: :get do |form| %>
       <h2 class="govuk-heading-m remove-top-margin">Level</h2>
 
+      <%= render 'shared/course_creation_hidden_fields',
+        form: form,
+        course_creation_params: @course_creation_params,
+        except_keys: [:level]
+      %>
       <%= render 'form_fields', form: form %>
 
       <h2 class="govuk-heading-m remove-top-margin">

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -15,6 +15,11 @@
                   ),
                   method: :get do |form| %>
 
+      <%= render 'shared/course_creation_hidden_fields',
+        form: form,
+        course_creation_params: @course_creation_params,
+        except_keys: [:start_date]
+      %>
       <%= render 'form_fields', form: form %>
 
       <%= form.submit "Continue",

--- a/app/views/courses/study_mode/new.html.erb
+++ b/app/views/courses/study_mode/new.html.erb
@@ -17,6 +17,12 @@
                   ),
                   method: :get do |form| %>
 
+
+      <%= render 'shared/course_creation_hidden_fields',
+        form: form,
+        course_creation_params: @course_creation_params,
+        except_keys: [:study_mode]
+      %>
       <%= render 'form_fields', form: form %>
 
       <%= form.submit "Continue",

--- a/spec/features/courses/accredited_body/edit_spec.rb
+++ b/spec/features/courses/accredited_body/edit_spec.rb
@@ -49,7 +49,6 @@ feature "Edit accredited body", type: :feature do
       searching_returns_some_results
       fill_in "Name of accredited body", with: "ACME"
       click_on "Save and publish changes"
-
       expect(accredited_body_search).to be_displayed
     end
   end

--- a/spec/features/courses/age_range_in_years/new_spec.rb
+++ b/spec/features/courses/age_range_in_years/new_spec.rb
@@ -1,8 +1,11 @@
 require "rails_helper"
 
-feature "new course outcome", type: :feature do
+feature "new course age range", type: :feature do
   let(:new_age_range_page) do
     PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
+  end
+  let(:new_outcome_page) do
+    PageObjects::Page::Organisations::Courses::NewOutcomePage.new
   end
   let(:provider) { build(:provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
@@ -10,10 +13,7 @@ feature "new course outcome", type: :feature do
     build(:course,
           :new,
           provider: provider,
-          level: "primary",
-          edit_options: {
-            age_range_in_years: %w[3_to_7 5_to_11 7_to_11 7_to_14],
-          })
+          level: :primary)
   end
 
   before do
@@ -22,10 +22,7 @@ feature "new course outcome", type: :feature do
     new_course = build(:course,
                        :new,
                        provider: provider,
-                       level: "primary",
-                       edit_options: {
-                         age_range_in_years: %w[3_to_7 5_to_11 7_to_11 7_to_14],
-                       })
+                       level: :primary)
     stub_api_v2_new_resource(new_course)
     stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
@@ -38,9 +35,11 @@ feature "new course outcome", type: :feature do
       provider.recruitment_cycle_year,
     )
 
+    stub_api_v2_build_course(age_range_in_years: "3_to_7")
     choose("course_age_range_in_years_3_to_7")
     click_on "Continue"
 
-    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+
+    expect(new_outcome_page).to be_displayed
   end
 end

--- a/spec/features/courses/applications_open/new_spec.rb
+++ b/spec/features/courses/applications_open/new_spec.rb
@@ -35,6 +35,6 @@ feature "new course applications open", type: :feature do
 
     click_on "Continue"
 
-    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+    expect(current_path).to eq new_provider_recruitment_cycle_courses_start_date_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 end

--- a/spec/features/courses/apprenticeship/new_spec.rb
+++ b/spec/features/courses/apprenticeship/new_spec.rb
@@ -33,21 +33,21 @@ feature "new course apprenticeship", type: :feature do
     new_apprenticeship_page.funding_type_fields.apprenticeship.click
     new_apprenticeship_page.continue.click
 
-    expect(current_path).to eq new_provider_recruitment_cycle_courses_entry_requirements_path(provider.provider_code, provider.recruitment_cycle_year)
+    expect(current_path).to eq new_provider_recruitment_cycle_courses_study_mode_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
-  context 'Higher education program type' do
+  context "Higher education program type" do
     let(:next_step_page) do
-      PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new
+      PageObjects::Page::Organisations::Courses::NewStudyModePage.new
     end
-    let(:selected_fields) { { program_type: 'higher_education_programme' } }
+    let(:selected_fields) { { funding_type: "apprenticeship" } }
     let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
 
     before do
-      choose('course_program_type_higher_education_programme')
-      click_on 'Continue'
+      new_apprenticeship_page.funding_type_fields.apprenticeship.click
+      new_apprenticeship_page.continue.click
     end
 
-    it_behaves_like 'a course creation page'
+    it_behaves_like "a course creation page"
   end
 end

--- a/spec/features/courses/apprenticeship/new_spec.rb
+++ b/spec/features/courses/apprenticeship/new_spec.rb
@@ -4,7 +4,12 @@ feature "new course apprenticeship", type: :feature do
   let(:new_apprenticeship_page) do
     PageObjects::Page::Organisations::Courses::NewApprenticeshipPage.new
   end
-  let(:course) { build(:course, :new, provider: provider) }
+  let(:course) do
+    build(:course,
+          :new,
+          provider: provider,
+          gcse_subjects_required: %w[maths science english])
+  end
   let(:provider) { build(:provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
@@ -15,7 +20,6 @@ feature "new course apprenticeship", type: :feature do
     stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
     stub_api_v2_build_course
     stub_api_v2_build_course(funding_type: "apprenticeship")
-
     visit new_provider_recruitment_cycle_courses_apprenticeship_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
@@ -27,8 +31,23 @@ feature "new course apprenticeship", type: :feature do
 
   scenario "sends user to entry requirements" do
     new_apprenticeship_page.funding_type_fields.apprenticeship.click
-    new_apprenticeship_page.save.click
+    new_apprenticeship_page.continue.click
 
-    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+    expect(current_path).to eq new_provider_recruitment_cycle_courses_entry_requirements_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+
+  context 'Higher education program type' do
+    let(:next_step_page) do
+      PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new
+    end
+    let(:selected_fields) { { program_type: 'higher_education_programme' } }
+    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
+
+    before do
+      choose('course_program_type_higher_education_programme')
+      click_on 'Continue'
+    end
+
+    it_behaves_like 'a course creation page'
   end
 end

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -5,6 +5,7 @@ feature "Course confirmation", type: :feature do
   let(:course_confirmation_page) do
     PageObjects::Page::Organisations::CourseConfirmation.new
   end
+  let(:course) { build(:course) }
   let(:provider) { build(:provider) }
 
   before do
@@ -14,13 +15,14 @@ feature "Course confirmation", type: :feature do
     new_course = build(:course, :new, provider: provider)
     stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
     stub_api_v2_new_resource(new_course)
+    stub_api_v2_build_course
   end
 
   scenario "viewing the course details page" do
     visit confirmation_provider_recruitment_cycle_courses_path(
       provider.provider_code,
       provider.recruitment_cycle_year,
-          )
+    )
 
     expect(course_confirmation_page.title).to have_content(
       "Check your answers before confirming",

--- a/spec/features/courses/entry_requirements/new_spec.rb
+++ b/spec/features/courses/entry_requirements/new_spec.rb
@@ -30,7 +30,11 @@ feature "new course entry_requirements", type: :feature do
   context "level primary" do
     let(:level) { :primary }
     before do
-      stub_api_v2_build_course(maths: "expect_to_achieve_before_training_begins")
+      stub_api_v2_build_course(
+        maths: "expect_to_achieve_before_training_begins",
+        english: "expect_to_achieve_before_training_begins",
+        science: "expect_to_achieve_before_training_begins",
+      )
     end
 
     scenario "creating a new course" do
@@ -63,6 +67,8 @@ feature "new course entry_requirements", type: :feature do
       end
 
       choose("course_maths_expect_to_achieve_before_training_begins")
+      choose("course_english_expect_to_achieve_before_training_begins")
+      choose("course_science_expect_to_achieve_before_training_begins")
       click_on "Continue"
 
       expect(current_path).to eq new_provider_recruitment_cycle_courses_applications_open_path(provider.provider_code, provider.recruitment_cycle_year)
@@ -72,7 +78,10 @@ feature "new course entry_requirements", type: :feature do
   context "level secondary" do
     let(:level) { :secondary }
     before do
-      stub_api_v2_build_course(english: "expect_to_achieve_before_training_begins")
+      stub_api_v2_build_course(
+        maths: "expect_to_achieve_before_training_begins",
+        english: "expect_to_achieve_before_training_begins",
+      )
     end
     scenario "creating a new course" do
       visit new_provider_recruitment_cycle_courses_entry_requirements_path(
@@ -102,6 +111,7 @@ feature "new course entry_requirements", type: :feature do
       end
 
       choose("course_english_expect_to_achieve_before_training_begins")
+      choose("course_maths_expect_to_achieve_before_training_begins")
       click_on "Continue"
 
       expect(current_path).to eq new_provider_recruitment_cycle_courses_applications_open_path(provider.provider_code, provider.recruitment_cycle_year)

--- a/spec/features/courses/entry_requirements/new_spec.rb
+++ b/spec/features/courses/entry_requirements/new_spec.rb
@@ -12,6 +12,7 @@ feature "new course entry_requirements", type: :feature do
   before do
     stub_omniauth
     stub_api_v2_resource(provider)
+    stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_new_resource(course)
     stub_api_v2_build_course
   end
@@ -64,7 +65,7 @@ feature "new course entry_requirements", type: :feature do
       choose("course_maths_expect_to_achieve_before_training_begins")
       click_on "Continue"
 
-      expect(current_path).to eq new_provider_recruitment_cycle_courses_outcome_path(provider.provider_code, provider.recruitment_cycle_year)
+      expect(current_path).to eq new_provider_recruitment_cycle_courses_applications_open_path(provider.provider_code, provider.recruitment_cycle_year)
     end
   end
 
@@ -103,7 +104,7 @@ feature "new course entry_requirements", type: :feature do
       choose("course_english_expect_to_achieve_before_training_begins")
       click_on "Continue"
 
-      expect(current_path).to eq new_provider_recruitment_cycle_courses_outcome_path(provider.provider_code, provider.recruitment_cycle_year)
+      expect(current_path).to eq new_provider_recruitment_cycle_courses_applications_open_path(provider.provider_code, provider.recruitment_cycle_year)
     end
   end
 end

--- a/spec/features/courses/level/new_spec.rb
+++ b/spec/features/courses/level/new_spec.rb
@@ -5,7 +5,7 @@ feature "New course level", type: :feature do
     PageObjects::Page::Organisations::Courses::NewLevelPage.new
   end
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, :new, provider: provider, gcse_subjects_required_using_level: true) }
+  let(:course) { build(:course, :new, provider: provider, level: :primary, gcse_subjects_required_using_level: true) }
 
   before do
     stub_omniauth
@@ -22,12 +22,12 @@ feature "New course level", type: :feature do
     choose "Secondary"
     click_on "Continue"
 
-    expect(current_path).to eq new_provider_recruitment_cycle_courses_outcome_path(provider.provider_code, provider.recruitment_cycle_year)
+    expect(current_path).to eq new_provider_recruitment_cycle_courses_age_range_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
   context "Selecting primary" do
     let(:next_step_page) do
-      PageObjects::Page::Organisations::Courses::NewOutcomePage.new
+      PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
     end
     let(:selected_fields) { { level: "primary", is_send: "0" } }
     let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }

--- a/spec/features/courses/level/new_spec.rb
+++ b/spec/features/courses/level/new_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature 'New course level', type: :feature do
+feature "New course level", type: :feature do
   let(:new_level_page) do
     PageObjects::Page::Organisations::Courses::NewLevelPage.new
   end
@@ -25,11 +25,11 @@ feature 'New course level', type: :feature do
     expect(current_path).to eq new_provider_recruitment_cycle_courses_outcome_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
-  context 'Selecting primary' do
+  context "Selecting primary" do
     let(:next_step_page) do
       PageObjects::Page::Organisations::Courses::NewOutcomePage.new
     end
-    let(:selected_fields) { { level: 'primary', is_send: '0' } }
+    let(:selected_fields) { { level: "primary", is_send: "0" } }
     let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
 
     before do
@@ -38,6 +38,6 @@ feature 'New course level', type: :feature do
       new_level_page.continue.click
     end
 
-    it_behaves_like 'a course creation page'
+    it_behaves_like "a course creation page"
   end
 end

--- a/spec/features/courses/level/new_spec.rb
+++ b/spec/features/courses/level/new_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-feature "New course level", type: :feature do
-  let(:new_outcome_page) do
+feature 'New course level', type: :feature do
+  let(:new_level_page) do
     PageObjects::Page::Organisations::Courses::NewLevelPage.new
   end
   let(:provider) { build(:provider) }
@@ -13,15 +13,31 @@ feature "New course level", type: :feature do
     stub_api_v2_new_resource(course)
     stub_api_v2_build_course
     stub_api_v2_build_course(is_send: 0, level: "secondary")
+
+    visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
+    "/courses/level/new"
   end
 
   scenario "sends user to entry requirements" do
-    visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
-    "/courses/level/new"
-
     choose "Secondary"
     click_on "Continue"
 
-    expect(current_path).to eq new_provider_recruitment_cycle_courses_entry_requirements_path(provider.provider_code, provider.recruitment_cycle_year)
+    expect(current_path).to eq new_provider_recruitment_cycle_courses_outcome_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+
+  context 'Selecting primary' do
+    let(:next_step_page) do
+      PageObjects::Page::Organisations::Courses::NewOutcomePage.new
+    end
+    let(:selected_fields) { { level: 'primary', is_send: '0' } }
+    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
+
+    before do
+      build_course_with_selected_value_request
+      new_level_page.level_fields.primary.click
+      new_level_page.continue.click
+    end
+
+    it_behaves_like 'a course creation page'
   end
 end

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -174,8 +174,8 @@ private
   end
 
   def select_applications_open_from(course_creation_params)
-    course_creation_params[:applications_open_from] = "2019-10-09"
-    course.applications_open_from = DateTime.new(2019, 10, 9).utc.iso8601
+    course_creation_params[:applications_open_from] = recruitment_cycle.application_start_date
+    course.applications_open_from = DateTime.parse(recruitment_cycle.application_start_date).utc.iso8601
     stub_build_course_with_params(course_creation_params)
 
     new_applications_open_page.applications_open_field.click

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -8,10 +8,14 @@ feature "new course", type: :feature do
   let(:new_outcome_page) do
     PageObjects::Page::Organisations::Courses::NewOutcomePage.new
   end
+  let(:new_apprenticeship_page) do
+    PageObjects::Page::Organisations::Courses::NewApprenticeshipPage.new
+  end
   let(:new_entry_requirements_page) do
     PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new
   end
   let(:build_new_course_request) { stub_api_v2_build_course }
+<<<<<<< HEAD
   let(:build_new_course_with_outcome_request) do
     stub_api_v2_build_course("qualification" => "qts")
   end
@@ -31,6 +35,8 @@ feature "new course", type: :feature do
       "science" => "must_have_qualification_at_application_time",
     )
   end
+=======
+>>>>>>> 22508ca... [2026] Hook up four steps
   let(:provider) { build(:provider) }
   let(:course) do
     build :course,
@@ -46,9 +52,6 @@ feature "new course", type: :feature do
     stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
     stub_api_v2_new_resource(course)
     build_new_course_request
-    build_new_course_with_outcome_request
-    build_new_course_with_outcome_and_entry_requirements_request
-    build_new_course_with_outcome_2_and_entry_requirements_request
   end
 
   context "Beginning the course creation flow" do
@@ -61,9 +64,9 @@ feature "new course", type: :feature do
     scenario "redirects and renders new course outcome page" do
       go_to_new_course_page_for_provider(provider)
 
-      expect(current_path).to eq new_provider_recruitment_cycle_courses_outcome_path(provider.provider_code, provider.recruitment_cycle_year)
+      expect(current_path).to eq new_provider_recruitment_cycle_courses_level_path(provider.provider_code, provider.recruitment_cycle_year)
 
-      expect(new_outcome_page).to(
+      expect(new_level_page).to(
         be_displayed(
           recruitment_cycle_year: recruitment_cycle.year,
           provider_code: provider.provider_code,
@@ -73,38 +76,67 @@ feature "new course", type: :feature do
       # The qualifications for a new course that hasn't had it's level set just
       # happens to result in these qualifications. This will change when the new
       # course flow properly sets the level of the course.
-      expect(new_outcome_page).to have_qualification_fields
-      expect(new_outcome_page.qualification_fields).to have_qts
-      expect(new_outcome_page.qualification_fields).to have_pgce_with_qts
-      expect(new_outcome_page.qualification_fields).to have_pgde_with_qts
-      new_outcome_page.qualification_fields.qts.click
+      # expect(new_outcome_page).to have_qualification_fields
+      # expect(new_outcome_page.qualification_fields).to have_qts
+      # expect(new_outcome_page.qualification_fields).to have_pgce_with_qts
+      # expect(new_outcome_page.qualification_fields).to have_pgde_with_qts
+      # new_outcome_page.qualification_fields.qts.click
     end
   end
 
+<<<<<<< HEAD
   context "course creation flow" do
     scenario "creates the correct course" do
       # This is intended to be a test which will go through the entire flow
       # and ensure that the correct page gets displayed at the end
       # with the correct course being created
+=======
+  context 'course creation flow', :focus do
+    context 'SCITT' do
+      scenario 'creates the correct course' do
+        # This is intended to be a test which will go through the entire flow
+        # and ensure that the correct page gets displayed at the end
+        # with the correct course being created
+        go_to_new_course_page_for_provider(provider)
 
-      go_to_new_course_page_for_provider(provider)
+        expect(new_level_page).to be_displayed
+        course_creation_params = select_level({})
+        course_creation_params = select_outcome(course_creation_params)
+        course_creation_params = select_apprenticeship(course_creation_params)
+        _course_creation_params = select_entry_requirements(course_creation_params)
+      end
+    end
+  end
+>>>>>>> 22508ca... [2026] Hook up four steps
 
-      expect(new_outcome_page).to be_displayed
-      new_outcome_page.qualification_fields.qts.click
-      stub_api_v2_new_resource(course)
-      new_outcome_page.continue.click
+private
 
+  def select_level(course_creation_params)
+    course_creation_params[:level] = 'primary'
+    course_creation_params[:is_send] = '0'
+    stub_build_course_with_params(course_creation_params)
+
+<<<<<<< HEAD
       expect_page_to_be_displayed_with_query(
         page: new_entry_requirements_page,
         expected_query: {
           "course[qualification]" => "qts",
         },
       )
+=======
+    new_level_page.level_fields.primary.click
+    new_level_page.continue.click
+>>>>>>> 22508ca... [2026] Hook up four steps
 
-      select_entry_requirements
+    expect_page_to_be_displayed_with_query(
+      page: new_outcome_page,
+      expected_query_params: course_creation_params
+    )
 
-      # They loop for now
+    course_creation_params
+  end
 
+<<<<<<< HEAD
       expect_page_to_be_displayed_with_query(
         page: new_outcome_page,
         expected_query: {
@@ -114,13 +146,21 @@ feature "new course", type: :feature do
           "course[science]" => "must_have_qualification_at_application_time",
         },
       )
+=======
+  def select_outcome(course_creation_params)
+    course_creation_params[:qualification] = 'qts'
+    stub_build_course_with_params(course_creation_params)
+>>>>>>> 22508ca... [2026] Hook up four steps
 
-      # Ensure that everything gets carried through for course creation
+    new_outcome_page.qualification_fields.qts.click
+    new_outcome_page.continue.click
 
-      new_outcome_page.qualification_fields.pgce_with_qts.click
-      stub_api_v2_new_resource(course)
-      new_outcome_page.continue.click
+    expect_page_to_be_displayed_with_query(
+      page: new_apprenticeship_page,
+      expected_query_params: course_creation_params
+    )
 
+<<<<<<< HEAD
       expect_page_to_be_displayed_with_query(
         page: new_entry_requirements_page,
         expected_query: {
@@ -131,25 +171,59 @@ feature "new course", type: :feature do
         },
       )
     end
+=======
+    course_creation_params
+>>>>>>> 22508ca... [2026] Hook up four steps
   end
 
-private
+  def select_apprenticeship(course_creation_params)
+    course_creation_params[:program_type] = 'pg_teaching_apprenticeship'
+    stub_build_course_with_params(course_creation_params)
+
+    new_outcome_page.continue.click
+
+    expect_page_to_be_displayed_with_query(
+      page: new_entry_requirements_page,
+      expected_query_params: course_creation_params
+    )
+
+    course_creation_params
+  end
+
+  def stub_build_course_with_params(params)
+    stub_api_v2_build_course(params)
+  end
 
   def go_to_new_course_page_for_provider(provider)
     visit new_provider_recruitment_cycle_course_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
-  def expect_page_to_be_displayed_with_query(page:, expected_query:)
+  def expect_page_to_be_displayed_with_query(page:, expected_query_params:)
+    url_params = {}
+    expected_query_params.each { |k, v| url_params["course[#{k}]"] = v }
+
     expect(page).to be_displayed
-    query = page.url_matches["query"]
-    expect(query).to eq(expected_query)
+    query = page.url_matches['query']
+    expect(query).to eq(url_params)
   end
 
-  def select_entry_requirements
-    new_entry_requirements_page.maths_requirements.choose("course_maths_must_have_qualification_at_application_time")
-    new_entry_requirements_page.english_requirements.choose("course_english_must_have_qualification_at_application_time")
-    new_entry_requirements_page.science_requirements.choose("course_science_must_have_qualification_at_application_time")
+  def select_entry_requirements(course_creation_params)
+    course_creation_params[:english] = 'must_have_qualification_at_application_time'
+    course_creation_params[:maths] = 'must_have_qualification_at_application_time'
+    course_creation_params[:science] = 'must_have_qualification_at_application_time'
+    stub_build_course_with_params(course_creation_params)
+
+    new_entry_requirements_page.maths_requirements.choose('course_maths_must_have_qualification_at_application_time')
+    new_entry_requirements_page.english_requirements.choose('course_english_must_have_qualification_at_application_time')
+    new_entry_requirements_page.science_requirements.choose('course_science_must_have_qualification_at_application_time')
     new_entry_requirements_page.continue.click
+
+    expect_page_to_be_displayed_with_query(
+      page: new_outcome_page,
+      expected_query_params: course_creation_params
+    )
+
+    course_creation_params
   end
 
   def initial_params

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -5,6 +5,9 @@ feature "new course", type: :feature do
   let(:new_level_page) do
     PageObjects::Page::Organisations::Courses::NewLevelPage.new
   end
+  let(:new_age_range_page) do
+    PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
+  end
   let(:new_outcome_page) do
     PageObjects::Page::Organisations::Courses::NewOutcomePage.new
   end
@@ -31,7 +34,9 @@ feature "new course", type: :feature do
   let(:course) do
     build :course,
           :new,
+          level: :primary,
           provider: provider,
+          subjects: %w[English],
           gcse_subjects_required: %w[maths science english]
   end
 
@@ -75,6 +80,7 @@ feature "new course", type: :feature do
 
         expect(new_level_page).to be_displayed
         course_creation_params = select_level({})
+        course_creation_params = select_age_range(course_creation_params)
         course_creation_params = select_outcome(course_creation_params)
         course_creation_params = select_apprenticeship(course_creation_params)
         course_creation_params = select_study_mode(course_creation_params)
@@ -97,6 +103,21 @@ private
 
     new_level_page.level_fields.primary.click
     new_level_page.continue.click
+
+    expect_page_to_be_displayed_with_query(
+      page: new_age_range_page,
+      expected_query_params: course_creation_params,
+    )
+
+    course_creation_params
+  end
+
+  def select_age_range(course_creation_params)
+    course_creation_params[:age_range_in_years] = "5_to_11"
+    stub_build_course_with_params(course_creation_params)
+
+    choose("course_age_range_in_years_5_to_11")
+    click_on "Continue"
 
     expect_page_to_be_displayed_with_query(
       page: new_outcome_page,
@@ -138,6 +159,7 @@ private
 
   def select_study_mode(course_creation_params)
     course_creation_params[:study_mode] = "full_time"
+    course.study_mode = "full_time"
     stub_build_course_with_params(course_creation_params)
 
     new_study_mode_page.study_mode_fields.full_time.click
@@ -152,7 +174,8 @@ private
   end
 
   def select_applications_open_from(course_creation_params)
-    course_creation_params[:applications_open_from] = "2018-10-09"
+    course_creation_params[:applications_open_from] = "2019-10-09"
+    course.applications_open_from = DateTime.new(2019, 10, 9).utc.iso8601
     stub_build_course_with_params(course_creation_params)
 
     new_applications_open_page.applications_open_field.click
@@ -167,10 +190,11 @@ private
   end
 
   def select_start_date(course_creation_params)
-    course_creation_params[:start_date] = "September 2019"
+    course_creation_params[:start_date] = "September 2020"
+    course.start_date = Time.zone.local(2019, 9)
     stub_build_course_with_params(course_creation_params)
 
-    new_start_date_page.select "September 2019"
+    new_start_date_page.select "September 2020"
     new_start_date_page.continue.click
 
     #Addressable, the gem site-prism relies on, cannot match parameters containing a +

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -15,28 +15,6 @@ feature "new course", type: :feature do
     PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new
   end
   let(:build_new_course_request) { stub_api_v2_build_course }
-<<<<<<< HEAD
-  let(:build_new_course_with_outcome_request) do
-    stub_api_v2_build_course("qualification" => "qts")
-  end
-  let(:build_new_course_with_outcome_and_entry_requirements_request) do
-    stub_api_v2_build_course(
-      "qualification" => "qts",
-      "english" => "must_have_qualification_at_application_time",
-      "maths" => "must_have_qualification_at_application_time",
-      "science" => "must_have_qualification_at_application_time",
-    )
-  end
-  let(:build_new_course_with_outcome_2_and_entry_requirements_request) do
-    stub_api_v2_build_course(
-      "qualification" => "pgce_with_qts",
-      "english" => "must_have_qualification_at_application_time",
-      "maths" => "must_have_qualification_at_application_time",
-      "science" => "must_have_qualification_at_application_time",
-    )
-  end
-=======
->>>>>>> 22508ca... [2026] Hook up four steps
   let(:provider) { build(:provider) }
   let(:course) do
     build :course,
@@ -84,14 +62,7 @@ feature "new course", type: :feature do
     end
   end
 
-<<<<<<< HEAD
-  context "course creation flow" do
-    scenario "creates the correct course" do
-      # This is intended to be a test which will go through the entire flow
-      # and ensure that the correct page gets displayed at the end
-      # with the correct course being created
-=======
-  context 'course creation flow', :focus do
+  context 'course creation flow' do
     context 'SCITT' do
       scenario 'creates the correct course' do
         # This is intended to be a test which will go through the entire flow
@@ -107,7 +78,6 @@ feature "new course", type: :feature do
       end
     end
   end
->>>>>>> 22508ca... [2026] Hook up four steps
 
 private
 
@@ -116,17 +86,8 @@ private
     course_creation_params[:is_send] = '0'
     stub_build_course_with_params(course_creation_params)
 
-<<<<<<< HEAD
-      expect_page_to_be_displayed_with_query(
-        page: new_entry_requirements_page,
-        expected_query: {
-          "course[qualification]" => "qts",
-        },
-      )
-=======
     new_level_page.level_fields.primary.click
     new_level_page.continue.click
->>>>>>> 22508ca... [2026] Hook up four steps
 
     expect_page_to_be_displayed_with_query(
       page: new_outcome_page,
@@ -136,21 +97,9 @@ private
     course_creation_params
   end
 
-<<<<<<< HEAD
-      expect_page_to_be_displayed_with_query(
-        page: new_outcome_page,
-        expected_query: {
-          "course[qualification]" => "qts",
-          "course[english]" => "must_have_qualification_at_application_time",
-          "course[maths]" => "must_have_qualification_at_application_time",
-          "course[science]" => "must_have_qualification_at_application_time",
-        },
-      )
-=======
   def select_outcome(course_creation_params)
     course_creation_params[:qualification] = 'qts'
     stub_build_course_with_params(course_creation_params)
->>>>>>> 22508ca... [2026] Hook up four steps
 
     new_outcome_page.qualification_fields.qts.click
     new_outcome_page.continue.click
@@ -160,20 +109,7 @@ private
       expected_query_params: course_creation_params
     )
 
-<<<<<<< HEAD
-      expect_page_to_be_displayed_with_query(
-        page: new_entry_requirements_page,
-        expected_query: {
-          "course[qualification]" => "pgce_with_qts",
-          "course[english]" => "must_have_qualification_at_application_time",
-          "course[maths]" => "must_have_qualification_at_application_time",
-          "course[science]" => "must_have_qualification_at_application_time",
-        },
-      )
-    end
-=======
     course_creation_params
->>>>>>> 22508ca... [2026] Hook up four steps
   end
 
   def select_apprenticeship(course_creation_params)
@@ -184,6 +120,25 @@ private
 
     expect_page_to_be_displayed_with_query(
       page: new_entry_requirements_page,
+      expected_query_params: course_creation_params
+    )
+
+    course_creation_params
+  end
+
+  def select_entry_requirements(course_creation_params)
+    course_creation_params[:english] = 'must_have_qualification_at_application_time'
+    course_creation_params[:maths] = 'must_have_qualification_at_application_time'
+    course_creation_params[:science] = 'must_have_qualification_at_application_time'
+    stub_build_course_with_params(course_creation_params)
+
+    new_entry_requirements_page.maths_requirements.choose('course_maths_must_have_qualification_at_application_time')
+    new_entry_requirements_page.english_requirements.choose('course_english_must_have_qualification_at_application_time')
+    new_entry_requirements_page.science_requirements.choose('course_science_must_have_qualification_at_application_time')
+    new_entry_requirements_page.continue.click
+
+    expect_page_to_be_displayed_with_query(
+      page: new_outcome_page,
       expected_query_params: course_creation_params
     )
 
@@ -205,25 +160,6 @@ private
     expect(page).to be_displayed
     query = page.url_matches['query']
     expect(query).to eq(url_params)
-  end
-
-  def select_entry_requirements(course_creation_params)
-    course_creation_params[:english] = 'must_have_qualification_at_application_time'
-    course_creation_params[:maths] = 'must_have_qualification_at_application_time'
-    course_creation_params[:science] = 'must_have_qualification_at_application_time'
-    stub_build_course_with_params(course_creation_params)
-
-    new_entry_requirements_page.maths_requirements.choose('course_maths_must_have_qualification_at_application_time')
-    new_entry_requirements_page.english_requirements.choose('course_english_must_have_qualification_at_application_time')
-    new_entry_requirements_page.science_requirements.choose('course_science_must_have_qualification_at_application_time')
-    new_entry_requirements_page.continue.click
-
-    expect_page_to_be_displayed_with_query(
-      page: new_outcome_page,
-      expected_query_params: course_creation_params
-    )
-
-    course_creation_params
   end
 
   def initial_params

--- a/spec/features/courses/outcome/new_spec.rb
+++ b/spec/features/courses/outcome/new_spec.rb
@@ -7,10 +7,6 @@ feature "new course outcome", type: :feature do
   let(:provider) { build(:provider) }
   let(:course) { build(:course, provider: provider) }
   let(:empty_build_course_request) { stub_api_v2_build_course }
-<<<<<<< HEAD
-  let(:build_course_with_qualification_request) { stub_api_v2_build_course(qualification: "qts") }
-=======
->>>>>>> 4d86ff8... [2026] Refactor new page tests to shared examples
 
   before do
     stub_omniauth
@@ -28,43 +24,20 @@ feature "new course outcome", type: :feature do
     end
   end
 
-<<<<<<< HEAD
   context "Selecting QTS" do
+    let(:next_step_page) do
+      PageObjects::Page::Organisations::Courses::NewApprenticeshipPage.new
+    end
+    let(:selected_fields) { { qualification: "qts" } }
+    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(qualification: "qts") }
+
     before do
+      build_course_with_selected_value_request
       choose("course_qualification_qts")
       click_on "Continue"
     end
 
-    scenario "sends user to entry requirements" do
-      expect(new_entry_requirements_page).to be_displayed(
-        provider_code: provider.provider_code,
-        recruitment_cycle_year: provider.recruitment_cycle_year,
-      )
-    end
-
-    scenario "stores the qualification in the URL" do
-      expect(new_entry_requirements_page.url_matches["query"]).to eq("course[qualification]" => "qts")
-    end
-
-    scenario "it builds the course with the qualification" do
-      expect(build_course_with_qualification_request).to have_been_made.at_least_once
-    end
-=======
-  context 'Selecting QTS' do
-    let(:next_step_page) do
-      PageObjects::Page::Organisations::Courses::NewApprenticeshipPage.new
-    end
-    let(:selected_fields) { { qualification: 'qts' } }
-    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(qualification: 'qts') }
-
-    before do
-      build_course_with_selected_value_request
-      choose('course_qualification_qts')
-      click_on 'Continue'
-    end
-
-    it_behaves_like 'a course creation page'
->>>>>>> 4d86ff8... [2026] Refactor new page tests to shared examples
+    it_behaves_like "a course creation page"
   end
 
 private

--- a/spec/features/courses/outcome/new_spec.rb
+++ b/spec/features/courses/outcome/new_spec.rb
@@ -4,13 +4,13 @@ feature "new course outcome", type: :feature do
   let(:new_outcome_page) do
     PageObjects::Page::Organisations::Courses::NewOutcomePage.new
   end
-  let(:new_entry_requirements_page) do
-    PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new
-  end
   let(:provider) { build(:provider) }
   let(:course) { build(:course, provider: provider) }
   let(:empty_build_course_request) { stub_api_v2_build_course }
+<<<<<<< HEAD
   let(:build_course_with_qualification_request) { stub_api_v2_build_course(qualification: "qts") }
+=======
+>>>>>>> 4d86ff8... [2026] Refactor new page tests to shared examples
 
   before do
     stub_omniauth
@@ -18,7 +18,6 @@ feature "new course outcome", type: :feature do
     new_course = build(:course, :new, provider: provider, gcse_subjects_required_using_level: true)
     stub_api_v2_new_resource(new_course)
     empty_build_course_request
-    build_course_with_qualification_request
 
     visit_new_outcome_page
   end
@@ -29,6 +28,7 @@ feature "new course outcome", type: :feature do
     end
   end
 
+<<<<<<< HEAD
   context "Selecting QTS" do
     before do
       choose("course_qualification_qts")
@@ -49,6 +49,22 @@ feature "new course outcome", type: :feature do
     scenario "it builds the course with the qualification" do
       expect(build_course_with_qualification_request).to have_been_made.at_least_once
     end
+=======
+  context 'Selecting QTS' do
+    let(:next_step_page) do
+      PageObjects::Page::Organisations::Courses::NewApprenticeshipPage.new
+    end
+    let(:selected_fields) { { qualification: 'qts' } }
+    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(qualification: 'qts') }
+
+    before do
+      build_course_with_selected_value_request
+      choose('course_qualification_qts')
+      click_on 'Continue'
+    end
+
+    it_behaves_like 'a course creation page'
+>>>>>>> 4d86ff8... [2026] Refactor new page tests to shared examples
   end
 
 private

--- a/spec/features/courses/study_mode/new_spec.rb
+++ b/spec/features/courses/study_mode/new_spec.rb
@@ -5,7 +5,14 @@ feature "new course study mode", type: :feature do
     PageObjects::Page::Organisations::Courses::NewStudyModePage.new
   end
 
-  let(:course) { build(:course, :new, provider: provider) }
+  let(:course) do
+    build(
+      :course,
+      :new,
+      provider: provider,
+      gcse_subjects_required: %w[maths science english],
+    )
+  end
   let(:provider) { build(:provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
@@ -33,6 +40,6 @@ feature "new course study mode", type: :feature do
 
     click_on "Continue"
 
-    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+    expect(current_path).to eq new_provider_recruitment_cycle_courses_entry_requirements_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 end

--- a/spec/services/next_course_creation_step_service_spec.rb
+++ b/spec/services/next_course_creation_step_service_spec.rb
@@ -1,0 +1,68 @@
+describe NextCourseCreationStepService do
+  let(:service) { described_class.new }
+
+  shared_examples "next step" do
+    it "Returns the correct next step" do
+      next_step = service.execute(current_step: current_step)
+      expect(next_step).to eq(expected_next_step)
+    end
+  end
+
+  context "SCITT Provider" do
+    context "Current step: Level" do
+      let(:current_step) { :level }
+      let(:expected_next_step) { :outcome }
+
+      include_examples "next step"
+    end
+
+    context "Current step: Outcome" do
+      let(:current_step) { :outcome }
+      let(:expected_next_step) { :apprenticeship }
+
+      include_examples "next step"
+    end
+
+    context "Current step: Apprenticeship" do
+      let(:current_step) { :apprenticeship }
+      let(:expected_next_step) { :full_or_part_time }
+
+      include_examples "next step"
+    end
+
+    context "Current step: Full or part time" do
+      let(:current_step) { :full_or_part_time }
+      let(:expected_next_step) { :location }
+
+      include_examples "next step"
+    end
+
+    context "Current step: Locations" do
+      let(:current_step) { :location }
+      let(:expected_next_step) { :entry_requirements }
+
+      include_examples "next step"
+    end
+
+    context "Current step: Entry requirements" do
+      let(:current_step) { :entry_requirements }
+      let(:expected_next_step) { :applications_open }
+
+      include_examples "next step"
+    end
+
+    context "Current step: Applications open" do
+      let(:current_step) { :applications_open }
+      let(:expected_next_step) { :start_date }
+
+      include_examples "next step"
+    end
+
+    context "Current step: Start date" do
+      let(:current_step) { :start_date }
+      let(:expected_next_step) { :confirmation }
+
+      include_examples "next step"
+    end
+  end
+end

--- a/spec/services/next_course_creation_step_service_spec.rb
+++ b/spec/services/next_course_creation_step_service_spec.rb
@@ -11,6 +11,13 @@ describe NextCourseCreationStepService do
   context "SCITT Provider" do
     context "Current step: Level" do
       let(:current_step) { :level }
+      let(:expected_next_step) { :age_range }
+
+      include_examples "next step"
+    end
+
+    context "Current step: Age reange" do
+      let(:current_step) { :age_range }
       let(:expected_next_step) { :outcome }
 
       include_examples "next step"

--- a/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
@@ -2,7 +2,9 @@ module PageObjects
   module Page
     module Organisations
       class CourseConfirmation < CourseBase
-        set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/confirmation"
+        set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/confirmation{?query*}"
+
+        element :continue, '[data-qa="course__save"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_age_range_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_age_range_page.rb
@@ -3,7 +3,7 @@ module PageObjects
     module Organisations
       module Courses
         class NewAgeRangePage < CourseBase
-          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/age-range/new"
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/age-range/new{?query*}"
 
           element :age_range_fields, '[data-qa="course__age_range_in_years"]'
         end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_applications_open_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_applications_open_page.rb
@@ -3,13 +3,14 @@ module PageObjects
     module Organisations
       module Courses
         class NewApplicationsOpenPage < CourseBase
-          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/application_open/new"
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/applications-open/new{?query*}"
 
           element :applications_open_field, '[data-qa="applications_open_from"]'
           element :applications_open_field_other, '[data-qa="applications_open_from_other"]'
           element :applications_open_field_day, '[data-qa="day"]'
           element :applications_open_field_month, '[data-qa="month"]'
           element :applications_open_field_year, '[data-qa="year"]'
+          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
@@ -3,7 +3,7 @@ module PageObjects
     module Organisations
       module Courses
         class NewApprenticeshipPage < CourseBase
-          set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/apprenticeship/new{?query*}'
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/apprenticeship/new{?query*}"
 
           section :funding_type_fields, '[data-qa="course__funding_type"]' do
             element :apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'

--- a/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
@@ -3,13 +3,15 @@ module PageObjects
     module Organisations
       module Courses
         class NewApprenticeshipPage < CourseBase
-          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/apprenticeship/new"
+          set_url '/organisations/{provider_code}/{recruitment_cycle_year}/courses/apprenticeship/new{?query*}'
 
           section :funding_type_fields, '[data-qa="course__funding_type"]' do
             element :apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'
             element :fee, '[data-qa="course__funding_type_fee"]'
           end
+
           element :save, '[data-qa="course__save"]'
+          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_start_date_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_start_date_page.rb
@@ -2,8 +2,10 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class StartDatePage < CourseBase
-          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/start_date/new"
+        class NewStartDatePage < CourseBase
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/start-date/new{?query*}"
+
+          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_study_mode_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_study_mode_page.rb
@@ -3,13 +3,15 @@ module PageObjects
     module Organisations
       module Courses
         class NewStudyModePage < CourseBase
-          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/study_mode/new"
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/full-part-time/new{?query*}"
 
           section :study_mode_fields, '[data-qa="course__study_mode"]' do
             element :full_time, "#course_study_mode_full_time"
             element :part_time, "#course_study_mode_part_time"
             element :full_time_or_part_time, "#course_study_mode_full_time_or_part_time"
           end
+
+          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -143,8 +143,7 @@ private
     url = "/build_new_course?" \
       "provider_code=#{provider_code}&recruitment_cycle_year=#{recruitment_cycle_year}&"
 
-    url_params = params.map { |k, v| "course[#{k}]=#{v}" }.join("&")
-    url + url_params
+    url + params.to_query("course")
   end
 end
 

--- a/spec/support/shared_examples/course_creation.rb
+++ b/spec/support/shared_examples/course_creation.rb
@@ -1,8 +1,8 @@
-shared_examples_for 'a course creation page' do
+shared_examples_for "a course creation page" do
   scenario "sends user to the next step page" do
     expect(next_step_page).to be_displayed(
       provider_code: provider.provider_code,
-      recruitment_cycle_year: provider.recruitment_cycle_year
+      recruitment_cycle_year: provider.recruitment_cycle_year,
     )
   end
 
@@ -12,8 +12,8 @@ shared_examples_for 'a course creation page' do
       res
     end
 
-    expect(next_step_page.url_matches['query']).to eq(
-      query_hash
+    expect(next_step_page.url_matches["query"]).to eq(
+      query_hash,
     )
   end
 

--- a/spec/support/shared_examples/course_creation.rb
+++ b/spec/support/shared_examples/course_creation.rb
@@ -1,0 +1,23 @@
+shared_examples_for 'a course creation page' do
+  scenario "sends user to the next step page" do
+    expect(next_step_page).to be_displayed(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year
+    )
+  end
+
+  scenario "stores the selected field" do
+    query_hash = selected_fields.reduce({}) do |res, (k, v)|
+      res["course[#{k}]"] = v
+      res
+    end
+
+    expect(next_step_page.url_matches['query']).to eq(
+      query_hash
+    )
+  end
+
+  scenario "it builds the course with the selected value" do
+    expect(build_course_with_selected_value_request).to have_been_made.at_least_once
+  end
+end


### PR DESCRIPTION
### Context

To lay out the structure of how we hook up the `continue` methods to controllers - this adds a test which hooks up all the currently available steps for `SCITTs` with a `Primary` course

### Changes proposed in this pull request

- Add a service for calculating the next step, given the current step
  - The motivation behind this is so that it can be expanded by passing in whatever other data is needed e.g. `provider_type` or `level`
- Create a test which asserts the flow is correct for this type of course
- Add in test helpers for course creation tests

### Guidance to review
