### PR TITLE
Hide financial support information in preview

### DIFF
--- a/app/views/courses/preview/financial_support/_financial_support.html.erb
+++ b/app/views/courses/preview/financial_support/_financial_support.html.erb
@@ -4,20 +4,9 @@
   <% if course.funding_type == 'salary' %>
     <%= render partial: 'courses/preview/financial_support/salaried' %>
   <% else %>
-
-    <% if course.has_scholarship_and_bursary? %>
-      <%= render partial: 'courses/preview/financial_support/scholarship_and_bursary' %>
-    <% elsif course.has_bursary? %>
-      <%= render partial: 'courses/preview/financial_support/bursary' %>
-    <% else %>
-      <p class="govuk-body">
-        You may be eligible for a <a href="https://www.gov.uk/teacher-training-funding" class="govuk-link">loan while you study</a>.
-      </p>
-    <% end %>
-
-    <p class="govuk-body">
-      <a href="https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates" class="govuk-link">Financial support if you’re from outside the UK</a>.
-    </p>
+    <div class="govuk-inset-text">
+      <p class="govuk-body">Bursaries, scholarships and financial support for 2020/21 will be announced soon.</p>
+    </div>
   <% end %>
 
   <% if course.financial_support.present? %>

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -148,14 +148,6 @@ feature "Preview course", type: :feature do
 
     expect(preview_course_page).to_not have_salary_details
 
-    expect(preview_course_page.scholarship_amount).to have_content(
-      "£20,000",
-    )
-
-    expect(preview_course_page.bursary_amount).to have_content(
-      "£22,000",
-    )
-
     expect(preview_course_page.required_qualifications).to have_content(
       course.required_qualifications,
     )


### PR DESCRIPTION
Bursaries and scholarships haven't been announced yet.

Alternative to #662

Only modifies the financial support, doesn't affect fees or salaries or financial support text for salaried courses.
