### PR TITLE
[2308] Don't use a redirect for no-orgs page

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -9,7 +9,7 @@ class ProvidersController < ApplicationController
       .where(recruitment_cycle_year: Settings.current_cycle)
       .all
 
-    redirect_to unauthorized_path if @providers.empty?
+    render "providers/no_providers", status: :forbidden if @providers.empty?
     redirect_to provider_path(@providers.first.provider_code) if @providers.size == 1
   end
 

--- a/app/views/providers/no_providers.erb
+++ b/app/views/providers/no_providers.erb
@@ -1,0 +1,15 @@
+<%= content_for :page_title, "We don’t know which organisation you’re part of" %>
+
+<div class="govuk-grid-row" data-qa="errors__unauthorized">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">We don’t know which organisation you’re part of</h1>
+    <p class="govuk-body">You have successfully signed in with your DfE account but we don’t recognise the email address you’ve used. This might have happened if you were forwarded the original invitation email or if you’ve recently updated your email address.</p>
+    <p class="govuk-body">We need more information from you before we can give you access to your organisation’s courses.</p>
+    <p class="govuk-body">To gain access, please:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>check that you signed up using the email address we contacted</li>
+      <li>contact us to tell us which organisation you need access to</li>
+    </ul>
+    <p class="govuk-body"><%= bat_contact_mail_to "Contact us by email to request access to your organisation", subject: "Publish teacher training courses access request" %></p>
+  </div>
+</div>

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -81,9 +81,9 @@ describe ProvidersController, type: :controller do
           )
         end
 
-        it "redirects to manage-courses-ui" do
+        it "responds with forbidden" do
           get :index
-          expect(response).to redirect_to(unauthorized_path)
+          expect(response).to have_http_status(:forbidden)
         end
       end
     end

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -33,12 +33,13 @@ describe "Providers", type: :request do
     end
 
     context "user has no providers" do
-      it "redirects to manage-courses-ui" do
+      it "shows no-providers page" do
         current_recruitment_cycle = build(:recruitment_cycle)
         stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
         stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers", jsonapi(:providers_response, data: []))
         get(providers_path)
-        expect(response).to redirect_to(unauthorized_path)
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to include("We don’t know which organisation you’re part of")
       end
     end
   end


### PR DESCRIPTION
### Context

Currently redirects to `/40x`

### Changes proposed in this pull request

This means that a page refresh will work when the user is granted
access, and reduces risk of users incorrectly getting stuck here.

The new erb is a copy of `app/views/errors/unauthorized.html.erb`

This commit disentangles this use case from the generic 401/403
handling.

### Guidance to review

:ship: