### PR TITLE
[2332] add /ping health chech endpoint

### DIFF
--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,0 +1,5 @@
+class HealthChecksController < ActionController::API
+  def ping
+    render body: "PONG"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
       via: %i[get post put]
   end
 
+  get :ping, controller: :health_checks
+
   # DfE Sign In
   get "/signin", to: "sessions#new", as: "signin"
   get "/signout", to: "sessions#signout", as: "signout"

--- a/spec/requests/health_checks_spec.rb
+++ b/spec/requests/health_checks_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe "health check requests" do
+  describe "GET /ping" do
+    it "returns PONG" do
+      get "/ping"
+
+      expect(response.body).to eq "PONG"
+    end
+  end
+end


### PR DESCRIPTION
### Context

We need to be able to check that the app is up on deployment.

### Changes proposed in this pull request

A `/ping` endpoint to perform a simple check that the application is running.

### Guidance to review

:shipit: 