### PR TITLE
[2414] Strip commas from course fees

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -70,6 +70,9 @@ class CoursesController < ApplicationController
     end
     params[:course].delete(:course_length_other_length)
 
+    # A user has been struggling to input a number in the course fees box because
+    # our validations do not allow commas to be added. eg 9,000 is not accepted.
+    # By stripping commas out the backend will not reject such input.
     params[:course][:fee_uk_eu].gsub!(",", "") if params[:course][:fee_uk_eu].present?
     params[:course][:fee_international].gsub!(",", "") if params[:course][:fee_international].present?
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -64,17 +64,7 @@ class CoursesController < ApplicationController
   end
 
   def update
-    # Course length should be saved as `course_length` so if "other" is selected then pass that text value into `course_length`
-    if params[:course][:course_length_other_length].present? && params[:course][:course_length] == "Other"
-      params[:course][:course_length] = params[:course][:course_length_other_length]
-    end
-    params[:course].delete(:course_length_other_length)
-
-    # A user has been struggling to input a number in the course fees box because
-    # our validations do not allow commas to be added. eg 9,000 is not accepted.
-    # By stripping commas out the backend will not reject such input.
-    params[:course][:fee_uk_eu].gsub!(",", "") if params[:course][:fee_uk_eu].present?
-    params[:course][:fee_international].gsub!(",", "") if params[:course][:fee_international].present?
+    massage_update_course_params
 
     if @course.update(course_params)
       flash[:success] = "Your changes have been saved"
@@ -370,5 +360,19 @@ private
     )
 
     @recruitment_cycle = RecruitmentCycle.find(cycle_year).first
+  end
+
+  def massage_update_course_params
+    # Course length should be saved as `course_length` so if "other" is selected then pass that text value into `course_length`
+    if params[:course][:course_length_other_length].present? && params[:course][:course_length] == "Other"
+      params[:course][:course_length] = params[:course][:course_length_other_length]
+    end
+    params[:course].delete(:course_length_other_length)
+
+    # A user has been struggling to input a number in the course fees box because
+    # our validations do not allow commas to be added. eg 9,000 is not accepted.
+    # By stripping commas out the backend will not reject such input.
+    params[:course][:fee_uk_eu].gsub!(",", "") if params[:course][:fee_uk_eu].present?
+    params[:course][:fee_international].gsub!(",", "") if params[:course][:fee_international].present?
   end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -70,6 +70,10 @@ class CoursesController < ApplicationController
     end
     params[:course].delete(:course_length_other_length)
 
+    # Remove commas from fees
+    params[:course][:fee_uk_eu].gsub!(",", "") if params[:course][:fee_uk_eu].present?
+    params[:course][:fee_international].gsub!(",", "") if params[:course][:fee_international].present?
+
     if @course.update(course_params)
       flash[:success] = "Your changes have been saved"
       redirect_to(

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -70,7 +70,6 @@ class CoursesController < ApplicationController
     end
     params[:course].delete(:course_length_other_length)
 
-    # Remove commas from fees
     params[:course][:fee_uk_eu].gsub!(",", "") if params[:course][:fee_uk_eu].present?
     params[:course][:fee_international].gsub!(",", "") if params[:course][:fee_international].present?
 


### PR DESCRIPTION
Be more flexible in what we accept from users.

A user has been struggling to input a number in the course fees box because our validations do not allow commas to be added. eg 9,000 is not accepted.

We need to loosen our validations to allow for this type of value to be entered.

![image](https://user-images.githubusercontent.com/19378/67678028-7cb55e80-f97d-11e9-882d-22e55efc5432.png)

https://www.qa.publish-teacher-training-courses.service.gov.uk/organisations/2AT/2020/courses/3CX8/fees