### PR TITLE
[2407] - Improve handling for missing / incorrect DFE Signin credentials (Development)

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -40,6 +40,9 @@ module OmniAuth
         fail!(:timeout, e)
       rescue ::SocketError => e
         fail!(:failed_to_connect, e)
+      rescue Rack::OAuth2::Client::Error => e
+        Rails.logger.error "Auth failure, is Settings.dfe_signin.secret correct? #{e}"
+        raise
       end
     end
   end


### PR DESCRIPTION
### Context
When running the front end application for the first time, the user is required to create a `config/setting/development.local.yml` and add a value for DFE Sign in secret.

A couple of scenarios can occur which can result in errors that are not immediately obvious:
- An incorrect secret is entered
- A typo is made in the yaml file (if the key is incorrect, the default value is used)

https://trello.com/c/D9Ym3r5I/2407-manage-courses-frontend-technical-onboarding

### Changes proposed in this pull request
- Rescue and log `Rack::OAuth2::Client::Error` (indicating that the `dfe_signin` secret _could_ be incorrect)

### Missing or incorrect secret
<img width="1680" alt="Screenshot 2019-10-28 at 11 12 42" src="https://user-images.githubusercontent.com/5256922/67674372-3ad3ea80-f974-11e9-9989-42190906901e.png">

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
