### PR TITLE
[2405] Show no-organisations page if user has no user record

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,10 @@ class ApplicationController < ActionController::Base
   end
 
   def render_unauthorized
-    respond_with_error(template: "errors/unauthorized", status: :unauthorized, error_text: "Unauthorized request")
+    # Backend responds with 401 if there is no matching record in the users table.
+    # Show the "We don’t know which organisation you’re part of" page to give users a route
+    # to getting access
+    render "providers/no_providers", status: :unauthorized
   end
 
   def handle_access_denied(exception)

--- a/app/views/providers/no_providers.erb
+++ b/app/views/providers/no_providers.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "We don’t know which organisation you’re part of" %>
 
-<div class="govuk-grid-row" data-qa="errors__unauthorized">
+<div class="govuk-grid-row" data-qa="errors__no_providers">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">We don’t know which organisation you’re part of</h1>
     <p class="govuk-body">You have successfully signed in with your DfE account but we don’t recognise the email address you’ve used. This might have happened if you were forwarded the original invitation email or if you’ve recently updated your email address.</p>

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -4,63 +4,34 @@ feature "View providers", type: :feature do
   let(:organisation_page) { PageObjects::Page::Organisations::OrganisationPage.new }
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
   let(:provider_1) { build :provider, provider_code: "A0", include_counts: [:courses] }
-  let(:provider_2) { build :provider, provider_code: "A1", include_counts: [:courses] }
-  let(:provider_response) { provider_1.to_jsonapi(include: %i[courses accrediting_provider]) }
-  let(:providers_response) do
-    resource_list_to_jsonapi([provider_1, provider_2])
-  end
+  let(:rollover) { false }
 
-  scenario "Navigate to /organisations" do
+  before do
     stub_omniauth
     stub_api_v2_request(
       "/recruitment_cycles/#{current_recruitment_cycle.year}",
       current_recruitment_cycle.to_jsonapi,
     )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers",
-      providers_response,
-    )
-
-    visit providers_path
-    expect(find("h1")).to have_content("Organisations")
-    expect(first(".govuk-list li")).to have_content(provider_1.provider_name.to_s)
+    allow(Settings).to receive(:rollover).and_return(rollover)
   end
 
+  context "with two providers" do
+    let(:provider_2) { build :provider, provider_code: "A1", include_counts: [:courses] }
+    let(:provider_response) { provider_1.to_jsonapi(include: %i[courses accrediting_provider]) }
 
-  scenario "Navigate to /organisations/A0" do
-    allow(Settings).to receive(:rollover).and_return(false)
-    stub_omniauth
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}",
-      current_recruitment_cycle.to_jsonapi,
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider_1.provider_code}",
-      provider_response,
-    )
-
-    visit provider_path(provider_1.provider_code)
-    expect(find("h1")).to have_content(provider_1.provider_name.to_s)
-    expect(organisation_page).not_to have_selector(".govuk-breadcrumbs")
-
-    expect(organisation_page).not_to have_current_cycle
-    expect(organisation_page).not_to have_next_cycle
-
-    expect(organisation_page).to have_link("Locations", href: "/organisations/A0/#{Settings.current_cycle}/locations")
-    expect(organisation_page).to have_link("Courses", href: "/organisations/A0/#{Settings.current_cycle}/courses")
-    expect(organisation_page).to have_link("UCAS contacts", href: "/organisations/A0/ucas-contacts")
-  end
-
-  context "Rollover" do
-    scenario "Navigate to /organisations/A0" do
-      allow(Settings).to receive(:rollover).and_return(true)
-      stub_omniauth
+    scenario "Navigate to /organisations" do
       stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}",
-        current_recruitment_cycle.to_jsonapi,
+        "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+        "/providers",
+        resource_list_to_jsonapi([provider_1, provider_2]),
       )
+
+      visit providers_path
+      expect(find("h1")).to have_content("Organisations")
+      expect(first(".govuk-list li")).to have_content(provider_1.provider_name.to_s)
+    end
+
+    scenario "Navigate to /organisations/A0" do
       stub_api_v2_request(
         "/recruitment_cycles/#{current_recruitment_cycle.year}" \
         "/providers/#{provider_1.provider_code}",
@@ -69,8 +40,60 @@ feature "View providers", type: :feature do
 
       visit provider_path(provider_1.provider_code)
       expect(find("h1")).to have_content(provider_1.provider_name.to_s)
-      expect(organisation_page).to have_current_cycle
-      expect(organisation_page).to have_next_cycle
+      expect(organisation_page).not_to have_selector(".govuk-breadcrumbs")
+
+      expect(organisation_page).not_to have_current_cycle
+      expect(organisation_page).not_to have_next_cycle
+
+      expect(organisation_page).to have_link("Locations", href: "/organisations/A0/#{Settings.current_cycle}/locations")
+      expect(organisation_page).to have_link("Courses", href: "/organisations/A0/#{Settings.current_cycle}/courses")
+      expect(organisation_page).to have_link("UCAS contacts", href: "/organisations/A0/ucas-contacts")
+    end
+
+    context "Rollover" do
+      let(:rollover) { true }
+
+      scenario "Navigate to /organisations/A0" do
+        stub_api_v2_request(
+          "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+          "/providers/#{provider_1.provider_code}",
+          provider_response,
+        )
+
+        visit provider_path(provider_1.provider_code)
+        expect(find("h1")).to have_content(provider_1.provider_name.to_s)
+        expect(organisation_page).to have_current_cycle
+        expect(organisation_page).to have_next_cycle
+      end
+    end
+  end
+
+  context "with no providers" do
+    let(:no_providers_page) { PageObjects::Page::Organisations::NoProviders.new }
+    let(:forbidden_page) { PageObjects::Page::Forbidden.new }
+
+    scenario "Navigate to /organisations" do
+      stub_api_v2_request(
+        "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+        "/providers",
+        resource_list_to_jsonapi([]),
+      )
+
+      visit providers_path
+      expect(no_providers_page.no_providers_text).to be_visible
+    end
+
+    scenario "Navigate to /organisations/A0" do
+      stub_api_v2_request(
+        "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+        "/providers/#{provider_1.provider_code}",
+        "",
+        :get,
+        403,
+      )
+
+      visit provider_path(provider_1.provider_code)
+      expect(forbidden_page.forbidden_text).to be_visible
     end
   end
 end

--- a/spec/features/unauthorized_api_requests_spec.rb
+++ b/spec/features/unauthorized_api_requests_spec.rb
@@ -1,20 +1,21 @@
 require "rails_helper"
 
 feature "Handling Unauthorized responses from the backend", type: :feature do
-  let(:unauthorized_page) { PageObjects::Page::Unauthorized.new }
+  let(:no_providers_page) { PageObjects::Page::Organisations::NoProviders.new }
 
   before do
     stub_omniauth
     stub_api_v2_request("/recruitment_cycles/#{Settings.current_cycle}", {}, :get, 401)
   end
 
-  it "Does not redirect the page" do
+  it "does not redirect" do
     visit "/organisations/A0/"
     expect(page.current_path).to eq("/organisations/A0")
   end
 
-  it "Renders the unauthorized page" do
+
+  it "renders the no-providers page" do
     visit "/organisations/A0/"
-    expect(unauthorized_page.unauthorized_text).to be_visible
+    expect(no_providers_page.no_providers_text).to be_visible
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/no_providers.rb
+++ b/spec/site_prism/page_objects/page/organisations/no_providers.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module Page
+    module Organisations
+      class NoProviders < PageObjects::Base
+        element :no_providers_text, "[data-qa=errors__no_providers]"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

The backend returns 401 if there is no user account. The last cleanup of
the status handling code left this user journey showing the "something
went wrong" unauthorized page.

### Changes proposed in this pull request

* Show no-organisations page if user has no user record
* All the test coverage

This change means that the same page is shown regardless of whether you
have no account in our database (401) or have an account but no access
to any providers (403), but the response codes to the browser are
reflective of which code the backend responded with (401/403).

### Guidance to review

:ship:?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally