### PR TITLE
[2326] Add modern language subjects page

### DIFF
--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -17,7 +17,9 @@ module Courses
     end
 
     def update
-      if @course.update(subjects: old_non_language_subjects + new_language_subjects)
+      updated_subject_list = strip_non_language_subjects
+      updated_subject_list += selected_language_subjects
+      if @course.update(subjects: updated_subject_list)
         flash[:success] = "Your changes have been saved"
         redirect_to(
           details_provider_recruitment_cycle_course_path(
@@ -34,19 +36,14 @@ module Courses
 
   private
 
-    def new_language_subjects
-      language_ids = params.dig(:course, :language_ids)
-      found_languages_ids = available_languages_ids & language_ids
-
-      found_languages_ids.map do |language_id|
-        Subject.new(id: language_id)
-      end
+    def strip_non_language_subjects
+      @course.subjects.reject { |s| available_languages_ids.include?(s.id) }
     end
 
-    def old_non_language_subjects
-      @course.subjects.reject do |subject|
-        available_languages_ids.include?(subject.id)
-      end
+    def selected_language_subjects
+      language_ids = params.dig(:course, :language_ids)
+      found_languages_ids = available_languages_ids & language_ids
+      found_languages_ids.map { |id| Subject.new(id: id) }
     end
 
     def available_languages_ids

--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -1,0 +1,73 @@
+module Courses
+  class ModernLanguagesController < ApplicationController
+    include CourseBasicDetailConcern
+    decorates_assigned :course
+    before_action :build_course, only: %i[edit update]
+
+    def edit
+      return unless @course.meta[:edit_options][:modern_languages].nil?
+
+      redirect_to(
+        details_provider_recruitment_cycle_course_path(
+          @course.provider_code,
+          @course.recruitment_cycle_year,
+          @course.course_code,
+        ),
+      )
+    end
+
+    def update
+      if @course.update(subjects: old_non_language_subjects + new_language_subjects)
+        flash[:success] = "Your changes have been saved"
+        redirect_to(
+          details_provider_recruitment_cycle_course_path(
+            @course.provider_code,
+            @course.recruitment_cycle_year,
+            @course.course_code,
+          ),
+        )
+      else
+        @errors = @course.errors.messages
+        render :edit
+      end
+    end
+
+  private
+
+    def new_language_subjects
+      language_ids = params.dig(:course, :language_ids)
+      found_languages_ids = potential_languages_ids & language_ids
+
+      found_languages_ids.map do |language_id|
+        Subject.new(id: language_id)
+      end
+    end
+
+    def old_non_language_subjects
+      @course.subjects.reject do |subject|
+        potential_languages_ids.include?(subject.id)
+      end
+    end
+
+    def potential_languages_ids
+      @course.meta[:edit_options][:modern_languages].map do |language|
+        language["id"]
+      end
+    end
+
+    def current_step
+      nil
+    end
+
+    def errors; end
+
+    def build_course
+      @course = Course
+                  .includes(:subjects, :site_statuses)
+                  .where(recruitment_cycle_year: params[:recruitment_cycle_year])
+                  .where(provider_code: params[:provider_code])
+                  .find(params[:code])
+                  .first
+    end
+  end
+end

--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -36,7 +36,7 @@ module Courses
 
     def new_language_subjects
       language_ids = params.dig(:course, :language_ids)
-      found_languages_ids = potential_languages_ids & language_ids
+      found_languages_ids = available_languages_ids & language_ids
 
       found_languages_ids.map do |language_id|
         Subject.new(id: language_id)
@@ -45,11 +45,11 @@ module Courses
 
     def old_non_language_subjects
       @course.subjects.reject do |subject|
-        potential_languages_ids.include?(subject.id)
+        available_languages_ids.include?(subject.id)
       end
     end
 
-    def potential_languages_ids
+    def available_languages_ids
       @course.meta[:edit_options][:modern_languages].map do |language|
         language["id"]
       end

--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -55,10 +55,6 @@ module Courses
       end
     end
 
-    def current_step
-      nil
-    end
-
     def errors; end
 
     def build_course

--- a/app/controllers/courses/subjects_controller.rb
+++ b/app/controllers/courses/subjects_controller.rb
@@ -18,7 +18,7 @@ module Courses
       elsif @course.update(subjects: selected_subjects)
         flash[:success] = "Your changes have been saved"
         redirect_to(
-          details_provider_recruitment_cycle_course_path(
+          modern_languages_provider_recruitment_cycle_course_path(
             @course.provider_code,
             @course.recruitment_cycle_year,
             @course.course_code,

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -143,6 +143,10 @@ class CourseDecorator < ApplicationDecorator
     meta["edit_options"]["subjects"].map { |subject| [subject["attributes"]["subject_name"], subject["id"]] }
   end
 
+  def subject_present?(subject_to_find)
+    subjects.map { |subject| subject["id"] }.include?(subject_to_find["id"])
+  end
+
 private
 
   def not_on_find

--- a/app/views/courses/modern_languages/_form_fields.html.erb
+++ b/app/views/courses/modern_languages/_form_fields.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-form-group" data-qa="course__languages">
+  <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+    <% course.meta["edit_options"]["modern_languages"].each do |language| %>
+      <div class="govuk-checkboxes__item">
+        <%= form.check_box :language_ids,
+          { checked: course.subject_present?(language),
+            class: 'govuk-checkboxes__input',
+            multiple: true,
+            data: { qa: "checkbox_language_#{language["attributes"]["subject_name"]}" }
+          }, language["id"], nil %>
+        <%= form.label "language_ids_#{language["id"]}",
+          language["attributes"]["subject_name"],
+          class: 'govuk-label govuk-checkboxes__label' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/courses/modern_languages/edit.erb
+++ b/app/views/courses/modern_languages/edit.erb
@@ -1,0 +1,39 @@
+<%= content_for :page_title, "Change modern languages – #{course.name_and_code}" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: course,
+          url: modern_languages_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+          method: :put do |form| %>
+      <div
+        class="<%= classnames("govuk-form-group", "govuk-form-group--error": @errors && @errors[:subjects]&.any?) %>"
+        data-qa="course__modern_languages_section">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+              Change modern languages
+            </h1>
+          </legend>
+          <%= render "shared/error_messages", field: :subjects if @errors %>
+          <%= render 'form_fields', form: form %>
+        </fieldset>
+      </div>
+
+      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
+        class: "govuk-button", data: { qa: 'course__save' }
+      %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes',
+          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/courses/modern_languages/edit.erb
+++ b/app/views/courses/modern_languages/edit.erb
@@ -21,7 +21,7 @@
             </h1>
           </legend>
           <%= render "shared/error_messages", field: :subjects if @errors %>
-          <%= render 'form_fields', form: form %>
+          <%= render 'courses/modern_languages/form_fields', form: form %>
         </fieldset>
       </div>
 

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -1,1 +1,1 @@
-<%= form.select :master_subject_id, course.selectable_master_subjects, {}, data: { qa: 'course__subjects' }, class: "govuk-select" %>
+<%= form.select :master_subject_id, options_for_select(course.selectable_master_subjects, @course.subjects.first&.id), {}, data: { qa: 'course__subjects' }, class: "govuk-select" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,9 @@ Rails.application.routes.draw do
         get "/subjects", on: :member, to: "courses/subjects#edit"
         put "/subjects", on: :member, to: "courses/subjects#update"
 
+        get "/modern-languages", on: :member, to: "courses/modern_languages#edit"
+        put "/modern-languages", on: :member, to: "courses/modern_languages#update"
+
         get "/age-range", on: :member, to: "courses/age_range#edit"
         put "/age-range", on: :member, to: "courses/age_range#update"
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -5,6 +5,7 @@ describe CourseDecorator do
   let(:next_recruitment_cycle) { build :recruitment_cycle, :next_cycle }
   let(:provider) { build(:provider, accredited_body?: false) }
   let(:english) { build(:subject, :english) }
+  let(:biology) { build(:subject, :biology) }
   let(:mathematics) { build(:subject, :mathematics) }
   let(:subjects) { [english, mathematics] }
 
@@ -183,6 +184,16 @@ describe CourseDecorator do
         [english.subject_name, english.id],
         [mathematics.subject_name, mathematics.id],
       ])
+    end
+  end
+
+  describe "#subject_present?" do
+    it "returns true when the subject id exists" do
+      expect(decorated_course.subject_present?(english)).to eq(true)
+    end
+
+    it "returns true when the subject id does not exists" do
+      expect(decorated_course.subject_present?(biology)).to eq(false)
     end
   end
 end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -32,5 +32,9 @@ FactoryBot.define do
     trait :french do
       subject_name { "French" }
     end
+
+    trait :japanese do
+      subject_name { "Japanese" }
+    end
   end
 end

--- a/spec/features/courses/modern_languages/edit_spec.rb
+++ b/spec/features/courses/modern_languages/edit_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+feature "Edit course modern languages", type: :feature do
+  let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+  let(:languages_page) { PageObjects::Page::Organisations::CourseModernLanguages.new }
+  let(:course_details_page) { PageObjects::Page::Organisations::CourseDetails.new }
+  let(:course_request_change_page) { PageObjects::Page::Organisations::CourseRequestChange.new }
+  let(:provider) { build(:provider, site: site) }
+  let(:site) { build(:site) }
+  let(:site_status) { build(:site_status, site: site) }
+  let(:edit_options) { { subjects: [], modern_languages: [] } }
+  let(:subjects) { [build(:subject, :modern_languages)] }
+  let(:course) do
+    build(:course,
+          provider: provider,
+          edit_options: edit_options,
+          languages: [],
+          subjects: subjects,
+          sites: [site],
+          site_statuses: [site_status])
+  end
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses,accrediting_provider")
+    stub_api_v2_resource_collection([course])
+    stub_api_v2_resource(course, include: "subjects,site_statuses")
+    stub_api_v2_resource(course, include: "sites,accrediting_provider,provider.sites")
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+  end
+
+  context "with a given set of modern languages" do
+    let(:french_subject) { build(:subject, :french) }
+    let(:japanese_subject) { build(:subject, :japanese) }
+    let(:modern_languages) { [japanese_subject, french_subject] }
+    let(:edit_options) do
+      {
+        modern_languages: modern_languages,
+        subjects: subjects,
+      }
+    end
+
+    let(:modern_languages_subject) { build(:subject, :modern_languages) }
+
+    let(:subjects) do
+      [
+        modern_languages_subject,
+      ]
+    end
+
+    scenario "can select multiple modern language subjects" do
+      languages_page.load_with_course(course)
+      edit_languages_stub = stub_api_v2_resource(course, method: :patch)
+
+      languages_page.languages_fields.find('[data-qa="checkbox_language_French"]').click
+      languages_page.languages_fields.find('[data-qa="checkbox_language_Japanese"]').click
+      languages_page.save.click
+      expect(course_details_page).to be_displayed
+
+      expect(edit_languages_stub.with do |request|
+        subjects = JSON.parse(request.body)["data"]["relationships"]["subjects"]["data"]
+        expect(subjects).to match_array([
+          include("id" => modern_languages_subject.id.to_s),
+          include("id" => french_subject.id.to_s),
+          include("id" => japanese_subject.id.to_s),
+        ])
+      end).to have_been_made
+    end
+  end
+
+  context "when a course already has a different language assigned" do
+    let(:modern_languages_subject) { build(:subject, :modern_languages) }
+    let(:french_subject) { build(:subject, :french) }
+    let(:subjects) do
+      [
+        modern_languages_subject,
+        french_subject,
+      ]
+    end
+    let(:modern_languages) { [japanese_subject, russian_subject, french_subject] }
+    let(:russian_subject) { build(:subject, :russian) }
+    let(:japanese_subject) { build(:subject, :japanese) }
+    let(:edit_options) do
+      {
+        modern_languages: modern_languages,
+        subjects: [modern_languages_subject],
+      }
+    end
+
+    scenario "can select multiple modern language subjects" do
+      languages_page.load_with_course(course)
+      edit_languages_stub = stub_api_v2_resource(course, method: :patch)
+
+      languages_page.languages_fields.find('[data-qa="checkbox_language_French"]').click
+      languages_page.languages_fields.find('[data-qa="checkbox_language_Russian"]').click
+      languages_page.languages_fields.find('[data-qa="checkbox_language_Japanese"]').click
+      languages_page.save.click
+      expect(course_details_page).to be_displayed
+
+      expect(edit_languages_stub.with do |request|
+        subjects = JSON.parse(request.body)["data"]["relationships"]["subjects"]["data"]
+        expect(subjects).to match_array([
+          include("id" => modern_languages_subject.id.to_s),
+          include("id" => russian_subject.id.to_s),
+          include("id" => japanese_subject.id.to_s),
+        ])
+      end).to have_been_made
+    end
+
+    scenario "checks the current modern language subjects is selected" do
+      languages_page.load_with_course(course)
+
+      expect(page).to have_field("course_language_ids_#{french_subject.id}", checked: true)
+    end
+  end
+
+  context "if no potential modern languages exist for the course" do
+    let(:edit_options) do
+      {
+        modern_languages: nil,
+      }
+    end
+
+    scenario "redirects to course details page" do
+      languages_page.load_with_course(course)
+      expect(course_details_page).to be_displayed
+    end
+  end
+end

--- a/spec/features/courses/modern_languages/edit_spec.rb
+++ b/spec/features/courses/modern_languages/edit_spec.rb
@@ -99,9 +99,9 @@ feature "Edit course modern languages", type: :feature do
                                         ])
       end
 
-      languages_page.languages_fields.find('[data-qa="checkbox_language_French"]').click
-      languages_page.languages_fields.find('[data-qa="checkbox_language_Russian"]').click
-      languages_page.languages_fields.find('[data-qa="checkbox_language_Japanese"]').click
+      languages_page.language_checkbox("French").click
+      languages_page.language_checkbox("Russian").click
+      languages_page.language_checkbox("Japanese").click
       languages_page.save.click
 
       expect(course_details_page).to be_displayed

--- a/spec/features/courses/modern_languages/edit_spec.rb
+++ b/spec/features/courses/modern_languages/edit_spec.rb
@@ -52,21 +52,21 @@ feature "Edit course modern languages", type: :feature do
 
     scenario "can select multiple modern language subjects" do
       languages_page.load_with_course(course)
-      edit_languages_stub = stub_api_v2_resource(course, method: :patch)
+
+      patch_course_stub = set_patch_course_expectation do |subjects|
+        expect(subjects).to match_array([
+                                          include("id" => modern_languages_subject.id.to_s),
+                                          include("id" => french_subject.id.to_s),
+                                          include("id" => japanese_subject.id.to_s),
+                                        ])
+      end
 
       languages_page.languages_fields.find('[data-qa="checkbox_language_French"]').click
       languages_page.languages_fields.find('[data-qa="checkbox_language_Japanese"]').click
       languages_page.save.click
-      expect(course_details_page).to be_displayed
 
-      expect(edit_languages_stub.with do |request|
-        subjects = JSON.parse(request.body)["data"]["relationships"]["subjects"]["data"]
-        expect(subjects).to match_array([
-          include("id" => modern_languages_subject.id.to_s),
-          include("id" => french_subject.id.to_s),
-          include("id" => japanese_subject.id.to_s),
-        ])
-      end).to have_been_made
+      expect(course_details_page).to be_displayed
+      expect(patch_course_stub).to have_been_made
     end
   end
 
@@ -91,22 +91,21 @@ feature "Edit course modern languages", type: :feature do
 
     scenario "can select multiple modern language subjects" do
       languages_page.load_with_course(course)
-      edit_languages_stub = stub_api_v2_resource(course, method: :patch)
+      patch_course_stub = set_patch_course_expectation do |subjects|
+        expect(subjects).to match_array([
+                                          include("id" => modern_languages_subject.id.to_s),
+                                          include("id" => russian_subject.id.to_s),
+                                          include("id" => japanese_subject.id.to_s),
+                                        ])
+      end
 
       languages_page.languages_fields.find('[data-qa="checkbox_language_French"]').click
       languages_page.languages_fields.find('[data-qa="checkbox_language_Russian"]').click
       languages_page.languages_fields.find('[data-qa="checkbox_language_Japanese"]').click
       languages_page.save.click
-      expect(course_details_page).to be_displayed
 
-      expect(edit_languages_stub.with do |request|
-        subjects = JSON.parse(request.body)["data"]["relationships"]["subjects"]["data"]
-        expect(subjects).to match_array([
-          include("id" => modern_languages_subject.id.to_s),
-          include("id" => russian_subject.id.to_s),
-          include("id" => japanese_subject.id.to_s),
-        ])
-      end).to have_been_made
+      expect(course_details_page).to be_displayed
+      expect(patch_course_stub).to have_been_made
     end
 
     scenario "checks the current modern language subjects is selected" do
@@ -126,6 +125,15 @@ feature "Edit course modern languages", type: :feature do
     scenario "redirects to course details page" do
       languages_page.load_with_course(course)
       expect(course_details_page).to be_displayed
+    end
+  end
+
+private
+
+  def set_patch_course_expectation(&attribute_validator)
+    stub_api_v2_resource(course, method: :patch) do |request_body_json|
+      subjects = request_body_json["data"]["relationships"]["subjects"]["data"]
+      attribute_validator.call(subjects)
     end
   end
 end

--- a/spec/features/courses/modern_languages/edit_spec.rb
+++ b/spec/features/courses/modern_languages/edit_spec.rb
@@ -116,7 +116,7 @@ feature "Edit course modern languages", type: :feature do
     end
   end
 
-  context "if no potential modern languages exist for the course" do
+  context "if no modern languages are available for the course" do
     let(:edit_options) do
       {
         modern_languages: nil,

--- a/spec/features/courses/modern_languages/edit_spec.rb
+++ b/spec/features/courses/modern_languages/edit_spec.rb
@@ -91,6 +91,7 @@ feature "Edit course modern languages", type: :feature do
 
     scenario "can select multiple modern language subjects" do
       languages_page.load_with_course(course)
+      expect(page).to have_field("course_language_ids_#{french_subject.id}", checked: true)
       patch_course_stub = set_patch_course_expectation do |subjects|
         expect(subjects).to match_array([
                                           include("id" => modern_languages_subject.id.to_s),
@@ -106,12 +107,6 @@ feature "Edit course modern languages", type: :feature do
 
       expect(course_details_page).to be_displayed
       expect(patch_course_stub).to have_been_made
-    end
-
-    scenario "checks the current modern language subjects is selected" do
-      languages_page.load_with_course(course)
-
-      expect(page).to have_field("course_language_ids_#{french_subject.id}", checked: true)
     end
   end
 

--- a/spec/features/courses/subjects/edit_spec.rb
+++ b/spec/features/courses/subjects/edit_spec.rb
@@ -29,7 +29,7 @@ feature "Edit course subjects", type: :feature do
     stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
   end
 
-  context "with a given set of potential subjects" do
+  context "with a given set of available subjects" do
     let(:english_subject) { build(:subject, :english) }
     let(:subjects) { [english_subject, build(:subject, :biology)] }
     let(:edit_options) do

--- a/spec/features/courses/subjects/edit_spec.rb
+++ b/spec/features/courses/subjects/edit_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 feature "Edit course subjects", type: :feature do
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
   let(:subjects_page) { PageObjects::Page::Organisations::CourseSubjects.new }
+  let(:course_details_page) { PageObjects::Page::Organisations::CourseDetails.new }
   let(:languages_page) { PageObjects::Page::Organisations::CourseModernLanguages.new }
   let(:course_request_change_page) { PageObjects::Page::Organisations::CourseRequestChange.new }
   let(:provider) { build(:provider, site: site) }

--- a/spec/site_prism/page_objects/page/organisations/course_modern_languages.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_modern_languages.rb
@@ -6,6 +6,10 @@ module PageObjects
 
         element :languages_fields, '[data-qa="course__languages"]'
         element :save, '[data-qa="course__save"]'
+
+        def language_checkbox(name)
+          languages_fields.find("[data-qa=\"checkbox_language_#{name}\"]")
+        end
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course_modern_languages.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_modern_languages.rb
@@ -1,0 +1,12 @@
+module PageObjects
+  module Page
+    module Organisations
+      class CourseModernLanguages < CourseBase
+        set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/modern-languages"
+
+        element :languages_fields, '[data-qa="course__languages"]'
+        element :save, '[data-qa="course__save"]'
+      end
+    end
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -68,7 +68,8 @@ module Helpers
   def stub_api_v2_resource(resource,
                            jsonapi_response: nil,
                            include: nil,
-                           method: :get)
+                           method: :get,
+                           &validate_request_body)
     query_params = {}
     query_params[:include] = include if include.present?
 
@@ -76,7 +77,7 @@ module Helpers
     url += "?#{query_params.to_param}" if query_params.any?
 
     jsonapi_response ||= resource.to_jsonapi(include: include)
-    stub_api_v2_request(url, jsonapi_response, method)
+    stub_api_v2_request(url, jsonapi_response, method, &validate_request_body)
   end
 
   def stub_api_v2_new_resource(resource, jsonapi_response = nil)


### PR DESCRIPTION
### Context
As it stands modern languages cannot be set for the modern language subjects.  

### Changes proposed in this pull request
Add a page for modifying modern language subjects so that modern subjects can be set.

### Guidance to review
This also contains a fix for subjects not being autoselected as pointed out by @fofr 

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
