### PR TITLE
[2281] Remove concept of drafts for About your org

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -35,7 +35,7 @@ class ProvidersController < ApplicationController
 
   def update
     if @provider.update(provider_params)
-      flash[:success] = "Your changes have been saved"
+      flash[:success] = "Your changes have been published"
       redirect_to(
         details_provider_recruitment_cycle_path(
           @provider.provider_code,

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -99,7 +99,9 @@
         <% end %>
       </div>
 
-      <%= f.submit "Save", class: "govuk-button" %>
+      <hr class="govuk-section-break govuk-section-break--l">
+      <p class="govuk-body">Changes will appear on Find postgraduate teacher training within 2 hours.</p>
+      <%= f.submit "Save and publish changes", class: "govuk-button" %>
     <% end %>
 
     <div class="form-group">

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -81,7 +81,9 @@
         <%= f.text_field field, options.merge(class: 'govuk-input govuk-input--width-10') %>
       <% end %>
 
-      <%= f.submit "Save", class: "govuk-button" %>
+      <hr class="govuk-section-break govuk-section-break--l">
+      <p class="govuk-body">Changes will appear on Find postgraduate teacher training within 2 hours.</p>
+      <%= f.submit "Save and publish changes", class: "govuk-button" %>
     <% end %>
 
     <div class="form-group">

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -34,7 +34,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-summary-list govuk-summary-list--short">
+    <div class="govuk-summary-list govuk-summary-list--short govuk-!-margin-top-0">
       <h3 class="govuk-heading-m govuk-!-font-size-27">
         <%= govuk_link_to "Contact details", contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
       </h3>
@@ -64,32 +64,9 @@
 
   <aside class="govuk-grid-column-one-third" data-qa="provider__status_panel">
     <div class="app-related">
-      <div class="govuk-!-margin-bottom-6" data-qa="provider__content-status">
-        <%= provider.status_tag %>
-      </div>
-      <% if @provider&.last_published_at %>
-        <p class="govuk-body">Last published on <%= l(@provider&.last_published_at.to_date) %></p>
-      <% end %>
-
       <h2 class="govuk-heading-m">View on a course</h2>
       <p class="govuk-body">This information will show on all your courses.</p>
-      <p class="govuk-body">View any course to see how it will look to applicants.</p>
-
-      <% unless @provider.is_published? %>
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
-          <h2 class="govuk-heading-m">Publish</h2>
-          <% if @recruitment_cycle.current_and_open? %>
-            <p class="govuk-body">You can make changes to this after publishing it.</p>
-            <%= form_for provider, url: publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year), method: :post do |f| %>
-              <%= f.submit "Publish", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: 'provider__publish' } %>
-            <% end %>
-          <% else %>
-            <p class="govuk-body" data-qa="provider__next_cycle_publish_help_text">This will appear on all your courses on Find in October, when the new cycle opens.</p>
-            <%= form_for provider, url: publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year), method: :post do |f| %>
-              <%= f.submit "Publish in October", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: 'provider__publish_next_cycle' } %>
-            <% end %>
-          <% end %>
-      <% end %>
+      <p class="govuk-body">View any course to see how it looks to applicants.</p>
     </div>
   </aside>
 </div>

--- a/spec/features/providers/about_spec.rb
+++ b/spec/features/providers/about_spec.rb
@@ -77,7 +77,7 @@ feature "View provider about", type: :feature do
     click_on "Save"
 
     expect(org_details_page.flash).to have_content(
-      "Your changes have been saved",
+      "Your changes have been published",
     )
     expect(current_path).to eq details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year)
   end

--- a/spec/features/providers/details_spec.rb
+++ b/spec/features/providers/details_spec.rb
@@ -22,7 +22,7 @@ feature "View provider", type: :feature do
     end
 
     it "renders correctly" do
-      test_details_page "Empty"
+      test_details_page
     end
   end
 
@@ -34,7 +34,7 @@ feature "View provider", type: :feature do
     end
 
     it "renders correctly" do
-      test_details_page "Draft"
+      test_details_page
     end
   end
 
@@ -46,38 +46,11 @@ feature "View provider", type: :feature do
     end
 
     it "renders correctly" do
-      test_details_page "Published"
+      test_details_page
     end
   end
 
-  context "Current recruitment cycle" do
-    let(:provider) { build(:provider, content_status: "draft") }
-
-    it "Displays the publish button" do
-      expect(org_detail_page.publish_button).to be_present
-    end
-  end
-
-  context "Next recruitment cycle" do
-    let(:provider) do
-      recruitment_cycle = build(:recruitment_cycle, year: Settings.current_cycle + 1)
-      build(
-        :provider,
-        content_status: "draft",
-        recruitment_cycle: recruitment_cycle,
-      )
-    end
-
-    it "Displays the publish in next cycle button" do
-      expect(org_detail_page.publish_in_next_cycle_button).to be_present
-    end
-
-    it "Displays additional information about publishing" do
-      expect(org_detail_page.next_recruitment_cycle_publishing_information)
-    end
-  end
-
-  def test_details_page(expected_status)
+  def test_details_page
     expect_breadcrumbs_to_be_correct
 
     expect(current_path).to eq details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
@@ -97,9 +70,7 @@ feature "View provider", type: :feature do
     )
     expect(org_detail_page.train_with_us).to have_content(provider.train_with_us)
     expect(org_detail_page.train_with_disability).to have_content(provider.train_with_disability)
-
     expect(org_detail_page).to have_status_panel
-    expect(org_detail_page.content_status).to have_content(expected_status)
   end
 
   def expect_breadcrumbs_to_be_correct

--- a/spec/site_prism/page_objects/page/organisations/organisation_details.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_details.rb
@@ -13,12 +13,8 @@ module PageObjects
         element :train_with_us, "[data-qa=enrichment__train_with_us]"
         element :train_with_disability, "[data-qa=enrichment__train_with_disability]"
         element :status_panel, "[data-qa=provider__status_panel]"
-        element :content_status, "[data-qa=provider__content-status]"
         element :flash, ".govuk-success-summary"
         elements :breadcrumbs, ".govuk-breadcrumbs__link"
-        element :publish_button, "[data-qa=provider__publish]"
-        element :publish_in_next_cycle_button, "[data-qa=provider__publish_next_cycle]"
-        element :next_recruitment_cycle_publishing_information, "[data-qa=provider__next_cycle_publish_help_text]"
       end
     end
   end


### PR DESCRIPTION
### Context

The backend publishes all information, regardless of enrichment state.

### Changes proposed in this pull request

Reflect this in the design by removing content status label and publish button.

Update success text and save button to indicate publishing, and note how long it will take to propagate.

### Guidance to review

This is an MVP solution and doesn't tidy up all the now unused code.

![Screen Shot 2019-10-03 at 15 01 32](https://user-images.githubusercontent.com/319055/66134389-2ceaae00-e5f0-11e9-83fc-c53d774559e7.png)

![Screen Shot 2019-10-03 at 15 13 16](https://user-images.githubusercontent.com/319055/66134528-5e637980-e5f0-11e9-929e-ee1f0b5d8386.png)
