### PR TITLE
[1963] Hook up course create button

### DIFF
--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -5,9 +5,15 @@
     <h1 class="govuk-heading-xl">
       Check your answers before confirming
     </h1>
+    <%= render 'shared/errors' %>
     <%= form_with model: course,
-                  url: new_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year),
+                  url: provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year),
                   method: :post do |f| %>
+      <%= render 'shared/course_creation_hidden_fields',
+        form: f,
+        course_creation_params: @course_creation_params,
+        except_keys: []
+      %>
       <hr class="govuk-section-break govuk-section-break--l">
       <div class="govuk-grid-row govuk-!-margin-bottom-9">
         <div class="govuk-grid-column-full">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
       put "/about", on: :member, to: "providers#update"
       post "/publish", on: :member, to: "providers#publish"
 
-      resource :courses, only: [] do
+      resource :courses, only: %i[create] do
         resource :outcome, on: :member, only: %i[new], controller: "courses/outcome" do
           get "continue"
         end

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -5,25 +5,124 @@ feature "Course confirmation", type: :feature do
   let(:course_confirmation_page) do
     PageObjects::Page::Organisations::CourseConfirmation.new
   end
-  let(:course) { build(:course) }
+  let(:course_page) do
+    PageObjects::Page::Organisations::Course.new
+  end
   let(:provider) { build(:provider) }
+  let(:course) do
+    build(
+      :course,
+      provider: provider,
+    )
+  end
 
   before do
     stub_omniauth
     stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_resource(provider)
-    new_course = build(:course, :new, provider: provider)
-    stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
-    stub_api_v2_new_resource(new_course)
+    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_new_resource(course)
+    stub_api_v2_build_course
+
+    visit confirmation_provider_recruitment_cycle_courses_path(
+      provider.provider_code,
+      provider.recruitment_cycle_year,
+      course: {
+        level: course.level,
+      },
+    )
+
+    stub_api_v2_resource(recruitment_cycle)
+    stub_api_v2_resource(provider)
     stub_api_v2_build_course
   end
 
   scenario "viewing the course details page" do
-    visit confirmation_provider_recruitment_cycle_courses_path(
-      provider.provider_code,
-      provider.recruitment_cycle_year,
+    expect(course_confirmation_page.title).to have_content(
+      "Check your answers before confirming",
     )
 
+    expect(course_confirmation_page.details.level.text).to eq(course.level.capitalize)
+    expect(course_confirmation_page.details.is_send.text).to eq("No")
+    expect(course_confirmation_page.details.subjects.text).to include("English")
+    expect(course_confirmation_page.details.subjects.text).to include("English with Primary")
+    expect(course_confirmation_page.details.age_range.text).to eq("11 to 16")
+    expect(course_confirmation_page.details.study_mode.text).to eq("Full time")
+    expect(course_confirmation_page.details.locations.text).to eq("None")
+    expect(course_confirmation_page.details.application_open_from.text).to eq("1 January 2019")
+    expect(course_confirmation_page.details.start_date.text).to eq("January 2019")
+    expect(course_confirmation_page.details.name.text).to eq("English")
+    expect(course_confirmation_page.details.description.text).to eq("PGCE with QTS full time")
+    expect(course_confirmation_page.details.entry_requirements.text).to include("Maths GCSE: Taking")
+    expect(course_confirmation_page.details.entry_requirements.text).to include("English GCSE: Must have")
+  end
+
+  context "Saving the course" do
+    context "Successfully" do
+      scenario "It creates the course on the API" do
+        course.course_code = "A123"
+        stub_api_v2_resource(course, include: "sites,provider.sites,accrediting_provider")
+        course_create_request = stub_api_v2_request(
+          "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+          "/providers/#{provider.provider_code}" \
+          "/courses",
+          course.to_jsonapi,
+          :post, 200
+        )
+
+        course_confirmation_page.save.click
+
+        expect(course_create_request).to have_been_made
+      end
+
+      scenario "It displays the course page when created" do
+        course.course_code = "A123"
+        stub_api_v2_resource(course, include: "sites,provider.sites,accrediting_provider")
+        stub_api_v2_request(
+          "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+          "/providers/#{provider.provider_code}" \
+          "/courses",
+          course.to_jsonapi,
+          :post, 200
+        )
+
+        course_confirmation_page.save.click
+
+        expect(course_page).to be_displayed
+      end
+    end
+
+    context "With errors" do
+      scenario "It renders the confirmation page" do
+        stub_api_v2_request(
+          "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+          "/providers/#{provider.provider_code}" \
+          "/courses",
+          {
+            errors: [
+              {
+                "source": { "pointer": "/data/attributes/cats" },
+                "title":  "You need more cats",
+                "detail": "Cats are important",
+              },
+            ],
+          },
+          :post, 200
+        )
+
+        course_confirmation_page.save.click
+
+        expect_course_confirmation_page_to_display_course_information
+        expect(course_confirmation_page).to have_content(
+          "Cats are important",
+        )
+      end
+    end
+  end
+
+private
+
+  def expect_course_confirmation_page_to_display_course_information
     expect(course_confirmation_page.title).to have_content(
       "Check your answers before confirming",
     )

--- a/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
@@ -4,7 +4,7 @@ module PageObjects
       class CourseConfirmation < CourseBase
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/confirmation{?query*}"
 
-        element :continue, '[data-qa="course__save"]'
+        element :save, '[data-qa="course__save"]'
 
         section :details, '[data-qa="course__details"]' do
           element :level, '[data-qa="course__level"]'


### PR DESCRIPTION
### Context

In order to actually create a course - the save button needs to post to the API

### Changes proposed in this pull request

- Save the course
- Redirect if errors
- Show the saved course when created

### Guidance to review
