### PR TITLE
[2365] Add subjects to course creation workflow

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -105,6 +105,7 @@ private
           :age_range_in_years,
           :master_subject_id,
           sites_ids: [],
+          subjects_ids: [],
         )
     else
       ActionController::Parameters.new({}).permit(:course)
@@ -146,6 +147,8 @@ private
       new_provider_recruitment_cycle_courses_start_date_path(path_params)
     when :age_range
       new_provider_recruitment_cycle_courses_age_range_path(path_params)
+    when :subjects
+      new_provider_recruitment_cycle_courses_subjects_path(path_params)
     when :confirmation
       confirmation_provider_recruitment_cycle_courses_path(path_params)
     end

--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -33,6 +33,7 @@ module Courses
           :study_mode,
           :age_range_in_years,
           :sites_ids,
+          :subjects_ids,
         )
         .permit(
           :applications_open_from,

--- a/app/controllers/courses/subjects_controller.rb
+++ b/app/controllers/courses/subjects_controller.rb
@@ -1,8 +1,9 @@
 module Courses
   class SubjectsController < ApplicationController
-    include CourseBasicDetailConcern
     decorates_assigned :course
     before_action :build_course, only: %i[edit update]
+    before_action :build_course_params, only: [:continue]
+    include CourseBasicDetailConcern
 
     def update
       master_subject_id = params.dig(:course, :master_subject_id)
@@ -29,7 +30,7 @@ module Courses
   private
 
     def current_step
-      nil
+      :subjects
     end
 
     def errors; end
@@ -41,6 +42,11 @@ module Courses
                   .where(provider_code: params[:provider_code])
                   .find(params[:code])
                   .first
+    end
+
+    def build_course_params
+      params[:course][:subjects_ids] = [params[:course][:master_subject_id]]
+      params[:course].delete :master_subject_id
     end
   end
 end

--- a/app/services/next_course_creation_step_service.rb
+++ b/app/services/next_course_creation_step_service.rb
@@ -2,6 +2,8 @@ class NextCourseCreationStepService
   def execute(current_step:)
     case current_step
     when :level
+      :subjects
+    when :subjects
       :age_range
     when :age_range
       :outcome

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -120,7 +120,7 @@
           Locations
         </dt>
         <dd class="govuk-summary-list__value" data-qa="course__locations">
-          <% if course.sites.empty? %>
+          <% if course.sites.nil? ||course.sites.empty? %>
             <span class="app-course-parts__fields__value--empty">None</span>
           <% elsif course.sites.size == 1 %>
             <%= course.sites.first.location_name %>

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -107,7 +107,7 @@
                 Locations
               </dt>
               <dd class="govuk-summary-list__value" data-qa="course__locations">
-                <% if course.sites.empty? %>
+                <% if course.sites.nil? || course.sites.empty? %>
                   <span class="app-course-parts__fields__value--empty">None</span>
                 <% elsif course.sites.size == 1 %>
                   <%= course.sites.first.location_name %>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -1,0 +1,30 @@
+<%= content_for :page_title, "Select subject" %>
+
+<%= render 'shared/errors' %>
+
+<h1 class="govuk-heading-xl">
+  Select subject
+</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: course,
+                  url: continue_provider_recruitment_cycle_courses_subjects_path(
+                    @provider.provider_code,
+                    @provider.recruitment_cycle_year
+                  ),
+                  method: :get do |form| %>
+      <h2 class="govuk-heading-m remove-top-margin">Level</h2>
+
+      <%= render 'shared/course_creation_hidden_fields',
+        form: form,
+        course_creation_params: @course_creation_params,
+        except_keys: []
+      %>
+      <%= render 'form_fields', form: form %>
+
+      <%= form.submit "Continue",
+                      class: "govuk-button",
+                      data: { qa: 'course__save' } %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,9 @@ Rails.application.routes.draw do
         resource :age_range, on: :member, only: %i[new], controller: "courses/age_range", path: "age-range" do
           get "continue"
         end
+        resource :subjects, on: :member, only: %i[new], controller: "courses/subjects", path: "subjects" do
+          get "continue"
+        end
         resource :apprenticeship, on: :member, only: %i[new], controller: "courses/apprenticeship" do
           get "continue"
         end

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -21,7 +21,6 @@ feature "Course confirmation", type: :feature do
     stub_api_v2_resource_collection([new_course], include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_new_resource(new_course)
     stub_api_v2_build_course
-
     visit confirmation_provider_recruitment_cycle_courses_path(
       provider.provider_code,
       provider.recruitment_cycle_year,

--- a/spec/features/courses/level/new_spec.rb
+++ b/spec/features/courses/level/new_spec.rb
@@ -5,7 +5,7 @@ feature "New course level", type: :feature do
     PageObjects::Page::Organisations::Courses::NewLevelPage.new
   end
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, :new, provider: provider, level: :primary, gcse_subjects_required_using_level: true) }
+  let(:course) { build(:course, :new, provider: provider, level: :primary, gcse_subjects_required_using_level: true, edit_options: { subjects: [] }) }
 
   before do
     stub_omniauth
@@ -22,12 +22,12 @@ feature "New course level", type: :feature do
     choose "Secondary"
     click_on "Continue"
 
-    expect(current_path).to eq new_provider_recruitment_cycle_courses_age_range_path(provider.provider_code, provider.recruitment_cycle_year)
+    expect(current_path).to eq new_provider_recruitment_cycle_courses_subjects_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
   context "Selecting primary" do
     let(:next_step_page) do
-      PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
+      PageObjects::Page::Organisations::Courses::NewSubjectsPage.new
     end
     let(:selected_fields) { { level: "primary", is_send: "0" } }
     let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+feature "New course level", type: :feature do
+  let(:new_subjects_page) do
+    PageObjects::Page::Organisations::Courses::NewSubjectsPage.new
+  end
+  let(:next_step_page) do
+    PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
+  end
+  let(:provider) { build(:provider) }
+  let(:english) { build(:subject, :english) }
+  let(:biology) { build(:subject, :biology) }
+  let(:subjects) { [english, biology] }
+  let(:edit_options) { { subjects: subjects, age_range_in_years: [] } }
+  let(:course) { build(:course, :new, provider: provider, level: :secondary, gcse_subjects_required_using_level: true, edit_options: edit_options) }
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(provider)
+    stub_api_v2_new_resource(course)
+    stub_api_v2_build_course
+    stub_api_v2_build_course
+
+    visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
+    "/courses/subjects/new"
+  end
+
+  context "Selecting primary" do
+    let(:selected_fields) { { subjects_ids: [english.id] } }
+    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
+
+    before do
+      build_course_with_selected_value_request
+      new_subjects_page.subjects_fields.select(english.subject_name).click
+      new_subjects_page.continue.click
+    end
+
+    scenario "sends user to new outcome page" do
+      expect(next_step_page).to be_displayed
+    end
+
+    it_behaves_like "a course creation page"
+  end
+end

--- a/spec/services/next_course_creation_step_service_spec.rb
+++ b/spec/services/next_course_creation_step_service_spec.rb
@@ -11,12 +11,19 @@ describe NextCourseCreationStepService do
   context "SCITT Provider" do
     context "Current step: Level" do
       let(:current_step) { :level }
+      let(:expected_next_step) { :subjects }
+
+      include_examples "next step"
+    end
+
+    context "Current step: Subjects" do
+      let(:current_step) { :subjects }
       let(:expected_next_step) { :age_range }
 
       include_examples "next step"
     end
 
-    context "Current step: Age reange" do
+    context "Current step: Age range" do
       let(:current_step) { :age_range }
       let(:expected_next_step) { :outcome }
 

--- a/spec/site_prism/page_objects/page/organisations/courses/new_subjects_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_subjects_page.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class NewSubjectsPage < CourseBase
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/subjects/new{?query*}"
+
+          element :subjects_fields, '[data-qa="course__subjects"]'
+          element :continue, '[data-qa="course__save"]'
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/course_creation.rb
+++ b/spec/support/shared_examples/course_creation.rb
@@ -7,13 +7,8 @@ shared_examples_for "a course creation page" do
   end
 
   scenario "stores the selected field" do
-    query_hash = selected_fields.reduce({}) do |res, (k, v)|
-      res["course[#{k}]"] = v
-      res
-    end
-
-    expect(next_step_page.url_matches["query"]).to eq(
-      query_hash,
+    expect(next_step_page.url_matches["query"].to_query).to eq(
+      selected_fields.to_query(:course),
     )
   end
 


### PR DESCRIPTION
### Context
We would like to be able to set single subjects during course creation.  

### Changes proposed in this pull request  
Add the new subject page and relevant plumbing.

### Guidance to review
