### PR TITLE
Randomize the development certificate serial number

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -40,7 +40,7 @@ if env == "development"
     def generate_root_cert(root_key)
       root_ca = OpenSSL::X509::Certificate.new
       root_ca.version = 2 # cf. RFC 5280 - to make it a "v3" certificate
-      root_ca.serial = 0x0
+      root_ca.serial = rand(100000) # randomized for local development to prevent SEC_ERROR_REUSED_ISSUER_AND_SERIAL errors in firefox after a git-clean
       root_ca.subject = OpenSSL::X509::Name.parse "/C=GB/L=London/O=DfE/CN=localhost"
       root_ca.issuer = root_ca.subject # root CA's are "self-signed"
       root_ca.public_key = root_key.public_key


### PR DESCRIPTION
To avoid firefox refusing access after a git clean.

Some more context

* https://security.stackexchange.com/questions/141618/openssl-serial-number-error-sec-error-reused-issuer-and-serial