### PR TITLE
[2409] login without dfe sign in

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,17 @@ To track exceptions through Sentry, configure the `SENTRY_DSN` environment varia
 ```
 SENTRY_DSN=https://aaa:bbb@sentry.io/123 rails s
 ```
+
+
+## Using Basic Auth Instead of DFE Sign-In
+
+For local development, you can disable reliance on DFE Sign-In by creating a
+file `config/settings/development.local.yml` with the contents:
+
+```yaml
+authorised_users:
+  your.email@digital.education.gov.uk: $LOCAL_PASSWORD
+```
+
+The email address has to exist in the users table of manage-courses-backend, but
+the password can be any non-secure local password you care to use.

--- a/README.md
+++ b/README.md
@@ -114,8 +114,11 @@ For local development, you can disable reliance on DFE Sign-In by creating a
 file `config/settings/development.local.yml` with the contents:
 
 ```yaml
-authorised_users:
-  your.email@digital.education.gov.uk: $LOCAL_PASSWORD
+authorised_user:
+  first_name: [your first name, this will be updated in the db]
+  last_name: [your last name, this will be updated in the db]
+  email: [the email address to login with]
+  password: [the password you wish to use]
 ```
 
 The email address has to exist in the users table of manage-courses-backend, but

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -32,7 +32,7 @@ class SessionsController < ApplicationController
   def signout
     if current_user.present?
       if development_mode_auth?
-        # Dissapointingly, with HTTP basic auth it's trick to really log
+        # Disappointingly, with HTTP basic auth it's trick to really log
         # someone out, since the browser just holds onto the user's username /
         # password and re-submits it until their session ends. So they'll just
         # create a new session after this "logout".

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -31,7 +31,21 @@ class SessionsController < ApplicationController
 
   def signout
     if current_user.present?
-      redirect_to "#{Settings.dfe_signin.issuer}/session/end?id_token_hint=#{current_user['credentials']['id_token']}&post_logout_redirect_uri=#{Settings.dfe_signin.base_url}/auth/dfe/signout"
+      if development_mode_auth?
+        # Dissapointingly, with HTTP basic auth it's trick to really log
+        # someone out, since the browser just holds onto the user's username /
+        # password and re-submits it until their session ends. So they'll just
+        # create a new session after this "logout".
+        reset_session
+        redirect_to root_path
+      else
+        uri = URI("#{Settings.dfe_signin.issuer}/session/end")
+        uri.query = {
+          id_token_hint: current_user["credentials"]["id_token"],
+          post_logout_redirect_uri: "#{Settings.dfe_signin.base_url}/auth/dfe/signout",
+        }.to_query
+        redirect_to uri.to_s
+      end
     else
       redirect_to root_path
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -8,6 +8,10 @@ describe ApplicationController, type: :controller do
   describe "#authenticate" do
     subject { controller.authenticate }
 
+    before do
+      disable_authorised_development_user
+    end
+
     context "user is unauthenticated" do
       it { should redirect_to "/signin" }
     end

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe "authorisation", type: :request do
+  context "authorised_user defined in settings" do
+    let(:user) { build(:user, password: password) }
+    let(:password) { "password" }
+    let(:provider) { build :provider }
+    let(:recruitment_cycle) { build :recruitment_cycle }
+    let(:headers) { {} }
+
+    before do
+      stub_api_v2_resource(recruitment_cycle)
+      stub_api_v2_resource_collection([provider])
+      stub_api_v2_resource(provider)
+    end
+
+    context "basic http authenticated" do
+      let(:headers) do
+        {
+          "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic
+                                    .encode_credentials(user.email, password),
+        }
+      end
+
+      it "considers the user logged in" do
+        stub_authorised_development_user(user) do
+          get "/organisations/#{provider.provider_code}", headers: headers
+        end
+
+        expect(response).to be_successful
+      end
+    end
+
+    context "without basic http authentication" do
+      it "requests user login" do
+        stub_authorised_development_user(user) do
+          get "/organisations/#{provider.provider_code}", headers: headers
+        end
+
+        expect(response).to be_unauthorized
+      end
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -7,9 +7,11 @@ describe "Sessions", type: :request do
       get(auth_dfe_callback_path)
 
       get(signout_path)
-      expect(response).to redirect_to(
-                            "#{Settings.dfe_signin.issuer}/session/end?id_token_hint=&post_logout_redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fdfe%2Fsignout"
-                          )
+      expect(response).to(
+        redirect_to(
+          "#{Settings.dfe_signin.issuer}/session/end?id_token_hint=&post_logout_redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fdfe%2Fsignout",
+        ),
+      )
     end
 
     context "user session is not present" do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -7,7 +7,9 @@ describe "Sessions", type: :request do
       get(auth_dfe_callback_path)
 
       get(signout_path)
-      expect(response).to redirect_to("#{Settings.dfe_signin.issuer}/session/end?id_token_hint=&post_logout_redirect_uri=https://localhost:3000/auth/dfe/signout")
+      expect(response).to redirect_to(
+                            "#{Settings.dfe_signin.issuer}/session/end?id_token_hint=&post_logout_redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fdfe%2Fsignout"
+                          )
     end
 
     context "user session is not present" do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -28,6 +28,34 @@ module Helpers
     )
     Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:dfe]
     stub_api_v2_request("/sessions", user.to_jsonapi, :post)
+
+    disable_authorised_development_user
+  end
+
+  def stub_authorised_development_user(user)
+    raise <<~EOMESSAGE unless block_given?
+      Can only stub authorised_user with a block, for example:
+
+        stub_authorised_development_user(user) do
+          get "/organisations"
+        end
+    EOMESSAGE
+
+    authorised_user = Config::Options.new(
+      email: user.email,
+      password: user.password,
+      first_name: user.first_name,
+      last_name: user.last_name,
+    )
+
+    stub_api_v2_request("/sessions", user.to_jsonapi, :post)
+
+    begin
+      Settings[:authorised_user] = authorised_user
+      yield
+    ensure
+      Settings.delete_field(:authorised_user)
+    end
   end
 
   def stub_api_v2_request(url_path, stub, method = :get, status = 200, token: nil, body: nil, &validate_request_body)
@@ -117,6 +145,10 @@ module Helpers
       url_for_build_course_with_params(params),
       jsonapi_response,
     )
+  end
+
+  def disable_authorised_development_user
+    allow(Settings).to receive(:key?).with(:authorised_user).and_return(false)
   end
 
 private


### PR DESCRIPTION
### Context

To reduce the friction to developing the app. So we can develop without requiring online access. etc.

### Changes proposed in this pull request

Add support for basic auth in `development` env, and if special config is provided.

### Guidance to review

Tests still have to be fixed, but I've run this locally and it seems to work. That includes existing functionality of sign-in and sign-out with DFE Sign-In.

But ... is this even a good idea?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
