### PR TITLE
[2224] Fix NoMethod Key for 403 handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -81,6 +81,8 @@ class ApplicationController < ActionController::Base
 private
 
   def user_has_not_accepted_terms(response_body)
+    return false unless response_body.is_a?(Hash)
+
     response_body.key?("meta") &&
       response_body["meta"]["error_type"] == "user_not_accepted_terms_and_conditions"
   end

--- a/spec/features/forbidden_api_requests_spec.rb
+++ b/spec/features/forbidden_api_requests_spec.rb
@@ -5,7 +5,7 @@ feature "Handling Forbidden responses from the backend", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request("/recruitment_cycles/2019", {}, :get, 403)
+    stub_api_v2_request("/recruitment_cycles/2019", "", :get, 403)
   end
 
   it "Does not redirect the page" do


### PR DESCRIPTION
### Context

`NoMethodError: undefined method `key?' for "":String` Was being thrown when getting `403` responses from the API due to incorrect assertions about the shape of the response in this situation.

### Changes proposed in this pull request

- Check that the response is a hash before checking for metadata 

### Guidance to review
