### PR TITLE
[2020] Add fields to confirmation page

### DIFF
--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -8,16 +8,194 @@
     <%= form_with model: course,
                   url: new_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year),
                   method: :post do |f| %>
-
       <hr class="govuk-section-break govuk-section-break--l">
+      <div class="govuk-grid-row govuk-!-margin-bottom-9">
+        <div class="govuk-grid-column-full">
+          <dl class="govuk-summary-list govuk-!-margin-bottom-0" data-qa="course__details">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Level
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__level">
+                <%= course.level&.humanize %>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                  Change<span class="govuk-visually-hidden"> Level</span>
+              </dd>
+            </div>
 
-      <p class="govuk-body">
-        <%= f.submit "Save new course",
-                      class: "govuk-button",
-                      data: { qa: 'course__save' } %>
-      </p>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                <abbr class="app-text-decoration-underline-dotted" title="Special educational needs and disability">SEND</abbr>
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__is_send">
+                <%= course.is_send? %>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                Change<span class="govuk-visually-hidden"> SEND</span>
+              </dd>
+            </div>
 
-      <p class="govuk-body">Saving this course will not publish it.</p>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                <%= 'Subject'.pluralize(course.subjects.count) %>
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__subjects">
+                <%= course.sorted_subjects %>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                  Change<span class="govuk-visually-hidden"> Subject</span>
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Age range
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__age_range">
+                <%= course.age_range %>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                Change<span class="govuk-visually-hidden"> age range</span>
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Outcome
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__qualifications">
+                <%= course.outcome %>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                Change<span class="govuk-visually-hidden"> outcome</span>
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Apprenticeship
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__apprenticeship">
+                <%= course.apprenticeship? %>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                Change<span class="govuk-visually-hidden"> apprenticeship</span>
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Full or part time
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__study_mode">
+                <%= course.study_mode.humanize %>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                Change<span class="govuk-visually-hidden"> full time of part time</span>
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Locations
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__locations">
+                <span class="app-course-parts__fields__value--empty">None</span>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                Change<span class="govuk-visually-hidden"> locations</span>
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Applications open
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__application_open_from">
+                <%= l(course.applications_open_from&.to_date) %>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                Change<span class="govuk-visually-hidden"> applications open date</span>
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Course starts
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__start_date">
+                <%= l(course.start_date&.to_date, format: :short) %>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                Change<span class="govuk-visually-hidden"> start date</span>
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Title
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__name">
+                <%= course.name %>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                Change<span class="govuk-visually-hidden"> title</span>
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Description
+              </dt>
+              <dd class="govuk-summary-list__value" data-qa="course__description">
+                <%= course.description %>
+              </dd>
+              <dd class="govuk-summary-list__actions"></dd>
+            </div>
+            <% if course.gcse_subjects_required.any? %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  UCAS Apply: GCSE requirements for applicants
+                </dt>
+                <dd class="govuk-summary-list__value govuk-!-padding-right-0" data-qa="course__entry_requirements">
+                  <% course.gcse_subjects_required.each do |subject| %>
+                    <%= render partial: 'courses/entry_requirements',
+                      locals: {
+                      gcse_subject: subject.titleize,
+                      gcse_subject_code: course[subject]
+                    } %>
+                  <% end %>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                  Change<span class="govuk-visually-hidden"> entry requirements</span>
+                </dd>
+              </div>
+            <% end %>
+            <% if course.next_cycle? && course.has_fees? %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Allocations
+                </dt>
+                <dd class="govuk-summary-list__value govuk-!-padding-right-0" data-qa="course__allocations_info">
+                  <% if course.subjects.include?('Physical education') %>
+                    <p class="govuk-body">Recruitment to fee-funded PE courses is limited by the number of places allocated to you by DfE.</p>
+                    <p class="govuk-body">If you haven't already, you must <%= govuk_link_to "request allocations", "https://docs.google.com/forms/d/e/1FAIpQLScxhMGaYil9KB4XWfVXG7Y_VQ-lmmr_xEkjWetcjIgLgTCIIA/viewform?usp=sf_link" %></p>
+                  <% else %>
+                    Recruitment is not restricted
+                  <% end %>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                </dd>
+              </div>
+            <% end %>
+          </dl>
+        </div>
+      </div>
+      <%= f.submit "Save new course",
+        class: "govuk-button",
+        data: { qa: 'course__save' } %>
+       <p class="govuk-body">Saving this course will not publish it.</p>
     <% end %>
   </div>
 </div>

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -27,5 +27,19 @@ feature "Course confirmation", type: :feature do
     expect(course_confirmation_page.title).to have_content(
       "Check your answers before confirming",
     )
+
+    expect(course_confirmation_page.details.level.text).to eq(course.level.capitalize)
+    expect(course_confirmation_page.details.is_send.text).to eq("No")
+    expect(course_confirmation_page.details.subjects.text).to include("English")
+    expect(course_confirmation_page.details.subjects.text).to include("English with Primary")
+    expect(course_confirmation_page.details.age_range.text).to eq("11 to 16")
+    expect(course_confirmation_page.details.study_mode.text).to eq("Full time")
+    expect(course_confirmation_page.details.locations.text).to eq("None")
+    expect(course_confirmation_page.details.application_open_from.text).to eq("1 January 2019")
+    expect(course_confirmation_page.details.start_date.text).to eq("January 2019")
+    expect(course_confirmation_page.details.name.text).to eq("English")
+    expect(course_confirmation_page.details.description.text).to eq("PGCE with QTS full time")
+    expect(course_confirmation_page.details.entry_requirements.text).to include("Maths GCSE: Taking")
+    expect(course_confirmation_page.details.entry_requirements.text).to include("English GCSE: Must have")
   end
 end

--- a/spec/features/courses/fee_or_salary/new_spec.rb
+++ b/spec/features/courses/fee_or_salary/new_spec.rb
@@ -7,7 +7,7 @@ feature "new course fee or salary", type: :feature do
 
   let(:course) { build(:course, :new, provider: provider) }
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, :new, provider: provider) }
+  let(:course) { build(:course, provider: provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
   before do

--- a/spec/features/courses/start_date/new_spec.rb
+++ b/spec/features/courses/start_date/new_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "New course start date", type: :feature do
   let(:recruitment_cycle) { build(:recruitment_cycle) }
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, :new, provider: provider) }
+  let(:course) { build(:course, provider: provider) }
 
   before do
     stub_omniauth
@@ -15,7 +15,7 @@ feature "New course start date", type: :feature do
     stub_api_v2_build_course(start_date: "September #{Settings.current_cycle}")
   end
 
-  scenario "choose coure start date" do
+  scenario "choose course start date" do
     visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
     "/courses/start-date/new"
 

--- a/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
@@ -5,6 +5,21 @@ module PageObjects
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/confirmation{?query*}"
 
         element :continue, '[data-qa="course__save"]'
+
+        section :details, '[data-qa="course__details"]' do
+          element :level, '[data-qa="course__level"]'
+          element :is_send, '[data-qa="course__is_send"]'
+          element :subjects, '[data-qa="course__subjects"]'
+          element :age_range, '[data-qa="course__age_range"]'
+          element :study_mode, '[data-qa="course__study_mode"]'
+          element :locations, '[data-qa="course__locations"]'
+          element :study_mode, '[data-qa="course__study_mode"]'
+          element :application_open_from, '[data-qa="course__application_open_from"]'
+          element :start_date, '[data-qa="course__start_date"]'
+          element :name, '[data-qa="course__name"]'
+          element :description, '[data-qa="course__description"]'
+          element :entry_requirements, '[data-qa="course__entry_requirements"]'
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

We need to display the data for the course in the confirmation page so the user can see what they have selected at a glance

### Changes proposed in this pull request

Adds the fields to the course confirmation page for the data we gather at the moment

![image](https://user-images.githubusercontent.com/976254/65970715-efa2e680-e45e-11e9-88e8-73dcfd5f9ed8.png)

### Guidance to review
