### PR TITLE
[2308] Redirect /organisations/ to /

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get "/auth/failure", to: "sessions#failure"
 
   root to: "providers#index"
+  get "/organisations", to: redirect("/")
 
   resources :providers, path: "organisations", param: :code do
     # Redirect year-less URLs to current recruitment cycle

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -76,7 +76,7 @@ feature "Sign in", type: :feature do
     expect(transition_info_page.title).to have_content("Important new features")
     transition_info_page.continue.click
 
-    expect(organisations_page).to be_displayed
+    expect(root_page).to be_displayed
     expect(request).to have_been_made
   end
 
@@ -95,7 +95,7 @@ feature "Sign in", type: :feature do
     expect(rollover_page.title).to have_content("Begin preparing for the next cycle")
     rollover_page.continue.click
 
-    expect(organisations_page).to be_displayed
+    expect(root_page).to be_displayed
     expect(request).to have_been_made
   end
 

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -7,13 +7,14 @@ describe "Providers", type: :request do
   end
 
   describe "GET index" do
+    let(:path) { root_path } # providers_path redirects to root, and the list is rendered from there
     context "with 1 provider" do
       it "redirects to providers show" do
         current_recruitment_cycle = build(:recruitment_cycle)
         provider = build(:provider)
         stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
         stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers", provider.to_jsonapi)
-        get(providers_path)
+        get(path)
         expect(response).to redirect_to provider_path(provider.provider_code)
       end
     end
@@ -26,7 +27,7 @@ describe "Providers", type: :request do
         providers = [provider1, provider2]
         stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
         stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers", resource_list_to_jsonapi(providers))
-        get(providers_path)
+        get(path)
         expect(response.body).to include("Organisations")
         expect(response.body).to include(provider1.provider_name)
       end
@@ -37,7 +38,7 @@ describe "Providers", type: :request do
         current_recruitment_cycle = build(:recruitment_cycle)
         stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
         stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers", jsonapi(:providers_response, data: []))
-        get(providers_path)
+        get(path)
         expect(response).to have_http_status(:forbidden)
         expect(response.body).to include("We don’t know which organisation you’re part of")
       end


### PR DESCRIPTION
### Context

Because they both render the same content

### Changes proposed in this pull request

[2308] Redirect /organisations/ to /

### Guidance to review
:ship: