### PR TITLE
[2325] Course creation flow for non-accredited body (SD)

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -104,6 +104,7 @@ private
           :start_date,
           :age_range_in_years,
           :master_subject_id,
+          :funding_type,
           sites_ids: [],
           subjects_ids: [],
         )
@@ -117,7 +118,7 @@ private
   end
 
   def next_step
-    next_step = NextCourseCreationStepService.new.execute(current_step: current_step)
+    next_step = NextCourseCreationStepService.new.execute(current_step: current_step, current_provider: @provider)
     next_page = course_creation_path_for(next_step)
 
     if next_page.nil?
@@ -149,6 +150,8 @@ private
       new_provider_recruitment_cycle_courses_age_range_path(path_params)
     when :subjects
       new_provider_recruitment_cycle_courses_subjects_path(path_params)
+    when :fee_or_salary
+      new_provider_recruitment_cycle_courses_fee_or_salary_path(path_params)
     when :confirmation
       confirmation_provider_recruitment_cycle_courses_path(path_params)
     end

--- a/app/controllers/courses/fee_or_salary_controller.rb
+++ b/app/controllers/courses/fee_or_salary_controller.rb
@@ -2,21 +2,11 @@ module Courses
   class FeeOrSalaryController < ApplicationController
     include CourseBasicDetailConcern
 
-    def continue
-      @errors = errors
-
-      if @errors.present?
-        render :new
-      else
-        redirect_to confirmation_provider_recruitment_cycle_courses_path(
-          params[:provider_code],
-          params[:recruitment_cycle_year],
-          course_params,
-        )
-      end
-    end
-
   private
+
+    def current_step
+      :fee_or_salary
+    end
 
     def errors; end
   end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -37,10 +37,6 @@ class CoursesController < ApplicationController
       Subject.new(id: subject_id)
     end
 
-    # We currently don't support setting the name of the course
-    # Nor does the API provide it
-    @course.name = "Temporary name"
-
     if @course.save
       redirect_to(
         provider_recruitment_cycle_course_path(

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -25,17 +25,7 @@ class CoursesController < ApplicationController
 
   def create
     build_provider_from_provider_code
-
-    @course = Course.new(
-      course_params.to_h.merge(
-        recruitment_cycle_year: @provider.recruitment_cycle_year,
-        provider_code: @provider.provider_code,
-      ),
-    )
-
-    @course.subjects = params.dig("course", "subjects_ids")&.map do |subject_id|
-      Subject.new(id: subject_id)
-    end
+    build_course_from_params
 
     if @course.save
       redirect_to(
@@ -52,6 +42,23 @@ class CoursesController < ApplicationController
       build_new_course
 
       render :confirmation
+    end
+  end
+
+  def build_course_from_params
+    @course = Course.new(
+      course_params.to_h.merge(
+        recruitment_cycle_year: @provider.recruitment_cycle_year,
+        provider_code: @provider.provider_code,
+      ),
+    )
+
+    @course.subjects = params.dig("course", "subjects_ids")&.map do |subject_id|
+      Subject.new(id: subject_id)
+    end
+
+    @course.sites = params.dig("course", "sites_ids")&.map do |site_id|
+      Site.new(id: site_id)
     end
   end
 

--- a/app/services/next_course_creation_step_service.rb
+++ b/app/services/next_course_creation_step_service.rb
@@ -1,5 +1,5 @@
 class NextCourseCreationStepService
-  def execute(current_step:)
+  def execute(current_step:, current_provider:)
     case current_step
     when :level
       :subjects
@@ -8,13 +8,21 @@ class NextCourseCreationStepService
     when :age_range
       :outcome
     when :outcome
-      :apprenticeship
+      if current_provider.accredited_body?
+        :apprenticeship
+      else
+        :fee_or_salary
+      end
     when :apprenticeship
       :full_or_part_time
     when :full_or_part_time
       :location
     when :location
-      :entry_requirements
+      if current_provider.accredited_body?
+        :entry_requirements
+      else
+        :accredited_body
+      end
     when :entry_requirements
       :applications_open
     when :applications_open

--- a/app/services/next_course_creation_step_service.rb
+++ b/app/services/next_course_creation_step_service.rb
@@ -13,6 +13,8 @@ class NextCourseCreationStepService
       else
         :fee_or_salary
       end
+    when :fee_or_salary
+      :full_or_part_time
     when :apprenticeship
       :full_or_part_time
     when :full_or_part_time

--- a/app/services/next_course_creation_step_service.rb
+++ b/app/services/next_course_creation_step_service.rb
@@ -8,11 +8,7 @@ class NextCourseCreationStepService
     when :age_range
       :outcome
     when :outcome
-      if current_provider.accredited_body?
-        :apprenticeship
-      else
-        :fee_or_salary
-      end
+      handle_outcome(current_provider)
     when :fee_or_salary
       :full_or_part_time
     when :apprenticeship
@@ -20,17 +16,31 @@ class NextCourseCreationStepService
     when :full_or_part_time
       :location
     when :location
-      if current_provider.accredited_body?
-        :entry_requirements
-      else
-        :accredited_body
-      end
+      handle_location(current_provider)
     when :entry_requirements
       :applications_open
     when :applications_open
       :start_date
     when :start_date
       :confirmation
+    end
+  end
+
+private
+
+  def handle_outcome(provider)
+    if provider.accredited_body?
+      :apprenticeship
+    else
+      :fee_or_salary
+    end
+  end
+
+  def handle_location(provider)
+    if provider.accredited_body?
+      :entry_requirements
+    else
+      :accredited_body
     end
   end
 end

--- a/spec/features/courses/fee_or_salary/new_spec.rb
+++ b/spec/features/courses/fee_or_salary/new_spec.rb
@@ -29,9 +29,18 @@ feature "new course fee or salary", type: :feature do
     expect(new_fee_or_salary_page.funding_type_fields).to have_salaried
   end
 
-  scenario "sends user to confirmation page" do
-    new_fee_or_salary_page.funding_type_fields.fee.click
-    new_fee_or_salary_page.save.click
-    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+  context "Selecting values" do
+    let(:next_step_page) do
+      PageObjects::Page::Organisations::Courses::NewStudyModePage.new
+    end
+    let(:selected_fields) { { funding_type: "fee" } }
+    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
+
+    before do
+      new_fee_or_salary_page.funding_type_fields.fee.click
+      new_fee_or_salary_page.save.click
+    end
+
+    it_behaves_like "a course creation page"
   end
 end

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -136,6 +136,18 @@ feature "new course", type: :feature do
                   },
                 ],
               },
+              "sites" => {
+                "data" => [
+                  {
+                    "type" => "sites",
+                    "id" => site1.id,
+                  },
+                  {
+                    "type" => "sites",
+                    "id" => site2.id,
+                  },
+                ],
+              },
             )
           end,
         ).to have_been_made

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -38,7 +38,7 @@ feature "new course", type: :feature do
   let(:build_new_course_request) { stub_api_v2_build_course }
   let(:site1) { build(:site, location_name: "Site one") }
   let(:site2) { build(:site, location_name: "Site two") }
-  let(:provider) { build(:provider, sites: [site1, site2]) }
+  let(:provider) { build(:provider, accredited_body?: true, sites: [site1, site2]) }
   let(:english) { build(:subject, :english) }
 
   let(:course) do
@@ -114,10 +114,6 @@ feature "new course", type: :feature do
         course_creation_params = select_applications_open_from(course_creation_params)
 
         select_start_date(course_creation_params)
-
-        # Add a temporary name
-        course.name = "Temporary name"
-        course_creation_params[:name] = "Temporary name"
 
         save_course
 

--- a/spec/features/courses/outcome/new_spec.rb
+++ b/spec/features/courses/outcome/new_spec.rb
@@ -26,7 +26,7 @@ feature "new course outcome", type: :feature do
 
   context "Selecting QTS" do
     let(:next_step_page) do
-      PageObjects::Page::Organisations::Courses::NewApprenticeshipPage.new
+      PageObjects::Page::Organisations::Courses::NewFeeOrSalaryPage.new
     end
     let(:selected_fields) { { qualification: "qts" } }
     let(:build_course_with_selected_value_request) { stub_api_v2_build_course(qualification: "qts") }
@@ -38,6 +38,15 @@ feature "new course outcome", type: :feature do
     end
 
     it_behaves_like "a course creation page"
+
+    context "With an accredited body provider" do
+      let(:provider) { build(:provider, accredited_body?: true) }
+      let(:next_step_page) do
+        PageObjects::Page::Organisations::Courses::NewApprenticeshipPage.new
+      end
+
+      it_behaves_like "a course creation page"
+    end
   end
 
 private

--- a/spec/features/courses/sites/new_spec.rb
+++ b/spec/features/courses/sites/new_spec.rb
@@ -11,6 +11,7 @@ feature "New course sites" do
     build(
       :provider,
       sites: [site1, site2, site3],
+      accredited_body?: true,
       recruitment_cycle: current_recruitment_cycle,
     )
   end
@@ -73,7 +74,7 @@ feature "New course sites" do
   end
 
   context "With a provider with a single site" do
-    let(:provider) { build(:provider, sites: [site2]) }
+    let(:provider) { build(:provider, sites: [site2], accredited_body?: true) }
 
     scenario "It transitions to the entry requirements page" do
       expect(new_entry_requirements_page).to be_displayed

--- a/spec/services/next_course_creation_step_service_spec.rb
+++ b/spec/services/next_course_creation_step_service_spec.rb
@@ -21,6 +21,13 @@ describe NextCourseCreationStepService do
       include_examples "next step"
     end
 
+    context "Current step: Fee or salary" do
+      let(:current_step) { :fee_or_salary }
+      let(:expected_next_step) { :full_or_part_time }
+
+      include_examples "next step"
+    end
+
     context "Current step: Location" do
       let(:current_step) { :location }
       let(:expected_next_step) { :accredited_body }

--- a/spec/services/next_course_creation_step_service_spec.rb
+++ b/spec/services/next_course_creation_step_service_spec.rb
@@ -3,12 +3,34 @@ describe NextCourseCreationStepService do
 
   shared_examples "next step" do
     it "Returns the correct next step" do
-      next_step = service.execute(current_step: current_step)
+      next_step = service.execute(
+        current_step: current_step,
+        current_provider: provider,
+      )
       expect(next_step).to eq(expected_next_step)
     end
   end
 
+  context "School Direct" do
+    let(:provider) { build(:provider, accredited_body?: false) }
+
+    context "Current step: Outcome" do
+      let(:current_step) { :outcome }
+      let(:expected_next_step) { :fee_or_salary }
+
+      include_examples "next step"
+    end
+
+    context "Current step: Location" do
+      let(:current_step) { :location }
+      let(:expected_next_step) { :accredited_body }
+
+      include_examples "next step"
+    end
+  end
+
   context "SCITT Provider" do
+    let(:provider) { build(:provider, accredited_body?: true) }
     context "Current step: Level" do
       let(:current_step) { :level }
       let(:expected_next_step) { :subjects }

--- a/spec/site_prism/page_objects/page/organisations/courses/new_fee_or_salary_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_fee_or_salary_page.rb
@@ -3,7 +3,7 @@ module PageObjects
     module Organisations
       module Courses
         class NewFeeOrSalaryPage < CourseBase
-          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/fee-or-salary/new"
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/fee-or-salary/new{?query*}"
 
           section :funding_type_fields, '[data-qa="course__funding_type"]' do
             element :apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'


### PR DESCRIPTION
### Context

Non-accredited bodies need to go through slightly different course creation flows due to what they're allowed to provide.  

### Changes proposed in this pull request

- Add in pages for non-accredited bodies to the course flow
- Update the relevant pages tests
- Fix up a couple of things noticed when testing E2E locally
    - Sites id's on creation
    - Remove temporary name

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
