### PR TITLE
[2324] Refactor subjects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :development, :test do
   gem "govuk-lint"
 
   # Ability to render JSONAPI
+  gem "jsonapi-deserializable"
   gem "jsonapi-renderer"
   gem "jsonapi-serializable"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,7 @@ GEM
       faraday (~> 0.15, >= 0.15.2)
       faraday_middleware (~> 0.9)
       rack (>= 0.2)
+    jsonapi-deserializable (0.2.0)
     jsonapi-renderer (0.2.2)
     jsonapi-serializable (0.3.1)
       jsonapi-renderer (~> 0.2.0)
@@ -459,6 +460,7 @@ DEPENDENCIES
   guard-rspec
   guard-rubocop
   json_api_client
+  jsonapi-deserializable
   jsonapi-renderer
   jsonapi-serializable
   jwt

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -103,6 +103,7 @@ private
           :applications_open_from,
           :start_date,
           :age_range_in_years,
+          :master_subject,
         )
     else
       ActionController::Parameters.new({}).permit(:course)

--- a/app/controllers/courses/subjects_controller.rb
+++ b/app/controllers/courses/subjects_controller.rb
@@ -1,0 +1,42 @@
+module Courses
+  class SubjectsController < ApplicationController
+    include CourseBasicDetailConcern
+    decorates_assigned :course
+    before_action :build_course, only: %i[edit update]
+
+    def update
+      master_subject = params.dig(:course, :master_subject)
+
+      if @course.update(subjects: [Subject.new(id: master_subject)])
+        flash[:success] = "Your changes have been saved"
+        redirect_to(
+          details_provider_recruitment_cycle_course_path(
+            @course.provider_code,
+            @course.recruitment_cycle_year,
+            @course.course_code,
+          ),
+        )
+      else
+        @errors = @course.errors.messages
+        render :edit
+      end
+    end
+
+  private
+
+    def current_step
+      nil
+    end
+
+    def errors; end
+
+    def build_course
+      @course = Course
+                  .includes(:subjects, :site_statuses)
+                  .where(recruitment_cycle_year: params[:recruitment_cycle_year])
+                  .where(provider_code: params[:provider_code])
+                  .find(params[:code])
+                  .first
+    end
+  end
+end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -240,6 +240,7 @@ private
 
     @provider_code = params[:provider_code]
     @course = Course
+      .includes(:subjects)
       .includes(site_statuses: [:site])
       .includes(provider: [:sites])
       .includes(:accrediting_provider)
@@ -259,6 +260,7 @@ private
 
     @provider_code = params[:provider_code]
     @course = Course
+      .includes(:subjects)
       .includes(:sites)
       .includes(provider: [:sites])
       .includes(:accrediting_provider)
@@ -321,13 +323,15 @@ private
       Settings.current_cycle,
     )
 
-    @source_course = Course.includes(:sites)
-                           .includes(provider: [:sites])
-                           .includes(:accrediting_provider)
-                           .where(recruitment_cycle_year: cycle_year)
-                           .where(provider_code: @provider_code)
-                           .find(params[:copy_from])
-                           .first
+    @source_course = Course
+      .includes(:subjects)
+      .includes(:sites)
+      .includes(provider: [:sites])
+      .includes(:accrediting_provider)
+      .where(recruitment_cycle_year: cycle_year)
+      .where(provider_code: @provider_code)
+      .find(params[:copy_from])
+      .first
   end
 
   def copy_field_if_present_in_source_course(field)

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -51,7 +51,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def sorted_subjects
-    object.subjects.sort.join("<br>").html_safe
+    object.subjects.map(&:subject_name).sort.join("<br>").html_safe
   end
 
   def length

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,6 +3,7 @@ class Course < Base
   belongs_to :provider, param: :provider_code
   has_many :site_statuses
   has_many :sites, through: :site_statuses, source: :site
+  has_many :subjects
 
   custom_endpoint :sync_with_search_and_compare, on: :member, request_method: :post
 
@@ -29,7 +30,7 @@ class Course < Base
   def self.build_new(params)
     response = connection.run(:get, "#{Course.site}build_new_course?#{params.to_query}")
 
-    course = Course.new(response.body["data"]["attributes"])
+    course = Course.parser.parse(Course, response).first
     course.meta = response.body["data"]["meta"]
 
     response.body["data"]["errors"].each do |error_hash|
@@ -38,6 +39,10 @@ class Course < Base
     end
 
     course
+  end
+
+  def has_physical_education_subject?
+    subjects.map(&:subject_name).include?("Physical education")
   end
 
   def full_time?

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,0 +1,8 @@
+class Subject < Base
+  has_many :course_subjects
+  has_many :courses, through: :course_subjects
+
+  property :type, type: :string
+  property :subject_code, type: :string
+  property :subject_name, type: :string
+end

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -34,7 +34,11 @@
         <dd class="govuk-summary-list__value" data-qa="course__subjects">
           <%= course.sorted_subjects %>
         </dd>
-        <dd class="govuk-summary-list__actions"></dd>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to subjects_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_subjects_link" } do %>
+            Change<span class="govuk-visually-hidden"> subjects</span>
+          <% end %>
+        </dd>
       </div>
 
       <% unless course.level == 'further_education' %>
@@ -245,7 +249,7 @@
             Allocations
           </dt>
           <dd class="govuk-summary-list__value govuk-!-padding-right-0" data-qa="course__allocations_info">
-            <% if course.subjects.include?('Physical education') %>
+            <% if course.has_physical_education_subject? %>
               <p class="govuk-body">Recruitment to fee-funded PE courses is limited by the number of places allocated to you by DfE.</p>
               <p class="govuk-body">If you haven't already, you must <%= govuk_link_to "request allocations", "https://docs.google.com/forms/d/e/1FAIpQLScxhMGaYil9KB4XWfVXG7Y_VQ-lmmr_xEkjWetcjIgLgTCIIA/viewform?usp=sf_link" %></p>
             <% else %>

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -184,7 +184,7 @@
                   Allocations
                 </dt>
                 <dd class="govuk-summary-list__value govuk-!-padding-right-0" data-qa="course__allocations_info">
-                  <% if course.subjects.include?('Physical education') %>
+                  <% if course.has_physical_education_subject? %>
                     <p class="govuk-body">Recruitment to fee-funded PE courses is limited by the number of places allocated to you by DfE.</p>
                     <p class="govuk-body">If you haven't already, you must <%= govuk_link_to "request allocations", "https://docs.google.com/forms/d/e/1FAIpQLScxhMGaYil9KB4XWfVXG7Y_VQ-lmmr_xEkjWetcjIgLgTCIIA/viewform?usp=sf_link" %></p>
                   <% else %>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -1,0 +1,1 @@
+<%= form.select :master_subject, @course.meta['edit_options']['subjects'].map { |subject| [subject["attributes"]["subject_name"], subject["id"]]}, {}, data: { qa: 'course__subjects' } %>

--- a/app/views/courses/subjects/edit.erb
+++ b/app/views/courses/subjects/edit.erb
@@ -1,0 +1,40 @@
+<%= content_for :page_title, "Change subjects – #{course.name_and_code}" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: course,
+          url: subjects_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+          method: :put do |form| %>
+
+      <div
+        class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:subjects]&.any?) %>"
+        data-qa="course__subjects">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+              Change subjects
+            </h1>
+          </legend>
+          <%= render "shared/error_messages", field: :subjects if @errors %>
+          <%= render 'form_fields', form: form %>
+        </fieldset>
+      </div>
+
+      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
+        class: "govuk-button", data: { qa: 'course__save' }
+      %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes',
+          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,9 @@ Rails.application.routes.draw do
         put "/accredited-body", on: :member, to: "courses/accredited_body#update"
         get "/accredited-body/search", on: :member, to: "courses/accredited_body#search"
 
+        get "/subjects", on: :member, to: "courses/subjects#edit"
+        put "/subjects", on: :member, to: "courses/subjects#update"
+
         get "/age-range", on: :member, to: "courses/age_range#edit"
         put "/age-range", on: :member, to: "courses/age_range#update"
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -15,6 +15,10 @@ describe CourseDecorator do
           provider: provider,
           accrediting_provider: provider,
           course_length: "OneYear",
+          subjects: [
+            build(:subject, subject_name: "English"),
+            build(:subject, subject_name: "Mathematics"),
+          ],
           open_for_applications?: true,
           last_published_at: "2019-03-05T14:42:34Z",
           recruitment_cycle: current_recruitment_cycle
@@ -37,7 +41,7 @@ describe CourseDecorator do
   end
 
   it "returns a list of subjects in alphabetical order" do
-    expect(decorated_course.sorted_subjects).to eq("English<br>English with Primary")
+    expect(decorated_course.sorted_subjects).to eq("English<br>Mathematics")
   end
 
   it "returns if applications are open or closed" do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     transient do
       sites { [] }
       site_statuses { [] }
+      subjects { [] }
       recruitment_cycle { build :recruitment_cycle }
       edit_options do
         # Shamelessly copied from backend. Also, will need updating when any of
@@ -90,7 +91,6 @@ FactoryBot.define do
     applications_open_from { DateTime.new(2019).utc.iso8601 }
     is_send? { false }
     level { "secondary" }
-    subjects { ["English", "English with Primary"] }
     about_course { nil }
     interview_process { nil }
     how_school_placements_work { nil }
@@ -120,6 +120,7 @@ FactoryBot.define do
 
     after :build do |course, evaluator|
       # Necessary gubbins necessary to make JSONAPIClient's associations work.
+      # https://github.com/JsonApiClient/json_api_client/issues/342
       course.sites = []
       evaluator.sites.each do |site|
         course.sites << site
@@ -128,6 +129,11 @@ FactoryBot.define do
       course.site_statuses = []
       evaluator.site_statuses.each do |site_status|
         course.site_statuses << site_status
+      end
+
+      course.subjects = []
+      evaluator.subjects&.each do |subject|
+        course.subjects << subject
       end
 
       course.recruitment_cycle = evaluator.recruitment_cycle

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :subject do
+    sequence(:id)
+    type { "subject" }
+    subject_code { "00" }
+    subject_name { "Primary with Mathematics" }
+  end
+end

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -37,7 +37,7 @@ feature "About course", type: :feature do
       "/recruitment_cycles/#{current_recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,courses.accrediting_provider",
+      "?include=subjects,sites,provider.sites,courses.accrediting_provider",
       course_response,
     )
 
@@ -45,7 +45,7 @@ feature "About course", type: :feature do
       "/recruitment_cycles/#{current_recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
+      "?include=subjects,sites,provider.sites,accrediting_provider",
       course_response,
     )
     stub_api_v2_request(
@@ -169,8 +169,18 @@ feature "About course", type: :feature do
       stub_api_v2_request(
         "/recruitment_cycles/#{current_recruitment_cycle.year}" \
         "/providers/#{provider.provider_code}" \
+        "/courses/#{course_2.course_code}" \
+        "?include=subjects,sites,provider.sites,accrediting_provider",
+        course_2.to_jsonapi(
+          include: %i[subjects provider sites recruitment_cycle],
+        ),
+      )
+
+      stub_api_v2_request(
+        "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+        "/providers/#{provider.provider_code}" \
         "/courses/#{course_3.course_code}" \
-        "?include=sites,provider.sites,accrediting_provider",
+        "?include=subjects,sites,provider.sites,accrediting_provider",
         course_3.to_jsonapi,
       )
 

--- a/spec/features/courses/accredited_body/edit_spec.rb
+++ b/spec/features/courses/accredited_body/edit_spec.rb
@@ -23,7 +23,7 @@ feature "Edit accredited body", type: :feature do
     stub_api_v2_resource(provider)
     stub_api_v2_resource(course)
     stub_api_v2_resource(course, include: "accrediting_provider")
-    stub_api_v2_resource(course, include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
 
     accredited_body_page.load_with_course(course)
   end

--- a/spec/features/courses/age_range_in_years/edit_spec.rb
+++ b/spec/features/courses/age_range_in_years/edit_spec.rb
@@ -14,8 +14,8 @@ feature "Edit course age range in years", type: :feature do
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-      build(:provider).to_jsonapi(include: %i[courses accrediting_provider]),
+      "/providers/#{provider.provider_code}?include=subjects,courses.accrediting_provider",
+      build(:provider).to_jsonapi(include: %i[subjects courses accrediting_provider]),
     )
 
     stub_course_request
@@ -95,8 +95,8 @@ feature "Edit course age range in years", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
     )
   end
 end

--- a/spec/features/courses/applications_open/edit_spec.rb
+++ b/spec/features/courses/applications_open/edit_spec.rb
@@ -14,8 +14,8 @@ feature "Edit course applications open", type: :feature do
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-      build(:provider).to_jsonapi(include: %i[courses accrediting_provider]),
+      "/providers/#{provider.provider_code}?include=subjects,courses.accrediting_provider",
+      build(:provider).to_jsonapi(include: %i[subjects courses accrediting_provider]),
     )
 
     stub_course_request
@@ -179,8 +179,8 @@ feature "Edit course applications open", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
     )
   end
 end

--- a/spec/features/courses/apprenticeship/edit_spec.rb
+++ b/spec/features/courses/apprenticeship/edit_spec.rb
@@ -94,8 +94,8 @@ feature "Edit course apprenticeship status", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
     )
   end
 end

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -8,20 +8,17 @@ feature "Course confirmation", type: :feature do
   let(:course_page) do
     PageObjects::Page::Organisations::Course.new
   end
+
+  let(:course) { build(:course, provider: provider, subjects: [build(:subject, subject_name: "English"), build(:subject, subject_name: "English with Primary")]) }
   let(:provider) { build(:provider) }
-  let(:course) do
-    build(
-      :course,
-      provider: provider,
-    )
-  end
 
   before do
     stub_omniauth
     stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_resource(provider)
-    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
-    stub_api_v2_new_resource(course)
+    new_course = build(:course, :new, provider: provider)
+    stub_api_v2_resource_collection([new_course], include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_new_resource(new_course)
     stub_api_v2_build_course
 
     visit confirmation_provider_recruitment_cycle_courses_path(
@@ -61,7 +58,7 @@ feature "Course confirmation", type: :feature do
     context "Successfully" do
       scenario "It creates the course on the API" do
         course.course_code = "A123"
-        stub_api_v2_resource(course, include: "sites,provider.sites,accrediting_provider")
+        stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
         course_create_request = stub_api_v2_request(
           "/recruitment_cycles/#{course.recruitment_cycle.year}" \
           "/providers/#{provider.provider_code}" \
@@ -77,7 +74,7 @@ feature "Course confirmation", type: :feature do
 
       scenario "It displays the course page when created" do
         course.course_code = "A123"
-        stub_api_v2_resource(course, include: "sites,provider.sites,accrediting_provider")
+        stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
         stub_api_v2_request(
           "/recruitment_cycles/#{course.recruitment_cycle.year}" \
           "/providers/#{provider.provider_code}" \

--- a/spec/features/courses/delete_or_withdraw_spec.rb
+++ b/spec/features/courses/delete_or_withdraw_spec.rb
@@ -19,8 +19,8 @@ feature "Getting rid of a course", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}/" \
       "providers/#{provider.provider_code}/" \
       "courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: %i[provider sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: %i[subjects provider sites]),
     )
 
     course_page.load(provider_code: provider.provider_code, recruitment_cycle_year: course.recruitment_cycle.year, course_code: course.course_code)

--- a/spec/features/courses/destroy_spec.rb
+++ b/spec/features/courses/destroy_spec.rb
@@ -25,7 +25,7 @@ feature "Delete course", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}/" \
       "providers/#{provider.provider_code}/" \
       "courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
+      "?include=subjects,sites,provider.sites,accrediting_provider",
       course.to_jsonapi(include: %i[provider sites]),
     )
     stub_api_v2_request(

--- a/spec/features/courses/details_spec.rb
+++ b/spec/features/courses/details_spec.rb
@@ -25,7 +25,7 @@ feature "Course details", type: :feature do
   end
   let(:course_response) do
     course.to_jsonapi(
-      include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites],
+      include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites],
     )
   end
 
@@ -37,7 +37,7 @@ feature "Course details", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
+      "?include=subjects,sites,provider.sites,accrediting_provider",
       course_response,
     )
   end
@@ -65,6 +65,11 @@ feature "Course details", type: :feature do
     expect(course_details_page.edit_age_range_link).to have_content(
       "Change age range",
     )
+
+    expect(course_details_page.edit_subjects_link).to have_content(
+      "Change subjects",
+    )
+
     expect(course_details_page.qualifications).to have_content(
       "PGCE with QTS",
     )
@@ -184,7 +189,7 @@ feature "Course details", type: :feature do
 
   scenario "viewing the show page for a course that does not exist" do
     stub_api_v2_request(
-      "/recruitment_cycles/#{Settings.current_cycle}/providers/ZZ/courses/ZZZ?include=sites,provider.sites,accrediting_provider",
+      "/recruitment_cycles/#{Settings.current_cycle}/providers/ZZ/courses/ZZZ?include=subjects,sites,provider.sites,accrediting_provider",
       "",
       :get,
       404,
@@ -218,7 +223,7 @@ feature "Course details", type: :feature do
           build :course,
                 provider: provider,
                 recruitment_cycle: next_recruitment_cycle,
-                subjects: ["Secondary", "Physical education"]
+                subjects: [build(:subject, subject_name: "Biology"), build(:subject, subject_name: "Physical education")]
         end
 
         scenario "displays no restrictions" do

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -19,8 +19,8 @@ feature "Edit course entry requirements", type: :feature do
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-      build(:provider).to_jsonapi(include: %i[courses accrediting_provider]),
+      "/providers/#{provider.provider_code}?include=subjects,courses.accrediting_provider",
+      build(:provider).to_jsonapi(include: %i[subjects courses accrediting_provider]),
     )
 
     stub_course_request
@@ -226,8 +226,8 @@ feature "Edit course entry requirements", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
     )
   end
 end

--- a/spec/features/courses/fee_or_salary/edit_spec.rb
+++ b/spec/features/courses/fee_or_salary/edit_spec.rb
@@ -14,8 +14,8 @@ feature "Edit course fee or salary status", type: :feature do
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-      provider.to_jsonapi(include: %i[courses accrediting_provider]),
+      "/providers/#{provider.provider_code}?include=subjects,courses.accrediting_provider",
+      provider.to_jsonapi(include: %i[subjects courses accrediting_provider]),
     )
 
     stub_course_request
@@ -97,8 +97,8 @@ feature "Edit course fee or salary status", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
     )
   end
 end

--- a/spec/features/courses/fee_or_salary/new_spec.rb
+++ b/spec/features/courses/fee_or_salary/new_spec.rb
@@ -16,7 +16,7 @@ feature "new course fee or salary", type: :feature do
     stub_api_v2_build_course
     stub_api_v2_build_course(funding_type: "fee")
     stub_api_v2_resource(recruitment_cycle)
-    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_build_course
 
     visit new_provider_recruitment_cycle_courses_fee_or_salary_path(provider.provider_code, provider.recruitment_cycle_year)

--- a/spec/features/courses/fees_spec.rb
+++ b/spec/features/courses/fees_spec.rb
@@ -216,6 +216,16 @@ feature "Course fees", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(
+        include: %i[subjects sites provider accrediting_provider],
+      ),
+    )
+
+    stub_api_v2_request(
+      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
+      "/courses/#{course.course_code}" \
       "?include=sites,provider.sites,accrediting_provider",
       course.to_jsonapi(
         include: %i[sites provider accrediting_provider],

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -36,9 +36,9 @@ feature "new course", type: :feature do
           :new,
           level: :primary,
           provider: provider,
-          subjects: %w[English],
           course_code: "A123",
           content_status: "draft",
+          subjects: [build(:subject, subject_name: "Primary with Mathematics")],
           gcse_subjects_required: %w[maths science english]
   end
   let(:course_creation_request) do
@@ -55,7 +55,7 @@ feature "new course", type: :feature do
     stub_omniauth
     stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_resource(provider)
-    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_new_resource(course)
     build_new_course_request
   end
@@ -120,7 +120,7 @@ private
 
   def save_course
     course_creation_request
-    stub_api_v2_resource(course, include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
     confirmation_page.save.click
   end
 

--- a/spec/features/courses/outcome/edit_spec.rb
+++ b/spec/features/courses/outcome/edit_spec.rb
@@ -164,8 +164,8 @@ feature "Edit course outcome", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
     )
   end
 end

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -62,7 +62,7 @@ feature "Preview course", type: :feature do
     stub_api_v2_request("/recruitment_cycles/#{course.recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
     stub_api_v2_request("/recruitment_cycles/#{course.recruitment_cycle.year}/recruitment_cycles", current_recruitment_cycle.to_jsonapi)
     stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/A0/courses/#{course.course_code}?include=site_statuses.site,provider.sites,accrediting_provider",
+      "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/A0/courses/#{course.course_code}?include=subjects,site_statuses.site,provider.sites,accrediting_provider",
       course_response,
     )
   end

--- a/spec/features/courses/requirements_spec.rb
+++ b/spec/features/courses/requirements_spec.rb
@@ -180,8 +180,8 @@ feature "Course requirements", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: %i[sites provider accrediting_provider]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: %i[subjects sites provider accrediting_provider]),
     )
   end
 end

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -170,9 +170,9 @@ feature "Course salary", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
+      "?include=subjects,sites,provider.sites,accrediting_provider",
       course.to_jsonapi(
-        include: %i[sites provider accrediting_provider recruitment_cycle],
+        include: %i[subjects sites provider accrediting_provider recruitment_cycle],
       ),
     )
   end

--- a/spec/features/courses/send/edit_spec.rb
+++ b/spec/features/courses/send/edit_spec.rb
@@ -105,8 +105,8 @@ feature "Edit course SEND", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
     )
   end
 end

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -41,7 +41,7 @@ feature "Course show", type: :feature do
 
   let(:course_response) do
     course.to_jsonapi(
-      include: %i[sites provider accrediting_provider recruitment_cycle],
+      include: %i[subjects sites provider accrediting_provider recruitment_cycle],
     )
   end
 
@@ -51,7 +51,7 @@ feature "Course show", type: :feature do
     stub_api_v2_resource current_recruitment_cycle
     stub_api_v2_resource next_recruitment_cycle
     stub_api_v2_resource course,
-                         include: "sites,provider.sites,accrediting_provider"
+                         include: "subjects,sites,provider.sites,accrediting_provider"
 
     visit provider_recruitment_cycle_course_path(course.provider.provider_code,
                                                  course.recruitment_cycle.year,
@@ -266,7 +266,7 @@ feature "Course show", type: :feature do
           "/recruitment_cycles/#{current_recruitment_cycle.year}" \
           "/providers/#{provider.provider_code}" \
           "/courses/#{course.course_code}" \
-          "?include=sites,provider.sites,accrediting_provider",
+          "?include=subjects,sites,provider.sites,accrediting_provider",
           course_response,
         )
       end

--- a/spec/features/courses/sites/edit_spec.rb
+++ b/spec/features/courses/sites/edit_spec.rb
@@ -38,8 +38,8 @@ feature "Edit course sites", type: :feature do
       "/recruitment_cycles/#{current_recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:accrediting_provider, :sites, provider: :sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:subjects, :accrediting_provider, :sites, provider: :sites]),
     )
 
     course_details_page.load(provider_code: provider.provider_code, recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
@@ -89,8 +89,8 @@ feature "Edit course sites", type: :feature do
         "/recruitment_cycles/#{current_recruitment_cycle.year}" \
         "/providers/#{provider.provider_code}" \
         "/courses/#{course.course_code}" \
-        "?include=sites,provider.sites,accrediting_provider",
-        course.to_jsonapi(include: [:sites, { provider: :sites }, :accrediting_provider]),
+        "?include=subjects,sites,provider.sites,accrediting_provider",
+        course.to_jsonapi(include: [:subjects, :sites, { provider: :sites }, :accrediting_provider]),
       )
     end
 

--- a/spec/features/courses/start_date/edit_spec.rb
+++ b/spec/features/courses/start_date/edit_spec.rb
@@ -132,8 +132,8 @@ feature "Edit course start date", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
     )
   end
 end

--- a/spec/features/courses/start_date/new_spec.rb
+++ b/spec/features/courses/start_date/new_spec.rb
@@ -10,7 +10,7 @@ feature "New course start date", type: :feature do
     stub_api_v2_resource(provider)
     stub_api_v2_new_resource(course)
     stub_api_v2_resource(recruitment_cycle)
-    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_build_course
     stub_api_v2_build_course(start_date: "September #{Settings.current_cycle}")
   end

--- a/spec/features/courses/study_mode/edit_spec.rb
+++ b/spec/features/courses/study_mode/edit_spec.rb
@@ -120,8 +120,8 @@ feature "Edit course study mode", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
     )
   end
 end

--- a/spec/features/courses/subjects/edit_spec.rb
+++ b/spec/features/courses/subjects/edit_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+xfeature "Edit course subjects", type: :feature do
+  let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+  let(:subjects_page) { PageObjects::Page::Organisations::CourseSubjects.new }
+  let(:course_details_page) { PageObjects::Page::Organisations::CourseDetails.new }
+  let(:course_request_change_page) { PageObjects::Page::Organisations::CourseRequestChange.new }
+  let(:provider) { build(:provider, site: site) }
+  let(:subjects) { [] }
+  let(:site) { build(:site) }
+  let(:site_status) { build(:site_status, site: site) }
+  let(:edit_options) { { subjects: subjects } }
+  let(:course) do
+    build(:course,
+          provider: provider,
+          edit_options: edit_options,
+          subjects: subjects,
+          sites: [site],
+          site_statuses: [site_status])
+  end
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses,accrediting_provider")
+    stub_api_v2_resource_collection([course])
+    stub_api_v2_resource(course, include: "subjects,site_statuses")
+    stub_api_v2_resource(course, include: "sites,accrediting_provider,provider.sites")
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+  end
+
+  scenario "can visit the subject edit page" do
+    course_details_page.load_with_course(course)
+    expect(course_details_page).to be_displayed
+    course_details_page.edit_subjects_link.click
+    expect(subjects_page).to be_displayed
+  end
+
+  context "with a given set of subjects" do
+    let(:subjects) { [build(:subject, subject_code: "00")] }
+    let(:edit_options) do
+      {
+        subjects: subjects,
+      }
+    end
+
+    scenario "can select a subject based on the level" do
+      stub_api_v2_resource(course, jsonapi_response: "{\"data\":{\"course_code\":\"X102\",\"type\":\"courses\",\"relationships\":{\"subjects\":{\"data\":[{\"type\":\"subjects\",\"id\":\"2\"}]}},\"attributes\":{}}}")
+
+      subjects_page.load_with_course(course)
+
+      subjects_page.subjects_fields.select(subjects.first.subject_name)
+      subjects_page.save.click
+      expect(course_details_page).to be_displayed
+    end
+  end
+end

--- a/spec/features/courses/withdraw_spec.rb
+++ b/spec/features/courses/withdraw_spec.rb
@@ -25,8 +25,8 @@ feature "Withdraw course", type: :feature do
       "/recruitment_cycles/#{course.recruitment_cycle.year}/" \
       "providers/#{provider.provider_code}/" \
       "courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: %i[provider sites]),
+      "?include=subjects,sites,provider.sites,accrediting_provider",
+      course.to_jsonapi(include: %i[subjects provider sites]),
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{course.recruitment_cycle.year}/" \

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe Course do
+  let(:provider)          { build :provider }
+  let(:course)            { build :course, :new, provider: provider }
   describe "#build_new" do
-    let(:provider)          { build :provider }
-    let(:course)            { build :course, :new, provider: provider }
     let(:recruitment_cycle) { course.recruitment_cycle }
     let(:build_course_stub) { stub_api_v2_build_course }
 
@@ -73,6 +73,18 @@ describe Course do
       it "is not running" do
         expect(course.not_running?).to eq(true)
       end
+    end
+  end
+
+  context "#has_physical_education_subject?" do
+    it "has a physical education subject" do
+      course = build(:course, subjects: [build(:subject, subject_name: "Physical education")])
+      expect(course.has_physical_education_subject?).to eq(true)
+    end
+
+    it "does not have a physical education subject" do
+      course = build(:course, subjects: [build(:subject, subject_name: "Biology")])
+      expect(course.has_physical_education_subject?).to eq(false)
     end
   end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -1,0 +1,3 @@
+describe Subject do
+  pending
+end

--- a/spec/requests/courses/about_spec.rb
+++ b/spec/requests/courses/about_spec.rb
@@ -12,7 +12,7 @@ describe "Courses", type: :request do
             recruitment_cycle: current_recruitment_cycle
     end
     let(:provider) { build :provider, accredited_body?: true, provider_code: "A0" }
-    let(:course_response) { course.to_jsonapi(include: %i[sites provider accrediting_provider recruitment_cycle]) }
+    let(:course_response) { course.to_jsonapi(include: %i[subjects sites provider accrediting_provider recruitment_cycle]) }
 
     let(:course_1) { build :course, name: "English", course_code: "EN01", include_nulls: [:accrediting_provider] }
     let(:course_2) do
@@ -33,11 +33,11 @@ describe "Courses", type: :request do
       get(auth_dfe_callback_path)
       stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
       stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course_response,
       )
       stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course_2_response,
       )
       stub_api_v2_request(
@@ -125,7 +125,7 @@ describe "Courses", type: :request do
       get(auth_dfe_callback_path)
       stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
       stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course_response,
       )
       stub_api_v2_request(

--- a/spec/requests/courses/delete_spec.rb
+++ b/spec/requests/courses/delete_spec.rb
@@ -12,14 +12,14 @@ describe "Courses", type: :request do
             recruitment_cycle: current_recruitment_cycle
     end
     let(:provider) { build :provider, accredited_body?: true, provider_code: "A0" }
-    let(:course_response) { course.to_jsonapi(include: %i[sites provider accrediting_provider recruitment_cycle]) }
+    let(:course_response) { course.to_jsonapi(include: %i[subjects sites provider accrediting_provider recruitment_cycle]) }
 
     before do
       stub_omniauth
       get(auth_dfe_callback_path)
       stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
       stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course_response,
       )
     end

--- a/spec/requests/courses/fees_spec.rb
+++ b/spec/requests/courses/fees_spec.rb
@@ -12,7 +12,7 @@ describe "Courses", type: :request do
             recruitment_cycle: current_recruitment_cycle
     end
     let(:provider)        { build(:provider, accredited_body?: true, provider_code: "A0") }
-    let(:course_response) { course.to_jsonapi(include: %i[sites provider accrediting_provider recruitment_cycle]) }
+    let(:course_response) { course.to_jsonapi(include: %i[subjects sites provider accrediting_provider recruitment_cycle]) }
 
     let(:course_1) { build :course, name: "English", course_code: "EN01", include_nulls: [:accrediting_provider] }
     let(:course_2) do
@@ -42,15 +42,15 @@ describe "Courses", type: :request do
       get(auth_dfe_callback_path)
       stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
       stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course_response,
       )
       stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course_2.to_jsonapi(include: %i[sites provider accrediting_provider recruitment_cycle]),
       )
       stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_3.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_3.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course_3.to_jsonapi(include: %i[sites provider accrediting_provider recruitment_cycle]),
       )
       stub_api_v2_request(

--- a/spec/requests/courses/requirements_spec.rb
+++ b/spec/requests/courses/requirements_spec.rb
@@ -12,7 +12,7 @@ describe "Courses", type: :request do
             recruitment_cycle: current_recruitment_cycle
     end
     let(:provider) { build(:provider, accredited_body?: true, provider_code: "A0") }
-    let(:course_response) { course.to_jsonapi(include: %i[sites provider accrediting_provider]) }
+    let(:course_response) { course.to_jsonapi(include: %i[subjects sites provider accrediting_provider]) }
 
     let(:course_1) { build :course, name: "English", course_code: "EN01", include_nulls: [:accrediting_provider] }
     let(:course_2) do
@@ -32,11 +32,11 @@ describe "Courses", type: :request do
       get(auth_dfe_callback_path)
       stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
       stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course_response,
       )
       stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course_2.to_jsonapi,
       )
       stub_api_v2_request(

--- a/spec/requests/courses/salary_spec.rb
+++ b/spec/requests/courses/salary_spec.rb
@@ -30,11 +30,11 @@ describe "Courses", type: :request do
       get(auth_dfe_callback_path)
       stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
       stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course_response,
       )
       stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course_2.to_jsonapi,
       )
       stub_api_v2_request(

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -11,7 +11,7 @@ describe "Courses" do
       get(auth_dfe_callback_path)
       stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
       stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=sites,provider.sites,accrediting_provider",
+        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
         course.to_jsonapi(include: %i[sites provider accrediting_provider]),
       )
     end

--- a/spec/site_prism/page_objects/page/organisations/course_details.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_details.rb
@@ -26,6 +26,7 @@ module PageObjects
         element :is_send, "[data-qa=course__is_send]"
         element :edit_is_send_link, "[data-qa=course__edit_is_send]"
         element :subjects, "[data-qa=course__subjects]"
+        element :edit_subjects_link, "[data-qa=course__edit_subjects_link]"
         element :age_range, "[data-qa=course__age_range]"
         element :edit_age_range_link, "[data-qa=course__edit_age_range_link]"
         element :level, "[data-qa=course__level]"

--- a/spec/site_prism/page_objects/page/organisations/course_subjects.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_subjects.rb
@@ -1,0 +1,12 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseSubjects < CourseBase
+        set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/subjects"
+
+        element :subjects_fields, '[data-qa="course__subjects"]'
+        element :save, '[data-qa="course__save"]'
+      end
+    end
+  end
+end

--- a/spec/support/define_factory_jsonapi_render_methods.rb
+++ b/spec/support/define_factory_jsonapi_render_methods.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
           SiteStatus: SiteStatusSerializer,
           User: UserSerializer,
           ProviderSuggestion: ProviderSuggestionSerializer,
+          Subject: SubjectSerializer,
         },
         include: opts[:include],
       )

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -99,7 +99,7 @@ module Helpers
   end
 
   def stub_api_v2_build_course(params = {})
-    jsonapi_response = course.to_jsonapi
+    jsonapi_response = course.to_jsonapi(include: [:subjects])
     jsonapi_response[:data][:meta] = course.meta
     jsonapi_response[:data][:errors] = []
     stub_api_v2_request(

--- a/spec/support/resource_list_to_jstonapi.rb
+++ b/spec/support/resource_list_to_jstonapi.rb
@@ -14,6 +14,7 @@ def resource_list_to_jsonapi(resource_list, **opts)
       SiteStatus: SiteStatusSerializer,
       User: UserSerializer,
       ProviderSuggestion: ProviderSuggestionSerializer,
+      Subject: SubjectSerializer,
     },
     include: opts[:include],
     meta: opts[:meta],

--- a/spec/support/serializers/course_serializer.rb
+++ b/spec/support/serializers/course_serializer.rb
@@ -7,6 +7,7 @@ class CourseSerializer < JSONAPI::Serializable::Resource
 
   has_many :site_statuses
   has_many :sites
+  has_many :subjects
 
   attributes(*FactoryBot.attributes_for("course").keys)
 

--- a/spec/support/serializers/subject_serializer.rb
+++ b/spec/support/serializers/subject_serializer.rb
@@ -1,0 +1,5 @@
+class SubjectSerializer < JSONAPI::Serializable::Resource
+  type "subjects"
+
+  attributes(*FactoryBot.attributes_for("subject").keys)
+end


### PR DESCRIPTION
### Context
In order to edit subjects the frontend must be able to recognise and manipulate the relationship between a course and a subject.

### Changes proposed in this pull request  
Add `has_many subjects` relationship to courses, and rework existing references to subjects to use this.

### Guidance to review
The subject controller is non-functional and subject specs are disabled as they will be worked on seperately, if needed I can strip them from this PR entirely but I'll have to put it back in later anyway to continue work on the subject editing as this is initially what this PR was for: https://trello.com/c/1MOCToMq/1858-edit-course-subject-mcbe  
The following backend PR must be merged prior to this: https://github.com/DFE-Digital/manage-courses-backend/pull/808