### PR TITLE
[2267] Temporarily remove course counts from organisations page

### DIFF
--- a/app/views/providers/_provider.html.erb
+++ b/app/views/providers/_provider.html.erb
@@ -1,6 +1,5 @@
 <li>
   <h2 class="govuk-heading-m">
     <%= link_to provider.provider_name, provider_path(provider.provider_code), class: "govuk-link" %>
-    <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block"><%= pluralize(provider.course_count, 'course') %></span>
   </h2>
 </li>


### PR DESCRIPTION
Remove counts to avoid confusing users with incorrect numbers.

We should fix this properly in the backend:
https://trello.com/c/9EcGLugq/2267-course-counts-on-organisation-list-show-the-wrong-number-of-courses

