### PR TITLE
Improve design for withdrawn courses

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -7,7 +7,7 @@ class CourseDecorator < ApplicationDecorator
 
   def vacancies
     content = object.has_vacancies? ? "Yes" : "No"
-    content += " (" + edit_vacancy_link + ")"
+    content += " (" + edit_vacancy_link + ")" unless object.is_withdrawn?
     content.html_safe
   end
 
@@ -144,6 +144,8 @@ private
   def not_on_find
     if object.new_and_not_running?
       "No – still in draft"
+    elsif object.is_withdrawn?
+      "No – withdrawn"
     else
       "No"
     end

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -18,13 +18,13 @@
     <%= course.on_find(@provider) %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__applications">
-    <% if course.is_running? %>
+    <% if course.is_running? || course.is_withdrawn? %>
       <%= course.open_or_closed_for_applications %>
     <% end %>
   </td>
   <% if @recruitment_cycle.current_and_open? %>
     <td class="govuk-table__cell" data-qa="courses-table__vacancies">
-      <% if course.is_running? %>
+      <% if course.is_running? || course.is_withdrawn? %>
         <%= course.vacancies %>
       <% end %>
     </td>

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -1,14 +1,9 @@
-<% if course.not_running? %>
-  <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-3">
-    <div class="govuk-warning-text app-warning-text--inline">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        This course is not running.
-      </strong>
-    </div>
-    <p class="govuk-body">
-      It won’t appear online. To publish it you’ll need to contact the Becoming a Teacher team:<br /><%= bat_contact_mail_to bat_contact_email_address_with_wrap, subject: "Course not running" %>
-    </p>
+<% if course.is_withdrawn? %>
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      This course has been withdrawn
+    </strong>
   </div>
 <% end %>
 

--- a/app/views/courses/_status_panel.html.erb
+++ b/app/views/courses/_status_panel.html.erb
@@ -12,13 +12,14 @@
 
   <% if course.is_published? && course.is_running? %>
     <%= render partial: 'courses/status_panel/published' %>
+  <% elsif course.is_withdrawn? %>
+    <%= render partial: 'courses/status_panel/withdrawn' %>
   <% else %>
     <%= render partial: 'courses/status_panel/unpublished' %>
   <% end %>
 
-  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
-
   <% if course.is_running? %>
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
     <h3 class="govuk-heading-m">Withdraw</h3>
     <p class="govuk-body">Remove this course from Find and close applications.</p>
     <%= link_to 'Withdraw this course', withdraw_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link--destructive govuk-body", data: { qa: "course__withdraw-link" } %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -67,11 +67,9 @@
       <div class="govuk-grid-column-two-thirds">
         <%= render partial: 'courses/description_content' %>
       </div>
-      <% unless course.not_running? %>
-        <div class="govuk-grid-column-one-third" data-qa="course__status_panel">
-          <%= render partial: 'courses/status_panel' %>
-        </div>
-      <% end %>
+      <div class="govuk-grid-column-one-third" data-qa="course__status_panel">
+        <%= render partial: 'courses/status_panel' %>
+      </div>
     </div>
   </section>
 </div>

--- a/app/views/courses/status_panel/_withdrawn.html.erb
+++ b/app/views/courses/status_panel/_withdrawn.html.erb
@@ -1,0 +1,21 @@
+<h3 class="govuk-heading-s govuk-!-margin-bottom-0">Applications</h3>
+<p class="govuk-body" data-qa="course__open_for_applications"><%= course.open_or_closed_for_applications %></p>
+
+<h3 class="govuk-heading-s govuk-!-margin-0">Vacancies</h3>
+<p class="govuk-body" data-qa="course__has_vacancies">
+  <%= course.vacancies %>
+</p>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+<h3 class="govuk-heading-m">Preview</h3>
+<p class="govuk-body">See how this course looked.</p>
+<p class="govuk-body">
+  <%= link_to 'Preview course', preview_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link', "data-qa": "course__preview-link" %>
+</p>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+
+<h3 class="govuk-heading-m">Publish</h3>
+<p class="govuk-body">
+  If you need to republish this course contact the Becoming a Teacher team:<br /><%= bat_contact_mail_to bat_contact_email_address_with_wrap, subject: "Republish a withdrawn course" %>
+</p>

--- a/app/webpacker/stylesheets/_phase-tag.scss
+++ b/app/webpacker/stylesheets/_phase-tag.scss
@@ -7,20 +7,13 @@
     margin-top: -1px;
   }
 
-  &--not-running {
-    background: govuk-colour("light-grey");
-    color: govuk-colour("black");
-    margin-bottom: -1px;
-    margin-top: -1px;
-  }
-
   &--draft {
     background: govuk-colour("orange");
   }
 
   &--withdrawn {
-    background: govuk-colour("mid-grey");
-    color: govuk-colour("black");
+    background: govuk-colour("black");
+    color: govuk-colour("white");
   }
 
   &--published {

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -218,19 +218,28 @@ feature "Course show", type: :feature do
     end
   end
 
-  context "when the course is not running" do
+  context "when the course is withdrawn" do
     let(:course) {
       build :course,
+            findable?: false,
+            content_status: "withdrawn",
             ucas_status: "not_running",
             provider: provider
     }
 
-    scenario "it hides the status panel" do
-      expect(course_page).not_to have_status_panel
+    scenario "it displays a status panel" do
+      expect(course_page).to have_status_panel
+      expect(course_page.is_findable).to have_content("No – withdrawn")
+      expect(course_page.status_tag).to have_content("Withdrawn")
+      expect(course_page.open_for_applications).to have_content("Closed")
+      expect(course_page.has_vacancies).to have_content("No")
+      expect(course_page).to have_preview_link
+      expect(course_page).not_to have_last_published_at
+      expect(course_page).not_to have_publish
     end
 
     scenario "it shows a warning about the course status" do
-      expect(course_page).to have_content("This course is not running.")
+      expect(course_page).to have_content("This course has been withdrawn")
     end
   end
 


### PR DESCRIPTION
- Improve text contrast on status tag
- Show that applications are closed and No vacancies in courses table
- Give better guidance text on course page
- Put status panel back
- Allow users to preview
- Give instructions on how to republish

(Note: There's no test changes for the courses table because we don't have a courses spec since the test went missing in https://github.com/DFE-Digital/manage-courses-frontend/pull/444, should be fixed separately)

### Before and after

| Page | Before | After |
|-|-|-|
| Course | ![Screen Shot 2019-10-09 at 14 28 13](https://user-images.githubusercontent.com/319055/66485693-243b2180-eaa1-11e9-8cc1-92d065c74d0e.png) | ![Screen Shot 2019-10-09 at 14 27 21](https://user-images.githubusercontent.com/319055/66485694-24d3b800-eaa1-11e9-9d4f-a59ca211a043.png) |
| Courses table | ![Screen Shot 2019-10-09 at 14 28 04](https://user-images.githubusercontent.com/319055/66485759-3f0d9600-eaa1-11e9-8631-bd1b9757fbdf.png) | ![Screen Shot 2019-10-09 at 14 27 40](https://user-images.githubusercontent.com/319055/66485760-3f0d9600-eaa1-11e9-9699-0107425736a3.png) |