### PR TITLE
[2107] Temporarily disable financial support previewing

### DIFF
--- a/app/views/courses/preview/financial_support/_financial_support.html.erb
+++ b/app/views/courses/preview/financial_support/_financial_support.html.erb
@@ -4,9 +4,9 @@
   <% if course.funding_type == 'salary' %>
     <%= render partial: 'courses/preview/financial_support/salaried' %>
   <% else %>
-    <div class="govuk-inset-text">
-      <p class="govuk-body">Bursaries, scholarships and financial support for 2020/21 will be announced soon.</p>
-    </div>
+    <p class="app-missing-section">
+      You can’t preview information about bursaries, scholarships and financial support, but it will be displayed in Find postgraduate teacher training.
+    </p>
   <% end %>
 
   <% if course.financial_support.present? %>


### PR DESCRIPTION
### Context

- Hide for all courses until we have new financial incentives in manage-courses-frontend
- Hide for multi subject courses until we've correctly incorporated the logic (eg Physics with Maths)

We will need to re-enable this, probably in two stages.

Card for unhiding for new financial incentives:
https://trello.com/c/pIsLAc6m/2261-unhide-financial-incentives-after-announcement

Card for fixing multi-subjects:
https://trello.com/c/0BWV4OKF/2107-salaried-course-bursary-bug-zendesk-query