### PR TITLE
[2175] Convert ucas contacts to full breadcrumb

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -54,4 +54,9 @@ module BreadcrumbHelper
     path = new_provider_recruitment_cycle_site_path(@provider.provider_code)
     sites_breadcrumb << ["Add a location", path]
   end
+
+  def ucas_contacts_breadcrumb
+    path = provider_ucas_contacts_path(@provider.provider_code)
+    provider_breadcrumb << ["UCAS contacts", path]
+  end
 end

--- a/app/views/ucas_contacts/show.html.erb
+++ b/app/views/ucas_contacts/show.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "UCAS contacts" %>
 
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_path(@provider.provider_code)) %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs("ucas_contacts") %>
 
 <h1 class="govuk-heading-xl">UCAS contacts</h1>
 


### PR DESCRIPTION
### Context

I understand from @fofr that the intention is only leaf-nodes on the
navigation to hae "back" and now that we've added another layer this
page should have the full breadcrumb.


### Changes proposed in this pull request

* Convert ucas contacts to full breadcrumb

![Selection_114](https://user-images.githubusercontent.com/19378/67284850-4df73e00-f4ce-11e9-8626-0ddcdf62a870.png)


### Guidance to review

:ship: