### PR TITLE
[2038] New sites page

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -104,7 +104,7 @@ private
           :start_date,
           :age_range_in_years,
           :master_subject_id,
-          site_ids: [],
+          sites_ids: [],
         )
     else
       ActionController::Parameters.new({}).permit(:course)
@@ -133,7 +133,7 @@ private
     when :apprenticeship
       new_provider_recruitment_cycle_courses_apprenticeship_path(path_params)
     when :location
-      new_provider_recruitment_cycle_courses_entry_requirements_path(path_params)
+      new_provider_recruitment_cycle_courses_locations_path(path_params)
     when :entry_requirements
       new_provider_recruitment_cycle_courses_entry_requirements_path(path_params)
     when :outcome

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -104,6 +104,7 @@ private
           :start_date,
           :age_range_in_years,
           :master_subject_id,
+          site_ids: [],
         )
     else
       ActionController::Parameters.new({}).permit(:course)
@@ -131,8 +132,6 @@ private
     case page
     when :apprenticeship
       new_provider_recruitment_cycle_courses_apprenticeship_path(path_params)
-    # Currently the location page isnt built - so we skip that step
-    # and go to the entry_requirements for now
     when :location
       new_provider_recruitment_cycle_courses_entry_requirements_path(path_params)
     when :entry_requirements

--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -32,6 +32,7 @@ module Courses
           :is_send,
           :study_mode,
           :age_range_in_years,
+          :sites_ids,
         )
         .permit(
           :applications_open_from,

--- a/app/controllers/courses/sites_controller.rb
+++ b/app/controllers/courses/sites_controller.rb
@@ -1,10 +1,10 @@
 module Courses
   class SitesController < ApplicationController
     decorates_assigned :course
-    before_action(
-      :build_course,
-      :build_provider,
-    )
+    include CourseBasicDetailConcern
+
+    before_action :build_course
+    before_action :build_provider_with_sites
 
     def edit; end
 
@@ -29,6 +29,14 @@ module Courses
 
   private
 
+    def build_provider_with_sites
+      @provider = Provider
+                    .includes(:sites)
+                    .where(recruitment_cycle_year: params[:recruitment_cycle_year])
+                    .find(params[:provider_code])
+                    .first
+    end
+
     def build_course
       @provider_code = params[:provider_code]
       @course = Course
@@ -38,10 +46,6 @@ module Courses
         .where(provider_code: @provider_code)
         .find(params[:code])
         .first
-    end
-
-    def build_provider
-      @provider = @course.provider
     end
   end
 end

--- a/app/controllers/courses/sites_controller.rb
+++ b/app/controllers/courses/sites_controller.rb
@@ -34,8 +34,7 @@ module Courses
       :location
     end
 
-    def errors
-    end
+    def errors; end
 
     def build_course_params
       selected_site_ids = params.dig(:course, :site_statuses_attributes)
@@ -43,7 +42,7 @@ module Courses
         .select { |field| field["selected"] == "1" }
         .map { |field| field["id"] }
 
-      params["course"]["site_ids"] = selected_site_ids
+      params["course"]["sites_ids"] = selected_site_ids
       params["course"].delete("site_statuses_attributes")
     end
 

--- a/app/controllers/courses/sites_controller.rb
+++ b/app/controllers/courses/sites_controller.rb
@@ -7,6 +7,13 @@ module Courses
     before_action :build_course, only: %i[edit update]
     before_action :build_provider_with_sites
 
+    def new
+      if @provider.sites.count == 1
+        set_default_site
+        redirect_to next_step
+      end
+    end
+
     def edit; end
 
     def update
@@ -35,6 +42,11 @@ module Courses
     end
 
     def errors; end
+
+    def set_default_site
+      params["course"] ||= {}
+      params["course"]["sites_ids"] = [@provider.sites.first.id]
+    end
 
     def build_course_params
       selected_site_ids = params.dig(:course, :site_statuses_attributes)

--- a/app/controllers/courses/sites_controller.rb
+++ b/app/controllers/courses/sites_controller.rb
@@ -1,9 +1,10 @@
 module Courses
   class SitesController < ApplicationController
     decorates_assigned :course
-    include CourseBasicDetailConcern
+    before_action :build_course_params, only: %i[continue]
 
-    before_action :build_course
+    include CourseBasicDetailConcern
+    before_action :build_course, only: %i[edit update]
     before_action :build_provider_with_sites
 
     def edit; end
@@ -28,6 +29,23 @@ module Courses
     end
 
   private
+
+    def current_step
+      :location
+    end
+
+    def errors
+    end
+
+    def build_course_params
+      selected_site_ids = params.dig(:course, :site_statuses_attributes)
+        .values
+        .select { |field| field["selected"] == "1" }
+        .map { |field| field["id"] }
+
+      params["course"]["site_ids"] = selected_site_ids
+      params["course"].delete("site_statuses_attributes")
+    end
 
     def build_provider_with_sites
       @provider = Provider

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -218,6 +218,7 @@ private
         :start_date,
         :funding_type,
         :age_range_in_years,
+        sites_ids: [],
       )
     else
       ActionController::Parameters.new({}).permit(:course)

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -94,7 +94,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def has_site?(site)
-    object.sites.include?(site)
+    object.sites.any? { |s| s.id == site.id }
   end
 
   def funding_option

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -3,6 +3,9 @@ class Site < Base
   belongs_to :provider, param: :provider_code
   has_one :site_status
 
+  properties :code, :location_name, :address1, :address2, :address3
+  properties :address4, :postcode
+
   REGIONS = [
     ["London", :london],
     ["South East", :south_east],

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -107,7 +107,19 @@
                 Locations
               </dt>
               <dd class="govuk-summary-list__value" data-qa="course__locations">
-                <span class="app-course-parts__fields__value--empty">None</span>
+                <% if course.sites.empty? %>
+                  <span class="app-course-parts__fields__value--empty">None</span>
+                <% elsif course.sites.size == 1 %>
+                  <%= course.sites.first.location_name %>
+                <% else %>
+                  <ul class="govuk-list app-courses-locations-list">
+                    <% course.alphabetically_sorted_sites.each do |site| %>
+                      <li>
+                        <%= site.location_name %>
+                      </li>
+                    <% end %>
+                  </ul>
+                <% end %>
               </dd>
               <dd class="govuk-summary-list__actions">
                 Change<span class="govuk-visually-hidden"> locations</span>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -3,6 +3,12 @@
 <h1 class="govuk-heading-xl">Pick the training locations for this course</h1>
 
 <%= form_for course, url: continue_provider_recruitment_cycle_courses_locations_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :get do |f| %>
+  <%= render 'shared/course_creation_hidden_fields',
+    form: f,
+    course_creation_params: @course_creation_params,
+    except_keys: [:sites_ids]
+  %>
+
   <div class="govuk-form-group">
     <div class="govuk-checkboxes">
       <%= f.fields_for :site_statuses, @provider.sites.sort_by(&:location_name) do |sf| %>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -1,0 +1,24 @@
+<%= content_for :page_title, "Pick the training locations for this course" %>
+
+<h1 class="govuk-heading-xl">Pick the training locations for this course</h1>
+
+<%= form_for course, url: continue_provider_recruitment_cycle_courses_locations_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :get do |f| %>
+  <div class="govuk-form-group">
+    <div class="govuk-checkboxes">
+      <%= f.fields_for :site_statuses, @provider.sites.sort_by(&:location_name) do |sf| %>
+        <% site = sf.object %>
+        <div class="govuk-checkboxes__item">
+          <%= sf.check_box 'selected', checked: course.has_site?(site), class: 'govuk-checkboxes__input' %>
+          <%= sf.label 'selected', class: 'govuk-label govuk-checkboxes__label'  do %>
+            <strong data-qa="site__name"><%= site.location_name %></strong>
+          <% end %>
+          <span class="govuk-hint govuk-checkboxes__hint">
+            <%= site.full_address %>
+          </span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <%= f.submit "Contine", class: "govuk-button", data: { qa: 'course__save' } %>
+<% end %>

--- a/app/views/shared/_course_creation_hidden_fields.html.erb
+++ b/app/views/shared/_course_creation_hidden_fields.html.erb
@@ -1,4 +1,10 @@
-<% course_creation_params.except(*except_keys).each do |k, v| %>
-  <%= form.hidden_field(k, value: v) %>
+<% course_creation_params.except(*except_keys).each do |field_name, field_value| %>
+  <% if field_value.is_a?(Array) %>
+    <% field_value.each do |array_value| %>
+      <%= form.hidden_field(field_name, multiple: true, value: array_value) %>
+    <% end %>
+  <% else %>
+    <%= form.hidden_field(field_name, value: field_value) %>
+  <% end %>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,9 @@ Rails.application.routes.draw do
         resource :level, on: :member, only: %i[new], controller: "courses/level" do
           get "continue"
         end
+        resource :locations, on: :member, only: %i[new], controller: "courses/sites" do
+          get "continue"
+        end
         resource :start_date, on: :member, only: %i[new], controller: "courses/start_date", path: "start-date" do
           get "continue"
         end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
       recruitment_cycle { build :recruitment_cycle }
     end
 
-    sequence(:id)
+    sequence(:id, &:to_s)
     sequence(:code, &:to_s)
     location_name { "Main Site" }
     address1 { nil }

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -8,8 +8,9 @@ feature "Course confirmation", type: :feature do
   let(:course_page) do
     PageObjects::Page::Organisations::Course.new
   end
-
-  let(:course) { build(:course, provider: provider, subjects: [build(:subject, :english), build(:subject, :mathematics)]) }
+  let(:site1) { build(:site, location_name: "Site one") }
+  let(:site2) { build(:site, location_name: "Site two") }
+  let(:course) { build(:course, provider: provider, sites: [site1, site2], subjects: [build(:subject, :english), build(:subject, :mathematics)]) }
   let(:provider) { build(:provider) }
 
   before do
@@ -45,7 +46,7 @@ feature "Course confirmation", type: :feature do
     expect(course_confirmation_page.details.subjects.text).to include("Mathematics")
     expect(course_confirmation_page.details.age_range.text).to eq("11 to 16")
     expect(course_confirmation_page.details.study_mode.text).to eq("Full time")
-    expect(course_confirmation_page.details.locations.text).to eq("None")
+    expect(course_confirmation_page.details.locations.text).to eq("Site one Site two")
     expect(course_confirmation_page.details.application_open_from.text).to eq("1 January 2019")
     expect(course_confirmation_page.details.start_date.text).to eq("January 2019")
     expect(course_confirmation_page.details.name.text).to eq("English")
@@ -130,7 +131,7 @@ private
     expect(course_confirmation_page.details.subjects.text).to include("Mathematics")
     expect(course_confirmation_page.details.age_range.text).to eq("11 to 16")
     expect(course_confirmation_page.details.study_mode.text).to eq("Full time")
-    expect(course_confirmation_page.details.locations.text).to eq("None")
+    expect(course_confirmation_page.details.locations.text).to eq("Site one Site two")
     expect(course_confirmation_page.details.application_open_from.text).to eq("1 January 2019")
     expect(course_confirmation_page.details.start_date.text).to eq("January 2019")
     expect(course_confirmation_page.details.name.text).to eq("English")

--- a/spec/features/courses/sites/edit_spec.rb
+++ b/spec/features/courses/sites/edit_spec.rb
@@ -29,6 +29,13 @@ feature "Edit course sites", type: :feature do
     stub_api_v2_request(
       "/recruitment_cycles/#{current_recruitment_cycle.year}" \
       "/providers/#{provider.provider_code}" \
+      "?include=sites",
+      provider.to_jsonapi(include: [:sites]),
+    )
+
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
       "/courses/#{course.course_code}" \
       "?include=sites,provider.sites",
       course.to_jsonapi(include: [:sites, provider: :sites]),

--- a/spec/features/courses/sites/new_spec.rb
+++ b/spec/features/courses/sites/new_spec.rb
@@ -30,7 +30,7 @@ feature "New course sites" do
     stub_api_v2_build_course
     build_course_with_sites_request
     build_course_with_two_sites_request
-    new_locations_page.load(provider_code: provider.provider_code, recruitment_cycle_year: current_recruitment_cycle.year)
+    new_locations_page.load(provider_code: provider.provider_code, recruitment_cycle_year: current_recruitment_cycle.year, course: {})
   end
 
   scenario "It loads the page" do
@@ -69,6 +69,18 @@ feature "New course sites" do
 
     scenario "It pre-checks the site" do
       expect(new_locations_page).to have_checked_field(site3.location_name)
+    end
+  end
+
+  context "With a provider with a single site" do
+    let(:provider) { build(:provider, sites: [site2]) }
+
+    scenario "It transitions to the entry requirements page" do
+      expect(new_entry_requirements_page).to be_displayed
+    end
+
+    scenario "It builds a new course with the providers site id to the query" do
+      expect(build_course_with_sites_request).to have_been_made.at_least_once
     end
   end
 end

--- a/spec/features/courses/sites/new_spec.rb
+++ b/spec/features/courses/sites/new_spec.rb
@@ -11,11 +11,12 @@ feature "New course sites" do
     build(
       :provider,
       sites: [site1, site2, site3],
-      recruitment_cycle: current_recruitment_cycle
+      recruitment_cycle: current_recruitment_cycle,
     )
   end
   let(:course) { build(:course) }
-  let(:build_course_with_sites_request) { stub_api_v2_build_course(site_ids: [site2.id]) }
+  let(:build_course_with_sites_request) { stub_api_v2_build_course(sites_ids: [site2.id]) }
+  let(:build_course_with_two_sites_request) { stub_api_v2_build_course(sites_ids: [site1.id, site2.id]) }
 
   before do
     stub_omniauth
@@ -28,6 +29,7 @@ feature "New course sites" do
     )
     stub_api_v2_build_course
     build_course_with_sites_request
+    build_course_with_two_sites_request
     new_locations_page.load(provider_code: provider.provider_code, recruitment_cycle_year: current_recruitment_cycle.year)
   end
 
@@ -45,6 +47,14 @@ feature "New course sites" do
     new_locations_page.continue.click
 
     expect(build_course_with_sites_request).to have_been_made.at_least_once
+  end
+
+  scenario "It builds a new course with two selected sites" do
+    new_locations_page.check(site1.location_name)
+    new_locations_page.check(site2.location_name)
+    new_locations_page.continue.click
+
+    expect(build_course_with_two_sites_request).to have_been_made.at_least_once
   end
 
   scenario "It transitions to the entry requirements page" do

--- a/spec/features/courses/sites/new_spec.rb
+++ b/spec/features/courses/sites/new_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+feature "New course sites" do
+  let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+  let(:new_locations_page) { PageObjects::Page::Organisations::Courses::NewLocationsPage.new }
+  let(:new_entry_requirements_page) { PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new }
+  let(:site1) { build(:site, location_name: "Site one") }
+  let(:site2) { build(:site, location_name: "Site two") }
+  let(:site3) { build(:site, location_name: "Another site") }
+  let(:provider) do
+    build(
+      :provider,
+      sites: [site1, site2, site3],
+      recruitment_cycle: current_recruitment_cycle
+    )
+  end
+  let(:course) { build(:course) }
+  let(:build_course_with_sites_request) { stub_api_v2_build_course(site_ids: [site2.id]) }
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(provider)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
+      "?include=sites",
+      provider.to_jsonapi(include: [:sites]),
+    )
+    stub_api_v2_build_course
+    build_course_with_sites_request
+    new_locations_page.load(provider_code: provider.provider_code, recruitment_cycle_year: current_recruitment_cycle.year)
+  end
+
+  scenario "It loads the page" do
+    expect(new_locations_page).to be_displayed
+  end
+
+  scenario "It displays the providers sites" do
+    displayed_site_names = new_locations_page.site_names.collect(&:text)
+    expect(displayed_site_names).to eq(["Another site", "Site one", "Site two"])
+  end
+
+  scenario "It builds a new course with the selected site" do
+    new_locations_page.check(site2.location_name)
+    new_locations_page.continue.click
+
+    expect(build_course_with_sites_request).to have_been_made.at_least_once
+  end
+
+  scenario "It transitions to the entry requirements page" do
+    new_locations_page.check(site2.location_name)
+    new_locations_page.continue.click
+
+    expect(new_entry_requirements_page).to be_displayed
+  end
+
+  context "with site ids already selected" do
+    let(:course) { build(:course, sites: [site3]) }
+
+    scenario "It pre-checks the site" do
+      expect(new_locations_page).to have_checked_field(site3.location_name)
+    end
+  end
+end

--- a/spec/features/courses/study_mode/new_spec.rb
+++ b/spec/features/courses/study_mode/new_spec.rb
@@ -4,6 +4,9 @@ feature "new course study mode", type: :feature do
   let(:new_study_mode_page) do
     PageObjects::Page::Organisations::Courses::NewStudyModePage.new
   end
+  let(:new_locations_page) do
+    PageObjects::Page::Organisations::Courses::NewLocationsPage.new
+  end
 
   let(:course) do
     build(
@@ -19,6 +22,7 @@ feature "new course study mode", type: :feature do
   before do
     stub_omniauth
     stub_api_v2_resource(provider)
+    stub_api_v2_resource(provider, include: "sites")
     stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
     stub_api_v2_build_course
@@ -40,6 +44,6 @@ feature "new course study mode", type: :feature do
 
     click_on "Continue"
 
-    expect(current_path).to eq new_provider_recruitment_cycle_courses_entry_requirements_path(provider.provider_code, provider.recruitment_cycle_year)
+    expect(new_locations_page).to be_displayed
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_locations_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_locations_page.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class NewLocationsPage < CourseBase
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/locations/new"
+
+          elements :site_names, '[data-qa="site__name"]'
+          element :continue, '[data-qa="course__save"]'
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_locations_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_locations_page.rb
@@ -3,7 +3,7 @@ module PageObjects
     module Organisations
       module Courses
         class NewLocationsPage < CourseBase
-          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/locations/new"
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/locations/new{?query*}"
 
           elements :site_names, '[data-qa="site__name"]'
           element :continue, '[data-qa="course__save"]'

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -100,7 +100,7 @@ module Helpers
   end
 
   def stub_api_v2_build_course(params = {})
-    jsonapi_response = course.to_jsonapi(include: [:subjects])
+    jsonapi_response = course.to_jsonapi(include: [:subjects, :sites])
     jsonapi_response[:data][:meta] = course.meta
     jsonapi_response[:data][:errors] = []
     stub_api_v2_request(

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -100,7 +100,7 @@ module Helpers
   end
 
   def stub_api_v2_build_course(params = {})
-    jsonapi_response = course.to_jsonapi(include: [:subjects, :sites])
+    jsonapi_response = course.to_jsonapi(include: %i[subjects sites])
     jsonapi_response[:data][:meta] = course.meta
     jsonapi_response[:data][:errors] = []
     stub_api_v2_request(


### PR DESCRIPTION
### Context

The course creation flow was currently skipping the `locations` step, we need to add it to assign training locations to new courses

### Changes proposed in this pull request

- Add in the page to the course creation flow
- Display locations on the confirmation page

### Guidance to review
