### PR TITLE
[XXXX] Remove financial information from course preview

### DIFF
--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -56,11 +56,6 @@
         <li><%= link_to 'Interview process', '#section-interviews', class: 'govuk-link' %></li>
       <% end %>
       <li><%= link_to 'How school placements work', '#section-schools', class: 'govuk-link' %></li>
-      <% if course.has_fees? %>
-        <li><%= link_to 'Fees', '#section-fees', class: 'govuk-link' %></li>
-      <% else %>
-        <li><%= link_to 'Salary', '#section-salary', class: 'govuk-link' %></li>
-      <% end %>
       <li><%= link_to 'Financial support', '#section-financial-support', class: 'govuk-link' %></li>
       <li><%= link_to 'Requirements', '#section-entry', class: 'govuk-link' %></li>
       <li><%= link_to 'About the training provider', '#section-about-provider', class: 'govuk-link' %></li>
@@ -78,13 +73,12 @@
 
     <%= render partial: 'courses/preview/about_schools' %>
 
-    <% if course.has_fees? %>
-      <%= render partial: 'courses/preview/fees' %>
-    <% else %>
-      <%= render partial: 'courses/preview/salary' %>
-    <% end %>
-
-    <%= render partial: 'courses/preview/financial_support/financial_support' %>
+    <div class="govuk-!-margin-bottom-8">
+      <h2 class="govuk-heading-l" id="section-financial-support">Financial support</h2>
+      <div class="govuk-inset-text">
+        <p class="govuk-body">Bursaries, scholarships and financial support for 2020/21 will be announced soon.</p>
+      </div>
+    </div>
 
     <%= render partial: 'courses/preview/entry_requirements_qualifications' %>
 

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -127,33 +127,7 @@ feature "Preview course", type: :feature do
     )
 
     expect(preview_course_page).to have_content(
-      "The course fees for #{Settings.current_cycle} – #{Settings.current_cycle + 1} are as follows",
-    )
-
-    expect(preview_course_page.uk_fees).to have_content(
-      "£9,250",
-    )
-
-    expect(preview_course_page.eu_fees).to have_content(
-      "£9,250",
-    )
-
-    expect(preview_course_page.international_fees).to have_content(
-      "£9,250",
-    )
-
-    expect(preview_course_page.fee_details).to have_content(
-      decorated_course.fee_details,
-    )
-
-    expect(preview_course_page).to_not have_salary_details
-
-    expect(preview_course_page.scholarship_amount).to have_content(
-      "£20,000",
-    )
-
-    expect(preview_course_page.bursary_amount).to have_content(
-      "£22,000",
+      "Bursaries, scholarships and financial support for 2020/21 will be announced soon.",
     )
 
     expect(preview_course_page.required_qualifications).to have_content(


### PR DESCRIPTION
### Context
Financial incentives

### Changes proposed in this pull request
Remove financial incentives until the announcement to align with FIND

### Guidance to review
🚢 

# After

![localhost_3000_organisations_T92_2020_courses_X130_preview(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/65901234-ae073280-e3af-11e9-9027-8389b7322ed2.png)
