### PR TITLE
[2492] - Run specs in parallel on CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ Rake::Task["default"].clear
 
 task :default do
   cores = ENV['PARALLEL_CORES']
-  Rake::Task["parallel"].invoke(cores)
+  Rake::Task["parallel:spec"].invoke(cores)
   Rake::Task["lint:ruby"].invoke
   Rake::Task["lint:scss"].invoke
 end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ steps:
     runInBackground: false
 
 - bash: |
-    docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
+    docker run --rm $(IMAGE_NAME) rails parallel:spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
     test_result=$?
     cat rspec-results.xml
     sed -i '$d;1,5d' rspec-results.xml

--- a/lib/tasks/parallel_tests.rake
+++ b/lib/tasks/parallel_tests.rake
@@ -1,6 +1,0 @@
-desc "Run specs in parallel"
-task :parallel, [:cores] do |_task, args|
-  cores = [args[:cores]]
-  puts "Running specs in parallel with #{cores} cores"
-  Rake::Task["parallel:spec"].invoke(*cores)
-end


### PR DESCRIPTION
### Context
Part of a bigger section of work to run specs in parallel.

### Changes proposed in this pull request
A simple change to the azure configuration so that specs are run in parallel on CI via the `parallel_tests` gem. Azure has _two_ available cores that can be utilised.

### How much time is saved?

_Before_
min ~50 seconds

_After_
40 seconds

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
