### PR TITLE
[2369] Add change links for course creation

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -5,6 +5,7 @@ module CourseBasicDetailConcern
     decorates_assigned :course
     before_action :build_provider, :build_new_course, only: %i[new continue]
     before_action :build_previous_course_creation_params, only: %i[new continue]
+    before_action :build_meta_course_creation_params, only: %i[new continue]
     before_action :build_course, only: %i[edit update]
   end
 
@@ -36,6 +37,8 @@ module CourseBasicDetailConcern
 
     if @errors.present?
       render :new
+    elsif params[:goto_confirmation].present?
+      redirect_to confirmation_provider_recruitment_cycle_courses_path(path_params)
     else
       redirect_to next_step
     end
@@ -75,6 +78,7 @@ private
           :year,
           :course_age_range_in_years_other_from,
           :course_age_range_in_years_other_to,
+          :goto_confirmation,
         )
         .permit(
           :page,
@@ -117,6 +121,10 @@ private
     @course_creation_params = course_params
   end
 
+  def build_meta_course_creation_params
+    @meta_course_creation_params = params.slice(:goto_confirmation)
+  end
+
   def next_step
     next_step = NextCourseCreationStepService.new.execute(current_step: current_step, current_provider: @provider)
     next_page = course_creation_path_for(next_step)
@@ -128,9 +136,11 @@ private
     next_page
   end
 
-  def course_creation_path_for(page)
-    path_params = { course: course_params }
+  def path_params
+    { course: course_params }
+  end
 
+  def course_creation_path_for(page)
     case page
     when :apprenticeship
       new_provider_recruitment_cycle_courses_apprenticeship_path(path_params)

--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -6,14 +6,7 @@ module Courses
 
     def continue
       build_course_params
-
-      @errors = errors
-
-      if @errors.present?
-        render :new
-      else
-        redirect_to next_step
-      end
+      super
     end
 
   private
@@ -34,6 +27,7 @@ module Courses
           :age_range_in_years,
           :sites_ids,
           :subjects_ids,
+          :goto_confirmation,
         )
         .permit(
           :applications_open_from,

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,6 +21,7 @@ class SessionsController < ApplicationController
     Raven.tags_context(sign_in_user_id: current_user.fetch("uid"))
     add_token_to_connection
     user = set_user_session
+
     # current_user['user_id'] won't be set until set_user_session is run
     Raven.user_context(id: current_user["user_id"])
     logger.debug { "User session create " + log_safe_current_user.to_s }

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -94,7 +94,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def has_site?(site)
-    object.sites.any? { |s| s.id == site.id }
+    !course.sites.nil? && object.sites.any? { |s| s.id == site.id }
   end
 
   def funding_option

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,4 +1,10 @@
 module ViewHelper
+  def course_creation_change_button(display_name, property_name, path)
+    link_to send(path, @provider.provider_code, course.recruitment_cycle_year, params.to_unsafe_h.merge(goto_confirmation: true)), class: "govuk-link", data: { qa: "course__edit_#{property_name}_link" } do
+      "Change<span class=\"govuk-visually-hidden\"> #{display_name}</span>"
+    end
+  end
+
   def govuk_link_to(body, url = body, html_options = { class: "govuk-link" })
     link_to body, url, html_options
   end

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -120,7 +120,7 @@
           Locations
         </dt>
         <dd class="govuk-summary-list__value" data-qa="course__locations">
-          <% if course.sites.nil? ||course.sites.empty? %>
+          <% if course.sites.nil? || course.sites.empty? %>
             <span class="app-course-parts__fields__value--empty">None</span>
           <% elsif course.sites.size == 1 %>
             <%= course.sites.first.location_name %>

--- a/app/views/courses/_new_fields_holder.html.erb
+++ b/app/views/courses/_new_fields_holder.html.erb
@@ -1,0 +1,21 @@
+<%= render 'shared/course_creation_hidden_fields',
+  form: form,
+  course_creation_params: @meta_course_creation_params,
+  except_keys: []
+%>
+
+<%= fields model: course do |fields| %>
+  <%= render 'shared/course_creation_hidden_fields',
+    form: fields,
+    course_creation_params: @course_creation_params,
+    except_keys: except_keys
+  %>
+  <%= yield fields %>
+<% end %>
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<p class="govuk-body">
+  <%= form.submit "Continue",
+                class: "govuk-button",
+                data: { qa: 'course__save' } %>
+</p>

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -10,36 +10,27 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
-                  url: continue_provider_recruitment_cycle_courses_age_range_path(
+    <%= form_with url: continue_provider_recruitment_cycle_courses_age_range_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
 
-      <div
-        class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years]&.any?) %>"
-        data-qa="course__age_range_in_years">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-fieldset__heading">
-              Specify an age range
-            </h1>
-          </legend>
-          <%= render "shared/error_messages", field: :age_range_in_years if @errors %>
-          <%= render 'shared/course_creation_hidden_fields',
-            form: form,
-            course_creation_params: @course_creation_params,
-            except_keys: [:age_range_in_years]
-          %>
-          <%= render 'form_fields', form: form %>
-        </fieldset>
-      </div>
-
-      <%= form.submit "Continue",
-                      class: "govuk-button",
-                      data: { qa: 'course__save' } %>
-
+      <%= render "courses/new_fields_holder", form: form, except_keys: [:age_range_in_years] do |fields| %>
+        <div
+          class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years]&.any?) %>"
+          data-qa="course__age_range_in_years">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                Specify an age range
+              </h1>
+            </legend>
+            <%= render "shared/error_messages", field: :age_range_in_years if @errors %>
+            <%= render 'form_fields', form: fields %>
+          </fieldset>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -14,24 +14,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
-                  url: continue_provider_recruitment_cycle_courses_applications_open_path(
+    <%= form_with url: continue_provider_recruitment_cycle_courses_applications_open_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
 
-      <%= render 'shared/course_creation_hidden_fields',
-        form: form,
-        course_creation_params: @course_creation_params,
-        except_keys: [:applications_open_from, :month, :day, :year]
-      %>
-      <%= render 'form_fields', form: form %>
-
-      <%= form.submit "Continue",
-                      class: "govuk-button",
-                      data: { qa: 'course__save' } %>
-
+      <%= render "courses/new_fields_holder", form: form, except_keys: [:applications_open_from, :month, :day, :year] do |fields| %>
+        <%= render 'form_fields', form: fields %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/apprenticeship/new.html.erb
+++ b/app/views/courses/apprenticeship/new.html.erb
@@ -11,23 +11,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_with model: course,
-                  url: continue_provider_recruitment_cycle_courses_apprenticeship_path(
+    <%= form_with url: continue_provider_recruitment_cycle_courses_apprenticeship_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
 
-      <%= render 'shared/course_creation_hidden_fields',
-        form: form,
-        course_creation_params: @course_creation_params,
-        except_keys: [:program_type]
-      %>
-      <%= render 'form_fields', form: form %>
-
-      <%= form.submit "Continue",
-                      class: "govuk-button",
-                      data: { qa: 'course__save' } %>
+      <%= render "courses/new_fields_holder", form: form, except_keys: [:program_type] do |fields| %>
+        <%= render 'form_fields', form: fields, gcse_subjects_required: course.gcse_subjects_required %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -1,5 +1,4 @@
 <%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}New course" %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
@@ -26,7 +25,11 @@
                 <%= course.level&.humanize %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                  Change<span class="govuk-visually-hidden"> Level</span>
+                <%= course_creation_change_button(
+                  "level",
+                  "level",
+                  :new_provider_recruitment_cycle_courses_level_path
+                ) %>
               </dd>
             </div>
 
@@ -38,7 +41,11 @@
                 <%= course.is_send? %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                Change<span class="govuk-visually-hidden"> SEND</span>
+                <%= course_creation_change_button(
+                  "SEND",
+                  "is_send",
+                  :new_provider_recruitment_cycle_courses_level_path
+                ) %>
               </dd>
             </div>
 
@@ -62,7 +69,11 @@
                 <%= course.age_range %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                Change<span class="govuk-visually-hidden"> age range</span>
+                <%= course_creation_change_button(
+                  "age range",
+                  "age_range",
+                  :new_provider_recruitment_cycle_courses_age_range_path
+                ) %>
               </dd>
             </div>
 
@@ -74,7 +85,11 @@
                 <%= course.outcome %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                Change<span class="govuk-visually-hidden"> outcome</span>
+                <%= course_creation_change_button(
+                  "outcome",
+                  "qualifications",
+                  :new_provider_recruitment_cycle_courses_outcome_path
+                ) %>
               </dd>
             </div>
 
@@ -86,7 +101,11 @@
                 <%= course.apprenticeship? %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                Change<span class="govuk-visually-hidden"> apprenticeship</span>
+                <%= course_creation_change_button(
+                  "apprenticeship",
+                  "apprenticeship",
+                  :new_provider_recruitment_cycle_courses_apprenticeship_path
+                ) %>
               </dd>
             </div>
 
@@ -98,7 +117,11 @@
                 <%= course.study_mode.humanize %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                Change<span class="govuk-visually-hidden"> full time of part time</span>
+                <%= course_creation_change_button(
+                  "full time or part time",
+                  "study_mode",
+                  :new_provider_recruitment_cycle_courses_study_mode_path
+                ) %>
               </dd>
             </div>
 
@@ -122,7 +145,11 @@
                 <% end %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                Change<span class="govuk-visually-hidden"> locations</span>
+                <%= course_creation_change_button(
+                  "locations",
+                  "locations",
+                  :new_provider_recruitment_cycle_courses_locations_path
+                ) %>
               </dd>
             </div>
 
@@ -134,7 +161,11 @@
                 <%= l(course.applications_open_from&.to_date) %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                Change<span class="govuk-visually-hidden"> applications open date</span>
+                <%= course_creation_change_button(
+                  "applications open date",
+                  "application_open_from",
+                  :new_provider_recruitment_cycle_courses_applications_open_path
+                ) %>
               </dd>
             </div>
 
@@ -146,7 +177,11 @@
                 <%= l(course.start_date&.to_date, format: :short) %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                Change<span class="govuk-visually-hidden"> start date</span>
+                <%= course_creation_change_button(
+                  "start date",
+                  "start_date",
+                  :new_provider_recruitment_cycle_courses_start_date_path
+                ) %>
               </dd>
             </div>
 
@@ -157,9 +192,7 @@
               <dd class="govuk-summary-list__value" data-qa="course__name">
                 <%= course.name %>
               </dd>
-              <dd class="govuk-summary-list__actions">
-                Change<span class="govuk-visually-hidden"> title</span>
-              </dd>
+              <dd class="govuk-summary-list__actions"></dd>
             </div>
 
             <div class="govuk-summary-list__row">
@@ -186,7 +219,11 @@
                   <% end %>
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                  Change<span class="govuk-visually-hidden"> entry requirements</span>
+                  <%= course_creation_change_button(
+                    "entry requirements",
+                    "entry_requirements",
+                    :new_provider_recruitment_cycle_courses_entry_requirements_path
+                  ) %>
                 </dd>
               </div>
             <% end %>

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -26,28 +26,14 @@
     <p class="govuk-body govuk-!-margin-bottom-8">
       The codes you pick determine how flexible you are towards those candidates.
     </p>
-    <%= form_with model: course,
-                  url: continue_provider_recruitment_cycle_courses_entry_requirements_path(
+    <%= form_with url: continue_provider_recruitment_cycle_courses_entry_requirements_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
-
-
-      <%= render 'shared/course_creation_hidden_fields',
-        form: form,
-        course_creation_params: @course_creation_params,
-        except_keys: [:maths, :english, :science]
-      %>
-      <%= render 'form_fields', form: form, gcse_subjects_required: course.gcse_subjects_required %>
-
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
-      <p class="govuk-body">
-        <%= form.submit "Continue",
-                      class: "govuk-button",
-                      data: { qa: 'course__save' } %>
-      </p>
+      <%= render "courses/new_fields_holder", form: form, except_keys: [:maths, :english, :science] do |fields| %>
+        <%= render 'form_fields', form: fields, gcse_subjects_required: course.gcse_subjects_required %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/fee_or_salary/new.html.erb
+++ b/app/views/courses/fee_or_salary/new.html.erb
@@ -12,23 +12,18 @@
 </h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_with model: course,
-                    url: continue_provider_recruitment_cycle_courses_fee_or_salary_path(
+    <%= form_with url: continue_provider_recruitment_cycle_courses_fee_or_salary_path(
                       @provider.provider_code,
                       @provider.recruitment_cycle_year
                     ),
                     method: :get do |form| %>
-      <%= render 'form_fields', form: form,
-        program_types: %i[pg_teaching_apprenticeship
-                          school_direct_training_programme
-                          school_direct_salaried_training_programme]
-      %>
-
-      <%= form.submit "Continue",
-                      class: "govuk-button",
-                      data: { qa: 'course__save' } %>
-
+      <%= render "courses/new_fields_holder", form: form, except_keys: [] do |fields| %>
+        <%= render "form_fields", form: fields,
+          program_types: %i[pg_teaching_apprenticeship
+                            school_direct_training_programme
+                            school_direct_salaried_training_programme]
+        %>
+      <% end %>
     <% end %>
   </div>
 </div>
-

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -7,30 +7,22 @@
 </h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
-                  url: continue_provider_recruitment_cycle_courses_level_path(
+    <%= form_with url: continue_provider_recruitment_cycle_courses_level_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
-      <h2 class="govuk-heading-m remove-top-margin">Level</h2>
 
-      <%= render 'shared/course_creation_hidden_fields',
-        form: form,
-        course_creation_params: @course_creation_params,
-        except_keys: [:level]
-      %>
-      <%= render 'form_fields', form: form %>
+      <%= render "courses/new_fields_holder", form: form, except_keys: [:level] do |fields| %>
+        <h2 class="govuk-heading-m remove-top-margin">Level</h2>
+        <%= render 'form_fields', form: fields %>
 
-      <h2 class="govuk-heading-m remove-top-margin">
-        Special educational needs and disability (SEND)
-      </h2>
+        <h2 class="govuk-heading-m remove-top-margin">
+          Special educational needs and disability (SEND)
+        </h2>
 
-      <%= render 'courses/send/form_fields', form: form %>
-
-      <%= form.submit "Continue",
-                      class: "govuk-button",
-                      data: { qa: 'course__save' } %>
+        <%= render 'courses/send/form_fields', form: fields %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -10,23 +10,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
-                  url: continue_provider_recruitment_cycle_courses_outcome_path(
+    <%= form_with url: continue_provider_recruitment_cycle_courses_outcome_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
 
-      <%= render 'shared/course_creation_hidden_fields',
-        form: form,
-        course_creation_params: @course_creation_params,
-        except_keys: [:qualification]
-      %>
-      <%= render 'form_fields', form: form, course_name_and_code: nil %>
-
-      <%= form.submit "Continue",
-                      class: "govuk-button",
-                      data: { qa: 'course__save' } %>
+      <%= render "courses/new_fields_holder", form: form, except_keys: [:qualification] do |fields| %>
+        <%= render 'form_fields', form: fields, course_name_and_code: nil %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -2,7 +2,9 @@
 
 <h1 class="govuk-heading-xl">Pick the training locations for this course</h1>
 
-<%= form_for course, url: continue_provider_recruitment_cycle_courses_locations_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :get do |f| %>
+<%= form_for course,
+  url: continue_provider_recruitment_cycle_courses_locations_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+  method: :get do |f| %>
   <%= render 'shared/course_creation_hidden_fields',
     form: f,
     course_creation_params: @course_creation_params,

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -15,16 +15,9 @@
                   ),
                   method: :get do |form| %>
 
-      <%= render 'shared/course_creation_hidden_fields',
-        form: form,
-        course_creation_params: @course_creation_params,
-        except_keys: [:start_date]
-      %>
-      <%= render 'form_fields', form: form %>
-
-      <%= form.submit "Continue",
-                      class: "govuk-button",
-                      data: { qa: 'course__save' } %>
+      <%= render "courses/new_fields_holder", form: form, except_keys: [:start_date] do |fields| %>
+        <%= render 'form_fields', form: fields %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/study_mode/new.html.erb
+++ b/app/views/courses/study_mode/new.html.erb
@@ -10,25 +10,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
-                  url: continue_provider_recruitment_cycle_courses_study_mode_path(
+    <%= form_with url: continue_provider_recruitment_cycle_courses_study_mode_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
 
-
-      <%= render 'shared/course_creation_hidden_fields',
-        form: form,
-        course_creation_params: @course_creation_params,
-        except_keys: [:study_mode]
-      %>
-      <%= render 'form_fields', form: form %>
-
-      <%= form.submit "Continue",
-                      class: "govuk-button",
-                      data: { qa: 'course__save' } %>
-
+      <%= render "courses/new_fields_holder", form: form, except_keys: [:study_mode] do |fields| %>
+        <%= render 'form_fields', form: fields %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_course_creation_hidden_fields.html.erb
+++ b/app/views/shared/_course_creation_hidden_fields.html.erb
@@ -7,4 +7,3 @@
     <%= form.hidden_field(field_name, value: field_value) %>
   <% end %>
 <% end %>
-

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ApplicationController, type: :controller do
+describe ApplicationController, type: :controller do
   before do
     controller.response = response
   end

--- a/spec/features/courses/age_range_in_years/new_spec.rb
+++ b/spec/features/courses/age_range_in_years/new_spec.rb
@@ -13,33 +13,54 @@ feature "new course age range", type: :feature do
     build(:course,
           :new,
           provider: provider,
-          level: :primary)
+          level: :primary,
+          study_mode: "full_time_or_part_time",
+          gcse_subjects_required_using_level: true,
+          applications_open_from: "2019-10-09",
+          start_date: "2019-10-09")
   end
 
   before do
-    stub_omniauth
+    stub_omniauth(provider: provider)
+    resource_list_to_jsonapi([provider])
     stub_api_v2_resource(provider)
+    stub_api_v2_resource(build(:provider, provider_code: "A2"))
+    stub_api_v2_resource(build(:provider, provider_code: "A4"))
     new_course = build(:course,
                        :new,
                        provider: provider,
                        level: :primary)
     stub_api_v2_new_resource(new_course)
     stub_api_v2_resource(recruitment_cycle)
-    stub_api_v2_resource_collection([new_course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource_collection([new_course], include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_build_course
+    stub_api_v2_build_course(age_range_in_years: "3_to_7")
   end
 
   scenario "sends user to entry requirements" do
+    visit_new_age_range_page
+
+    choose("course_age_range_in_years_3_to_7")
+    new_age_range_page.continue.click
+
+    expect(new_outcome_page).to be_displayed
+  end
+
+  scenario "sends user back to course confirmation" do
+    visit_new_age_range_page(goto_confirmation: true)
+
+    choose("course_age_range_in_years_3_to_7")
+    new_age_range_page.continue.click
+
+    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+
+  def visit_new_age_range_page(**query_params)
+    visit signin_path
     visit new_provider_recruitment_cycle_courses_age_range_path(
       provider.provider_code,
       provider.recruitment_cycle_year,
+      query_params,
     )
-
-    stub_api_v2_build_course(age_range_in_years: "3_to_7")
-    choose("course_age_range_in_years_3_to_7")
-    click_on "Continue"
-
-
-    expect(new_outcome_page).to be_displayed
   end
 end

--- a/spec/features/courses/applications_open/new_spec.rb
+++ b/spec/features/courses/applications_open/new_spec.rb
@@ -6,20 +6,29 @@ feature "new course applications open", type: :feature do
   end
 
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, :new, provider: provider) }
+  let(:course) do
+    build(
+      :course, :new,
+      provider: provider,
+      study_mode: "full_time_or_part_time",
+      gcse_subjects_required_using_level: true,
+      start_date: "2019-10-09"
+    )
+  end
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
   before do
-    stub_omniauth
+    stub_omniauth(provider: provider)
     stub_api_v2_resource(provider)
+    stub_api_v2_resource(build(:provider, provider_code: "A2"))
+    stub_api_v2_resource(build(:provider, provider_code: "A4"))
     stub_api_v2_resource(recruitment_cycle)
-    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
     stub_api_v2_build_course
     stub_api_v2_build_course(applications_open_from: "2018-10-09")
   end
 
-  scenario "sends user to confirmation page" do
-    visit new_provider_recruitment_cycle_courses_applications_open_path(provider.provider_code, provider.recruitment_cycle_year)
+  scenario "sends user to start date page" do
+    visit_new_applications_open_page
 
     expect(new_applications_open_page.applications_open_field).to_not be_checked
     expect(new_applications_open_page.applications_open_field_other).to_not be_checked
@@ -32,9 +41,40 @@ feature "new course applications open", type: :feature do
     expect(new_applications_open_page).to have_applications_open_field_other
 
     new_applications_open_page.applications_open_field.click
-
-    click_on "Continue"
+    new_applications_open_page.continue.click
 
     expect(current_path).to eq new_provider_recruitment_cycle_courses_start_date_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+
+  context "after setting the application open field" do
+    let(:course) do
+      build(
+        :course, :new,
+        provider: provider,
+        study_mode: "full_time_or_part_time",
+        gcse_subjects_required_using_level: true,
+        applications_open_from: "2019-10-09",
+        start_date: "2019-10-09"
+      )
+    end
+
+    scenario "sends user back to course confirmation" do
+      stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
+      visit_new_applications_open_page(goto_confirmation: true)
+
+      new_applications_open_page.applications_open_field.click
+      new_applications_open_page.continue.click
+
+      expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+    end
+  end
+
+  def visit_new_applications_open_page(**query_params)
+    visit signin_path
+    visit new_provider_recruitment_cycle_courses_applications_open_path(
+      provider.provider_code,
+      provider.recruitment_cycle_year,
+      query_params,
+    )
   end
 end

--- a/spec/features/courses/apprenticeship/new_spec.rb
+++ b/spec/features/courses/apprenticeship/new_spec.rb
@@ -8,7 +8,11 @@ feature "new course apprenticeship", type: :feature do
     build(:course,
           :new,
           provider: provider,
-          gcse_subjects_required: %w[maths science english])
+          gcse_subjects_required: %w[maths science english],
+          study_mode: "full_time_or_part_time",
+          gcse_subjects_required_using_level: true,
+          applications_open_from: "2019-10-09",
+          start_date: "2019-10-09")
   end
   let(:provider) { build(:provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
@@ -17,7 +21,7 @@ feature "new course apprenticeship", type: :feature do
     stub_omniauth
     stub_api_v2_resource(provider)
     stub_api_v2_resource(recruitment_cycle)
-    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_build_course
     stub_api_v2_build_course(funding_type: "apprenticeship")
     visit new_provider_recruitment_cycle_courses_apprenticeship_path(provider.provider_code, provider.recruitment_cycle_year)
@@ -36,6 +40,15 @@ feature "new course apprenticeship", type: :feature do
     expect(current_path).to eq new_provider_recruitment_cycle_courses_study_mode_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
+  scenario "sends user back to course confirmation" do
+    visit_new_apprenticeship_page(goto_confirmation: true)
+
+    new_apprenticeship_page.funding_type_fields.apprenticeship.click
+    new_apprenticeship_page.continue.click
+
+    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+
   context "Higher education program type" do
     let(:next_step_page) do
       PageObjects::Page::Organisations::Courses::NewStudyModePage.new
@@ -49,5 +62,9 @@ feature "new course apprenticeship", type: :feature do
     end
 
     it_behaves_like "a course creation page"
+  end
+
+  def visit_new_apprenticeship_page(**query_params)
+    visit new_provider_recruitment_cycle_courses_apprenticeship_path(provider.provider_code, provider.recruitment_cycle_year, query_params)
   end
 end

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -10,17 +10,37 @@ feature "Course confirmation", type: :feature do
   end
   let(:site1) { build(:site, location_name: "Site one") }
   let(:site2) { build(:site, location_name: "Site two") }
-  let(:course) { build(:course, provider: provider, sites: [site1, site2], subjects: [build(:subject, :english), build(:subject, :mathematics)]) }
+  let(:course) do
+    build(:course,
+          provider: provider,
+          sites: [site1, site2],
+          subjects: [
+            build(:subject, :english),
+            build(:subject, :mathematics),
+          ],
+          edit_options: {
+            age_range_in_years: [],
+            study_modes: [],
+            start_dates: [],
+            entry_requirements: [],
+            qualifications: [],
+          })
+  end
   let(:provider) { build(:provider) }
 
   before do
-    stub_omniauth
+    stub_omniauth(provider: provider)
     stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_resource(provider)
+    stub_api_v2_resource(provider, include: "sites")
     new_course = build(:course, :new, provider: provider)
     stub_api_v2_resource_collection([new_course], include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_new_resource(new_course)
+
     stub_api_v2_build_course
+    stub_api_v2_build_course(level: course.level)
+
+    visit signin_path
     visit confirmation_provider_recruitment_cycle_courses_path(
       provider.provider_code,
       provider.recruitment_cycle_year,
@@ -116,6 +136,116 @@ feature "Course confirmation", type: :feature do
           "Cats are important",
         )
       end
+    end
+  end
+
+  describe "Changing properties" do
+    shared_examples "goes to the edit page" do
+      it "goes to the edit page" do
+        expect(destination_page).to be_displayed
+        expect(destination_page).to have_current_path(/goto_confirmation=true/)
+        expect(destination_page).to have_current_path(/course%5Blevel%5D=#{course.level}/)
+      end
+    end
+
+    context "level" do
+      let(:destination_page) { PageObjects::Page::Organisations::Courses::NewLevelPage.new }
+
+      before do
+        course_confirmation_page.details.edit_level.click
+      end
+
+      include_examples "goes to the edit page"
+    end
+
+    context "is send" do
+      let(:destination_page) { PageObjects::Page::Organisations::Courses::NewLevelPage.new }
+
+      before do
+        course_confirmation_page.details.edit_is_send.click
+      end
+
+      include_examples "goes to the edit page"
+    end
+
+    context "age range" do
+      let(:destination_page) { PageObjects::Page::Organisations::Courses::NewAgeRangePage.new }
+
+      before do
+        course_confirmation_page.details.edit_age_range.click
+      end
+
+      include_examples "goes to the edit page"
+    end
+
+    context "apprenticeship" do
+      let(:destination_page) { PageObjects::Page::Organisations::Courses::NewApprenticeshipPage.new }
+
+      before do
+        course_confirmation_page.details.edit_apprenticeship.click
+      end
+
+      include_examples "goes to the edit page"
+    end
+
+    context "study mode" do
+      let(:destination_page) { PageObjects::Page::Organisations::Courses::NewStudyModePage.new }
+
+      before do
+        course_confirmation_page.details.edit_study_mode.click
+      end
+
+      include_examples "goes to the edit page"
+    end
+
+    context "locations page" do
+      let(:destination_page) { PageObjects::Page::Organisations::Courses::NewLocationsPage.new }
+
+      before do
+        course_confirmation_page.details.edit_locations.click
+      end
+
+      include_examples "goes to the edit page"
+    end
+
+    context "application open from page" do
+      let(:destination_page) { PageObjects::Page::Organisations::Courses::NewApplicationsOpenPage.new }
+
+      before do
+        course_confirmation_page.details.edit_application_open_from.click
+      end
+
+      include_examples "goes to the edit page"
+    end
+
+    context "start date page" do
+      let(:destination_page) { PageObjects::Page::Organisations::Courses::NewStartDatePage.new }
+
+      before do
+        course_confirmation_page.details.edit_start_date.click
+      end
+
+      include_examples "goes to the edit page"
+    end
+
+    context "entry requirements page" do
+      let(:destination_page) { PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new }
+
+      before do
+        course_confirmation_page.details.edit_entry_requirements.click
+      end
+
+      include_examples "goes to the edit page"
+    end
+
+    context "course outcome page" do
+      let(:destination_page) { PageObjects::Page::Organisations::Courses::NewCourseOutcome.new }
+
+      before do
+        course_confirmation_page.details.edit_qualifications.click
+      end
+
+      include_examples "goes to the edit page"
     end
   end
 

--- a/spec/features/courses/level/new_spec.rb
+++ b/spec/features/courses/level/new_spec.rb
@@ -5,24 +5,46 @@ feature "New course level", type: :feature do
     PageObjects::Page::Organisations::Courses::NewLevelPage.new
   end
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, :new, provider: provider, level: :primary, gcse_subjects_required_using_level: true, edit_options: { subjects: [] }) }
+  let(:course) do
+    build(:course,
+          :new,
+          provider: provider,
+          level: :primary,
+          study_mode: "full_time_or_part_time",
+          gcse_subjects_required_using_level: true,
+          applications_open_from: "2019-10-09",
+          start_date: "2019-10-09",
+          edit_options: {
+            subjects: [],
+          })
+  end
 
   before do
     stub_omniauth
+    stub_api_v2_resource(provider.recruitment_cycle)
+    stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_resource(provider)
     stub_api_v2_new_resource(course)
     stub_api_v2_build_course
     stub_api_v2_build_course(is_send: 0, level: "secondary")
 
-    visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
-    "/courses/level/new"
+    visit_new_level_page
   end
 
   scenario "sends user to entry requirements" do
-    choose "Secondary"
-    click_on "Continue"
+    new_level_page.level_fields.secondary.choose
+    new_level_page.continue.click
 
     expect(current_path).to eq new_provider_recruitment_cycle_courses_subjects_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+
+  scenario "sends user back to course confirmation" do
+    visit_new_level_page(goto_confirmation: true)
+
+    new_level_page.level_fields.secondary.choose
+    new_level_page.continue.click
+
+    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
   context "Selecting primary" do
@@ -39,5 +61,11 @@ feature "New course level", type: :feature do
     end
 
     it_behaves_like "a course creation page"
+  end
+
+private
+
+  def visit_new_level_page(**query_params)
+    visit new_provider_recruitment_cycle_courses_level_path(provider.provider_code, provider.recruitment_cycle.year, query_params)
   end
 end

--- a/spec/features/courses/start_date/new_spec.rb
+++ b/spec/features/courses/start_date/new_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 feature "New course start date", type: :feature do
+  let(:new_start_date_page) { PageObjects::Page::Organisations::CourseStartDate.new }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
   let(:provider) { build(:provider) }
   let(:course) { build(:course, provider: provider) }
@@ -16,12 +17,30 @@ feature "New course start date", type: :feature do
   end
 
   scenario "choose course start date" do
-    visit "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}" \
-    "/courses/start-date/new"
+    visit_new_start_date_page
 
     select "September #{Settings.current_cycle}"
     click_on "Continue"
 
     expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+
+  scenario "sends user back to course confirmation" do
+    visit_new_start_date_page(goto_confirmation: true)
+
+    select "September #{Settings.current_cycle}"
+    new_start_date_page.continue.click
+
+    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+
+private
+
+  def visit_new_start_date_page(**query_params)
+    visit new_provider_recruitment_cycle_courses_start_date_path(
+      provider.provider_code,
+      provider.recruitment_cycle.year,
+      query_params,
+    )
   end
 end

--- a/spec/features/courses/study_mode/new_spec.rb
+++ b/spec/features/courses/study_mode/new_spec.rb
@@ -14,23 +14,26 @@ feature "new course study mode", type: :feature do
       :new,
       provider: provider,
       gcse_subjects_required: %w[maths science english],
+      study_mode: "full_time",
+      applications_open_from: "2019-10-09",
+      start_date: "2019-10-09",
     )
   end
   let(:provider) { build(:provider) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
   before do
-    stub_omniauth
+    stub_omniauth(provider: provider)
     stub_api_v2_resource(provider)
     stub_api_v2_resource(provider, include: "sites")
     stub_api_v2_resource(recruitment_cycle)
-    stub_api_v2_resource_collection([course], include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_build_course
     stub_api_v2_build_course(study_mode: "full_time_or_part_time")
   end
 
   scenario "sends user to confirmation page" do
-    visit new_provider_recruitment_cycle_courses_study_mode_path(provider.provider_code, provider.recruitment_cycle_year)
+    visit_new_study_mode_page
 
     expect(new_study_mode_page).to have_study_mode_fields
     expect(new_study_mode_page.study_mode_fields)
@@ -45,5 +48,24 @@ feature "new course study mode", type: :feature do
     click_on "Continue"
 
     expect(new_locations_page).to be_displayed
+  end
+
+  scenario "sends user back to course confirmation" do
+    visit_new_study_mode_page(goto_confirmation: true)
+    new_study_mode_page.study_mode_fields.full_time_or_part_time.click
+    new_study_mode_page.continue.click
+
+    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+  end
+
+private
+
+  def visit_new_study_mode_page(**query_params)
+    visit signin_path
+    visit new_provider_recruitment_cycle_courses_study_mode_path(
+      provider.provider_code,
+      provider.recruitment_cycle_year,
+      query_params,
+    )
   end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "View helpers", type: :helper do
+feature "View helpers", type: :helper do
   describe "#govuk_link_to" do
     it "returns an anchor tag with the govuk-link class" do
       expect(helper.govuk_link_to("ACME SCITT", "https://localhost:44364/organisations/A0")).to eq("<a class=\"govuk-link\" href=\"https://localhost:44364/organisations/A0\">ACME SCITT</a>")

--- a/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
@@ -7,18 +7,29 @@ module PageObjects
         element :save, '[data-qa="course__save"]'
 
         section :details, '[data-qa="course__details"]' do
+          element :edit_level, '[data-qa="course__edit_level_link"]'
           element :level, '[data-qa="course__level"]'
+          element :edit_age_range, '[data-qa="course__edit_age_range_link"]'
+          element :age_range, '[data-qa="course__age_range"]'
+          element :edit_apprenticeship, '[data-qa="course__edit_apprenticeship_link"]'
+          element :apprenticeship, '[data-qa="course__apprenticeship"]'
+          element :edit_is_send, '[data-qa="course__edit_is_send_link"]'
           element :is_send, '[data-qa="course__is_send"]'
           element :subjects, '[data-qa="course__subjects"]'
-          element :age_range, '[data-qa="course__age_range"]'
+          element :edit_study_mode, '[data-qa="course__edit_study_mode_link"]'
           element :study_mode, '[data-qa="course__study_mode"]'
+          element :edit_locations, '[data-qa="course__edit_locations_link"]'
           element :locations, '[data-qa="course__locations"]'
-          element :study_mode, '[data-qa="course__study_mode"]'
+          element :edit_application_open_from, '[data-qa="course__edit_application_open_from_link"]'
           element :application_open_from, '[data-qa="course__application_open_from"]'
+          element :edit_start_date, '[data-qa="course__edit_start_date_link"]'
           element :start_date, '[data-qa="course__start_date"]'
           element :name, '[data-qa="course__name"]'
           element :description, '[data-qa="course__description"]'
+          element :edit_entry_requirements, '[data-qa="course__edit_entry_requirements_link"]'
           element :entry_requirements, '[data-qa="course__entry_requirements"]'
+          element :edit_qualifications, '[data-qa="course__edit_qualifications_link"]'
+          element :qualifications, '[data-qa="course__qualifications"]'
         end
 
         section :preview, '[data-qa="course__preview"]' do

--- a/spec/site_prism/page_objects/page/organisations/course_outcome.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_outcome.rb
@@ -5,6 +5,8 @@ module PageObjects
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/outcome"
 
         element :qualification_fields, '[data-qa="course__qualification"]'
+
+        element :continue, '[data-qa="course__save"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_start_date.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_start_date.rb
@@ -5,6 +5,8 @@ module PageObjects
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/start-date"
 
         element :start_date_field, '[data-qa="start_date"]'
+
+        element :continue, '[data-qa="course__save"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_age_range_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_age_range_page.rb
@@ -2,7 +2,7 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class NewAgeRangePage < CourseBase
+        class NewAgeRangePage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/age-range/new{?query*}"
 
           element :age_range_fields, '[data-qa="course__age_range_in_years"]'

--- a/spec/site_prism/page_objects/page/organisations/courses/new_applications_open_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_applications_open_page.rb
@@ -2,7 +2,7 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class NewApplicationsOpenPage < CourseBase
+        class NewApplicationsOpenPage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/applications-open/new{?query*}"
 
           element :applications_open_field, '[data-qa="applications_open_from"]'
@@ -10,7 +10,6 @@ module PageObjects
           element :applications_open_field_day, '[data-qa="day"]'
           element :applications_open_field_month, '[data-qa="month"]'
           element :applications_open_field_year, '[data-qa="year"]'
-          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
@@ -2,16 +2,13 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class NewApprenticeshipPage < CourseBase
+        class NewApprenticeshipPage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/apprenticeship/new{?query*}"
 
           section :funding_type_fields, '[data-qa="course__funding_type"]' do
             element :apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'
             element :fee, '[data-qa="course__funding_type_fee"]'
           end
-
-          element :save, '[data-qa="course__save"]'
-          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_course_base.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_course_base.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class NewCourseBase < CourseBase
+          element :continue, '[data-qa="course__save"]'
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_course_outcome.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_course_outcome.rb
@@ -1,0 +1,13 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class NewCourseOutcome < NewCourseBase
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/outcome/new{?query*}"
+
+          element :qualification_fields, '[data-qa="course__qualification"]'
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_entry_requirements_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_entry_requirements_page.rb
@@ -2,14 +2,12 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class NewEntryRequirementsPage < CourseBase
+        class NewEntryRequirementsPage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/entry-requirements/new{?query*}"
 
           element :maths_requirements,   '[data-qa="course__maths"]'
           element :english_requirements, '[data-qa="course__english"]'
           element :science_requirements, '[data-qa="course__science"]'
-
-          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_fee_or_salary_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_fee_or_salary_page.rb
@@ -2,7 +2,7 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class NewFeeOrSalaryPage < CourseBase
+        class NewFeeOrSalaryPage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/fee-or-salary/new{?query*}"
 
           section :funding_type_fields, '[data-qa="course__funding_type"]' do
@@ -10,7 +10,6 @@ module PageObjects
             element :fee, '[data-qa="course__funding_type_fee"]'
             element :salaried, '[data-qa="course__funding_type_salary"]'
           end
-          element :save, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_level_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_level_page.rb
@@ -2,7 +2,7 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class NewLevelPage < CourseBase
+        class NewLevelPage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/level/new"
 
           section :level_fields, '[data-qa="course__level"]' do
@@ -10,8 +10,6 @@ module PageObjects
             element :secondary,         "#course_level_secondary"
             element :further_education, "#course_level_further_education"
           end
-
-          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_locations_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_locations_page.rb
@@ -2,11 +2,10 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class NewLocationsPage < CourseBase
+        class NewLocationsPage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/locations/new{?query*}"
 
           elements :site_names, '[data-qa="site__name"]'
-          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_outcome_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_outcome_page.rb
@@ -2,7 +2,7 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class NewOutcomePage < CourseBase
+        class NewOutcomePage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/outcome/new{?query*}"
 
           section :qualification_fields, '[data-qa="course__qualification"]' do
@@ -11,8 +11,6 @@ module PageObjects
             element :pgce_with_qts, "#course_qualification_pgce_with_qts"
             element :pgde_with_qts, "#course_qualification_pgde_with_qts"
           end
-
-          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_start_date_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_start_date_page.rb
@@ -2,10 +2,8 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class NewStartDatePage < CourseBase
+        class NewStartDatePage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/start-date/new{?query*}"
-
-          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_study_mode_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_study_mode_page.rb
@@ -2,7 +2,7 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class NewStudyModePage < CourseBase
+        class NewStudyModePage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/full-part-time/new{?query*}"
 
           section :study_mode_fields, '[data-qa="course__study_mode"]' do
@@ -10,8 +10,6 @@ module PageObjects
             element :part_time, "#course_study_mode_part_time"
             element :full_time_or_part_time, "#course_study_mode_full_time_or_part_time"
           end
-
-          element :continue, '[data-qa="course__save"]'
         end
       end
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,6 +1,7 @@
 module Helpers
-  def stub_omniauth(user: nil)
+  def stub_omniauth(user: nil, provider: nil)
     user ||= build(:user)
+    provider ||= build(:provider)
 
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:dfe] = {
@@ -20,9 +21,10 @@ module Helpers
 
     # This is needed because we check the provider count on all pages
     # TODO: Move this to be returned with the user.
+    #AHHHHHHHHH
     stub_api_v2_request(
       "/recruitment_cycles/#{Settings.current_cycle}/providers",
-      build(:provider).to_jsonapi,
+      provider.to_jsonapi,
     )
     Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:dfe]
     stub_api_v2_request("/sessions", user.to_jsonapi, :post)


### PR DESCRIPTION
### Context
As it stands in order to change parts of course that is currently being created one must create a new course from scratch or use the back button.

### Changes proposed in this pull request
This PR allows someone to edit individual properties from the confirmation screen.

### Guidance to review
You will often see occurrences of `2.times` when visiting a page, for some reason when pages are visited for the first time they will not have their query parameters and visiting it twice fixes things. Ideas on how to better indicate this are appreciated and/or an existing Capybara issue.  
Because sites changing is not fully implemented the change link will simply redirect the user to the next step.
If #705 is merged first, this PR will need to be updated, if not we will need another PR to add the change to subjects.