### PR TITLE
[2435] - fix(course age range form): validation errors

### DIFF
--- a/app/controllers/courses/age_range_controller.rb
+++ b/app/controllers/courses/age_range_controller.rb
@@ -6,7 +6,10 @@ module Courses
 
     def update
       @errors = build_errors
-      return render :edit if @errors.present?
+      if @errors.present?
+        @course.age_range_in_years = "#{age_from_param}_to_#{age_to_param}"
+        return render :edit
+      end
 
       update_age_range_param
 
@@ -28,11 +31,7 @@ module Courses
   private
 
     def update_age_range_param
-      if valid_custom_age_range?
-        params[:course][:age_range_in_years] = "#{age_from_param}_to_#{age_to_param}"
-      elsif age_range_is_other?
-        params[:course][:age_range_in_years] = nil
-      end
+      params[:course][:age_range_in_years] = "#{age_from_param}_to_#{age_to_param}" if valid_custom_age_range?
     end
 
     def valid_custom_age_range?
@@ -40,13 +39,65 @@ module Courses
     end
 
     def build_errors
-      if age_range_is_other? && (age_from_param.blank? || age_to_param.blank?)
-        {
-          age_range_in_years: ["Enter an age for both from and to"],
-          age_range_in_years_from: ["Enter an age"],
-          age_range_in_years_to: ["Enter an age"],
+      from_and_to_error = "Enter an age in both From and To"
+      from_missing_error = "Enter an age in From"
+      to_missing_error = "Enter an age in To"
+      from_invalid_error = "Enter a valid age in From"
+      to_invalid_error = "Enter a valid age in To"
+
+      if age_range_from_and_to_missing?
+        return {
+          age_range_in_years: [from_and_to_error],
+          age_range_in_years_from: [from_missing_error],
+          age_range_in_years_to: [to_missing_error],
         }
       end
+
+      if age_range_from_missing?
+        return {
+          age_range_in_years_from: [from_missing_error],
+        }
+      end
+
+      if age_range_to_missing?
+        return {
+          age_range_in_years_to: [to_missing_error],
+        }
+      end
+
+      if age_range_from_invalid?
+        return {
+          age_range_in_years: [from_invalid_error],
+          age_range_in_years_from: [from_invalid_error],
+        }
+      end
+
+      if age_range_less_than_4?
+        {
+          age_range_in_years: [to_invalid_error],
+          age_range_in_years_to: [to_invalid_error],
+        }
+      end
+    end
+
+    def age_range_less_than_4?
+      age_range_is_other? && ((age_to_param.to_i - age_from_param.to_i).abs < 4)
+    end
+
+    def age_range_from_invalid?
+      age_range_is_other? && (age_from_param.to_i > age_to_param.to_i)
+    end
+
+    def age_range_from_and_to_missing?
+      age_range_is_other? && (age_from_param.blank? && age_to_param.blank?)
+    end
+
+    def age_range_from_missing?
+      age_range_is_other? && (age_from_param.blank? && age_to_param.present?)
+    end
+
+    def age_range_to_missing?
+      age_range_is_other? && (age_from_param.present? && age_to_param.blank?)
     end
 
     def age_to_param

--- a/app/controllers/courses/age_range_controller.rb
+++ b/app/controllers/courses/age_range_controller.rb
@@ -39,43 +39,37 @@ module Courses
     end
 
     def build_errors
-      from_and_to_error = "Enter an age in both From and To"
-      from_missing_error = "Enter an age in From"
-      to_missing_error = "Enter an age in To"
-      from_invalid_error = "Enter a valid age in From"
-      to_invalid_error = "Enter a valid age in To"
-
       if age_range_from_and_to_missing?
         return {
-          age_range_in_years: [from_and_to_error],
-          age_range_in_years_from: [from_missing_error],
-          age_range_in_years_to: [to_missing_error],
+          age_range_in_years: [t("age_range.errors.from_and_to_error")],
+          age_range_in_years_from: [t("age_range.errors.from_missing_error")],
+          age_range_in_years_to: [t("age_range.errors.to_missing_error")],
         }
       end
 
       if age_range_from_missing?
         return {
-          age_range_in_years_from: [from_missing_error],
+          age_range_in_years_from: [t("age_range.errors.from_missing_error")],
         }
       end
 
       if age_range_to_missing?
         return {
-          age_range_in_years_to: [to_missing_error],
+          age_range_in_years_to: [t("age_range.errors.to_missing_error")],
         }
       end
 
       if age_range_from_invalid?
         return {
-          age_range_in_years: [from_invalid_error],
-          age_range_in_years_from: [from_invalid_error],
+          age_range_in_years: [t("age_range.errors.from_invalid_error")],
+          age_range_in_years_from: [t("age_range.errors.from_invalid_error")],
         }
       end
 
       if age_range_less_than_4?
         {
-          age_range_in_years: [to_invalid_error],
-          age_range_in_years_to: [to_invalid_error],
+          age_range_in_years: [t("age_range.errors.to_invalid_error")],
+          age_range_in_years_to: [t("age_range.errors.to_invalid_error")],
         }
       end
     end

--- a/app/helpers/age_range_errors_view_helper.rb
+++ b/app/helpers/age_range_errors_view_helper.rb
@@ -1,0 +1,22 @@
+module AgeRangeErrorsViewHelper
+  def expand_another_age_range?
+    (course.other_age_range? && course.age_range_in_years.present?) ||
+      (@errors && (@errors[:age_range_in_years_to].present? || @errors[:age_range_in_years_from].present?))
+  end
+
+  def age_range_from_field_value
+    if course.other_age_range? && course.age_range_in_years.present?
+      course.age_range_in_years.split("_").first
+    else
+      ""
+    end
+  end
+
+  def age_range_to_field_value
+    if course.other_age_range? && course.age_range_in_years.present?
+      course.age_range_in_years.split("_").last
+    else
+      ""
+    end
+  end
+end

--- a/app/views/courses/age_range/_errors.html.erb
+++ b/app/views/courses/age_range/_errors.html.erb
@@ -1,0 +1,23 @@
+<% error_summary_title ||= 'You’ll need to correct some information.' %>
+<% if @errors && @errors.any? %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      <%= error_summary_title %>
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <% if @errors.key?(:age_range_in_years) %>
+          <li data-error-message="<%= @errors[:age_range_in_years].first %>">
+            <%= link_to @errors[:age_range_in_years].first, "#age_range_in_years-error" %>
+          </li>
+        <% else %>
+          <% @errors.each do |id, messages| %>
+            <% messages.each do |message| %>
+              <li data-error-message="<%= message %>"><%= link_to message, "##{id.to_s}-error" %></li>
+            <% end %>
+          <% end %>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/courses/age_range/_form_fields.html.erb
+++ b/app/views/courses/age_range/_form_fields.html.erb
@@ -12,8 +12,8 @@
   <div class="govuk-radios__divider">or</div>
   <div class="govuk-radios__item">
     <%= form.radio_button :age_range_in_years, 'other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" },
-      checked: course.other_age_range? && course.age_range_in_years.present?,
-      aria: { describedby: @errors && @errors[:age_range_in_years] ? "course_age_range_in_years-error" : '' } %>
+      checked: (course.other_age_range? && course.age_range_in_years.present?) || (@errors && (@errors[:age_range_in_years_to].present? || @errors[:age_range_in_years_from].present?)),
+      aria: { describedby: @errors && @errors[:age_range_in_years_other] ? "course_age_range_in_years-error" : '' } %>
     <%= form.label :age_range_in_years, t("edit_options.age_range_in_years.other.label"), value: 'other', class: 'govuk-label govuk-radios__label' %>
   </div>
   <div class="govuk-radios__conditional <%= 'govuk-radios__conditional--hidden' if !course.other_age_range? %>" id="other-container">

--- a/app/views/courses/age_range/_form_fields.html.erb
+++ b/app/views/courses/age_range/_form_fields.html.erb
@@ -12,7 +12,7 @@
   <div class="govuk-radios__divider">or</div>
   <div class="govuk-radios__item">
     <%= form.radio_button :age_range_in_years, 'other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" },
-      checked: (course.other_age_range? && course.age_range_in_years.present?) || (@errors && (@errors[:age_range_in_years_to].present? || @errors[:age_range_in_years_from].present?)),
+      checked: expand_another_age_range?,
       aria: { describedby: @errors && @errors[:age_range_in_years_other] ? "course_age_range_in_years-error" : '' } %>
     <%= form.label :age_range_in_years, t("edit_options.age_range_in_years.other.label"), value: 'other', class: 'govuk-label govuk-radios__label' %>
   </div>
@@ -24,7 +24,7 @@
       <%= form.number_field 'course_age_range_in_years_other_from',
           min: 0,
           max: 46,
-          value: (course.other_age_range? && course.age_range_in_years.present?) ? course.age_range_in_years.split('_').first : '',
+          value: age_range_from_field_value,
           class: 'govuk-input govuk-input--width-2' %>
     </div>
     <%= render "shared/error_messages", field: :age_range_in_years_to if @errors %>
@@ -33,7 +33,7 @@
       <%= form.number_field 'course_age_range_in_years_other_to',
           min: 4,
           max: 50,
-          value: (course.other_age_range? && course.age_range_in_years.present?) ? course.age_range_in_years.split('_').last : '',
+          value: age_range_to_field_value,
           class: 'govuk-input govuk-input--width-2' %>
     </div>
   </div>

--- a/app/views/courses/age_range/_form_fields.html.erb
+++ b/app/views/courses/age_range/_form_fields.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-radios" data-module="govuk-radios">
   <% @course.meta['edit_options']['age_range_in_years'].each do |value| %>
     <div class="govuk-radios__item">
-      <%= form.radio_button :age_range_in_years, value, class: 'govuk-radios__input' %>
+      <%= form.radio_button :age_range_in_years, value, class: 'govuk-radios__input', data: {qa: "course__age_range_in_years_#{value}_radio"} %>
       <%= form.label :age_range_in_years,
             t("edit_options.age_range_in_years.#{value}.label"),
             value: value,
@@ -11,7 +11,7 @@
   <% end %>
   <div class="govuk-radios__divider">or</div>
   <div class="govuk-radios__item">
-    <%= form.radio_button :age_range_in_years, 'other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" },
+    <%= form.radio_button :age_range_in_years, 'other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container", qa: "course__age_range_in_years_other_radio" },
       checked: expand_another_age_range?,
       aria: { describedby: @errors && @errors[:age_range_in_years_other] ? "course_age_range_in_years-error" : '' } %>
     <%= form.label :age_range_in_years, t("edit_options.age_range_in_years.other.label"), value: 'other', class: 'govuk-label govuk-radios__label' %>
@@ -25,7 +25,9 @@
           min: 0,
           max: 46,
           value: age_range_from_field_value,
-          class: 'govuk-input govuk-input--width-2' %>
+          class: 'govuk-input govuk-input--width-2' ,
+          data: { qa: "course__age_range_in_years_other_from_input"}
+      %>
     </div>
     <%= render "shared/error_messages", field: :age_range_in_years_to if @errors %>
     <div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years_to].present?) %>">
@@ -34,7 +36,9 @@
           min: 4,
           max: 50,
           value: age_range_to_field_value,
-          class: 'govuk-input govuk-input--width-2' %>
+          class: 'govuk-input govuk-input--width-2',
+          data: { qa: "course__age_range_in_years_other_to_input"}
+      %>
     </div>
   </div>
 </div>

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -3,7 +3,7 @@
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
 
-<%= render 'shared/errors' %>
+<%= render 'errors' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -10,7 +10,6 @@
     <%= form_with model: course,
           url: age_range_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
           method: :put do |form| %>
-
       <div
         class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years]&.any?) %>"
         data-qa="course__age_range_in_years">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,3 +117,10 @@ en:
         label: "Don’t get an email"
       all:
         label: "Get an email for each application you receive"
+  age_range:
+    errors:
+      from_and_to_error: "Enter an age in both From and To"
+      from_missing_error: "Enter an age in From"
+      to_missing_error: "Enter an age in To"
+      from_invalid_error: "Enter a valid age in From"
+      to_invalid_error: "Enter a valid age in To"

--- a/spec/features/courses/age_range_in_years/edit_spec.rb
+++ b/spec/features/courses/age_range_in_years/edit_spec.rb
@@ -74,8 +74,8 @@ feature "Edit course age range in years", type: :feature do
         :patch, 200
         )
 
-      choose("course_age_range_in_years_14_to_19")
-      click_on "Save"
+      age_range_in_years_page.age_range_14_to_19.click
+      age_range_in_years_page.save.click
 
       expect(course_details_page).to be_displayed
       expect(course_details_page.flash).to have_content("Your changes have been saved")
@@ -91,12 +91,10 @@ feature "Edit course age range in years", type: :feature do
         :patch, 200
       )
 
-      choose("course_age_range_in_years_other")
-
-      fill_in("course_course_age_range_in_years_other_from", with: "14")
-      fill_in("course_course_age_range_in_years_other_to", with: "19")
-
-      click_on "Save"
+      age_range_in_years_page.age_range_other.click
+      age_range_in_years_page.age_range_from_field.set("14")
+      age_range_in_years_page.age_range_to_field.set("19")
+      age_range_in_years_page.save.click
 
       expect(course_details_page).to be_displayed
       expect(course_details_page.flash).to have_content("Your changes have been saved")
@@ -105,8 +103,8 @@ feature "Edit course age range in years", type: :feature do
 
     context "displaying errors for custom age range selection" do
       scenario "From and To ages is missing" do
-        choose("course_age_range_in_years_other")
-        click_on "Save"
+        age_range_in_years_page.age_range_other.click
+        age_range_in_years_page.save.click
 
         expect(age_range_in_years_page).to be_displayed
         expect(age_range_in_years_page.error_flash).to have_content(
@@ -115,9 +113,9 @@ feature "Edit course age range in years", type: :feature do
       end
 
       scenario "From age is missing" do
-        choose("course_age_range_in_years_other")
-        fill_in("course_course_age_range_in_years_other_from", with: "16")
-        click_on "Save"
+        age_range_in_years_page.age_range_other.click
+        age_range_in_years_page.age_range_from_field.set("16")
+        age_range_in_years_page.save.click
 
         expect(age_range_in_years_page).to be_displayed
         expect(age_range_in_years_page.error_flash).to have_content(
@@ -126,9 +124,9 @@ feature "Edit course age range in years", type: :feature do
       end
 
       scenario "To age is missing" do
-        choose("course_age_range_in_years_other")
-        fill_in("course_course_age_range_in_years_other_to", with: "19")
-        click_on "Save"
+        age_range_in_years_page.age_range_other.click
+        age_range_in_years_page.age_range_to_field.set("19")
+        age_range_in_years_page.save.click
 
         expect(age_range_in_years_page).to be_displayed
         expect(age_range_in_years_page.error_flash).to have_content(
@@ -137,10 +135,10 @@ feature "Edit course age range in years", type: :feature do
       end
 
       scenario "From age is greater then To age" do
-        choose("course_age_range_in_years_other")
-        fill_in("course_course_age_range_in_years_other_from", with: "19")
-        fill_in("course_course_age_range_in_years_other_to", with: "17")
-        click_on "Save"
+        age_range_in_years_page.age_range_other.click
+        age_range_in_years_page.age_range_from_field.set("19")
+        age_range_in_years_page.age_range_to_field.set("17")
+        age_range_in_years_page.save.click
 
         expect(age_range_in_years_page).to be_displayed
         expect(age_range_in_years_page.error_flash).to have_content(
@@ -149,10 +147,10 @@ feature "Edit course age range in years", type: :feature do
       end
 
       scenario "To age is 4 years less than From age" do
-        choose("course_age_range_in_years_other")
-        fill_in("course_course_age_range_in_years_other_from", with: "16")
-        fill_in("course_course_age_range_in_years_other_to", with: "17")
-        click_on "Save"
+        age_range_in_years_page.age_range_other.click
+        age_range_in_years_page.age_range_from_field.set("17")
+        age_range_in_years_page.age_range_to_field.set("17")
+        age_range_in_years_page.save.click
 
         expect(age_range_in_years_page).to be_displayed
         expect(age_range_in_years_page.error_flash).to have_content(

--- a/spec/features/courses/age_range_in_years/edit_spec.rb
+++ b/spec/features/courses/age_range_in_years/edit_spec.rb
@@ -92,14 +92,8 @@ feature "Edit course age range in years", type: :feature do
       )
 
       choose("course_age_range_in_years_other")
-      click_on "Save"
 
-      expect(age_range_in_years_page).to be_displayed
-      expect(age_range_in_years_page.error_flash).to have_content(
-        "You’ll need to correct some information.\nEnter an age for both from and to Enter an age Enter an age",
-      )
-
-      fill_in("course_course_age_range_in_years_other_from", with: "16")
+      fill_in("course_course_age_range_in_years_other_from", with: "14")
       fill_in("course_course_age_range_in_years_other_to", with: "19")
 
       click_on "Save"
@@ -107,6 +101,64 @@ feature "Edit course age range in years", type: :feature do
       expect(course_details_page).to be_displayed
       expect(course_details_page.flash).to have_content("Your changes have been saved")
       expect(update_course_stub).to have_been_requested
+    end
+
+    context "displaying errors for custom age range selection" do
+      scenario "From and To ages is missing" do
+        choose("course_age_range_in_years_other")
+        click_on "Save"
+
+        expect(age_range_in_years_page).to be_displayed
+        expect(age_range_in_years_page.error_flash).to have_content(
+          "You’ll need to correct some information.\nEnter an age in both From and To",
+        )
+      end
+
+      scenario "From age is missing" do
+        choose("course_age_range_in_years_other")
+        fill_in("course_course_age_range_in_years_other_from", with: "16")
+        click_on "Save"
+
+        expect(age_range_in_years_page).to be_displayed
+        expect(age_range_in_years_page.error_flash).to have_content(
+          "You’ll need to correct some information.\nEnter an age in To",
+        )
+      end
+
+      scenario "To age is missing" do
+        choose("course_age_range_in_years_other")
+        fill_in("course_course_age_range_in_years_other_to", with: "19")
+        click_on "Save"
+
+        expect(age_range_in_years_page).to be_displayed
+        expect(age_range_in_years_page.error_flash).to have_content(
+          "You’ll need to correct some information.\nEnter an age in From",
+        )
+      end
+
+      scenario "From age is greater then To age" do
+        choose("course_age_range_in_years_other")
+        fill_in("course_course_age_range_in_years_other_from", with: "19")
+        fill_in("course_course_age_range_in_years_other_to", with: "17")
+        click_on "Save"
+
+        expect(age_range_in_years_page).to be_displayed
+        expect(age_range_in_years_page.error_flash).to have_content(
+          "You’ll need to correct some information.\nEnter a valid age in From",
+        )
+      end
+
+      scenario "To age is 4 years less than From age" do
+        choose("course_age_range_in_years_other")
+        fill_in("course_course_age_range_in_years_other_from", with: "16")
+        fill_in("course_course_age_range_in_years_other_to", with: "17")
+        click_on "Save"
+
+        expect(age_range_in_years_page).to be_displayed
+        expect(age_range_in_years_page.error_flash).to have_content(
+          "You’ll need to correct some information.\nEnter a valid age in To",
+         )
+      end
     end
   end
 

--- a/spec/site_prism/page_objects/page/organisations/course_age_range.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_age_range.rb
@@ -5,6 +5,11 @@ module PageObjects
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/age-range"
 
         element :age_range_fields, '[data-qa="course__age_range_in_years"]'
+        element :age_range_14_to_19, '[data-qa="course__age_range_in_years_14_to_19_radio"]'
+        element :age_range_other, '[data-qa="course__age_range_in_years_other_radio"]'
+        element :age_range_from_field, '[data-qa="course__age_range_in_years_other_from_input"]'
+        element :age_range_to_field, '[data-qa="course__age_range_in_years_other_to_input"]'
+        element :save, '[data-qa="course__save"]'
       end
     end
   end


### PR DESCRIPTION
### Context
When a user selects a 'another age range' and does not fill in the 'From' and 'To' fields the correct errors are now appearing on the page. If an error is shown then the 'another age range' radio automatically expands in order to show errors. 

### Changes proposed in this pull request
- fixes to front end error handling
- error copy updated
- increased test coverage

Validations included:
- missing 'from' and 'to' fields
- missing 'to' field
- missing 'from' field
- 'to' field greater than 'from' field
- course age range less than 4 years

### Before
![age_fix_2](https://user-images.githubusercontent.com/5256922/67949100-fb5d0680-fbde-11e9-9128-2c60ac1c259e.gif)

### After
![age_validation_fix](https://user-images.githubusercontent.com/5256922/67940776-3b66be00-fbcc-11e9-9dd3-6ee251fadd08.gif)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
