### PR TITLE
[2276] Send first and last name from dfe SignIn

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,6 +126,8 @@ private
   def add_token_to_connection
     payload = {
       email:           current_user_info["email"].to_s,
+      first_name:      current_user_info["first_name"].to_s,
+      last_name:       current_user_info["last_name"].to_s,
       sign_in_user_id: current_user_dfe_signin_id,
     }
     token = JWT.encode(payload,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -13,13 +13,15 @@ RSpec.describe ApplicationController, type: :controller do
     end
 
     context "user is authenticated" do
+      let(:user_first_name) { "John" }
+      let(:user_last_name) { "Smith" }
       let(:user_email) { "email@example.com" }
       let(:sign_in_user_id) { SecureRandom.uuid }
 
       let(:user_info) do
         {
-          "first_name" => "John",
-          "last_name" => "Smith",
+          "first_name" => user_first_name,
+          "last_name" => user_last_name,
           "email" => user_email,
         }
       end
@@ -28,6 +30,8 @@ RSpec.describe ApplicationController, type: :controller do
         {
           email:           user_email.to_s,
           sign_in_user_id: sign_in_user_id,
+          first_name:      user_first_name,
+          last_name:       user_last_name,
         }
       end
 


### PR DESCRIPTION
### Context

The backend needs to save users first and last name, and so it needs to be sent them from DfE SignIn

### Changes proposed in this pull request

Send the first and last name in the payload to DfE SignIn

### Guidance to review
