### PR TITLE
[2308] Use the "forbidden" page when accessing unauthorized provider url

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
     if user_has_not_accepted_terms(exception.env.body)
       redirect_to accept_terms_path
     else
-      respond_with_error(template: "errors/unauthorized", status: :forbidden, error_text: "Forbidden request")
+      respond_with_error(template: "errors/forbidden", status: :forbidden, error_text: "Forbidden request")
     end
   end
 

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">You are not permitted to see this page</h1>
     <p class="govuk-body">This page is restricted to certain users only.</p>
     <p class="govuk-body">
-      Contact us by email to request access to your organisation: <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses access request" %>
+      Contact us by email to request access: <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses access request" %>
     </p>
   </div>
 </div>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "You are not permitted to see this page" %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" data-qa="errors__forbidden">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">You are not permitted to see this page</h1>
     <p class="govuk-body">This page is restricted to certain users only.</p>

--- a/spec/features/forbidden_api_requests_spec.rb
+++ b/spec/features/forbidden_api_requests_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Handling Forbidden responses from the backend", type: :feature do
-  let(:unauthorized_page) { PageObjects::Page::Unauthorized.new }
+  let(:forbidden_page) { PageObjects::Page::Forbidden.new }
 
   before do
     stub_omniauth
@@ -13,8 +13,8 @@ feature "Handling Forbidden responses from the backend", type: :feature do
     expect(page.current_path).to eq("/organisations/A0")
   end
 
-  it "Renders the unauthorized page" do
+  it "Renders the forbidden page" do
     visit "/organisations/A0/"
-    expect(unauthorized_page.unauthorized_text).to be_visible
+    expect(forbidden_page.forbidden_text).to be_visible
   end
 end

--- a/spec/site_prism/page_objects/page/forbidden.rb
+++ b/spec/site_prism/page_objects/page/forbidden.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module Page
+    class Forbidden < PageObjects::Base
+      element :forbidden_text, "[data-qa=errors__forbidden]"
+    end
+  end
+end


### PR DESCRIPTION
### Context

Previously showed the "We don't know which org...." page which was not
accurate becaause they might have access to other providers.

### Changes proposed in this pull request

* Use the "forbidden" page when accessing unauthorized provider url

You can see that page currently at https://www.qa.publish-teacher-training-courses.service.gov.uk/403

![Selection_097](https://user-images.githubusercontent.com/19378/66561111-bd754100-eb50-11e9-9107-f86a6533ad5b.png)


### Guidance to review

We might want to improve the text on this page:
https://github.com/DFE-Digital/manage-courses-frontend/blob/462c82e8b61db354262675191ee0776af83f278e/app/views/errors/forbidden.html.erb#L5

This is the generic 403-forbidden page.

We could

* improve this page's copy
* have a page just for this specific circumstance with specific copy on it