### PR TITLE
[2522] - feat(security): add Brakeman Static Analysis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,9 @@ group :development, :test do
 end
 
 group :development do
+  # static analysis
+  gem "brakeman"
+
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem "listen", ">= 3.0.5", "< 3.3"
   gem "web-console", ">= 3.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
+    brakeman (4.7.1)
     builder (3.2.3)
     byebug (11.0.1)
     canonical-rails (0.2.6)
@@ -454,6 +455,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)
+  brakeman
   byebug
   canonical-rails
   capybara (>= 2.15)

--- a/Rakefile
+++ b/Rakefile
@@ -12,4 +12,5 @@ task :default do
   Rake::Task["parallel:spec"].invoke(cores)
   Rake::Task["lint:ruby"].invoke
   Rake::Task["lint:scss"].invoke
+  Rake::Task["brakeman"].invoke
 end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,14 @@ steps:
     runInBackground: false
 
 - task: Docker@1
+  displayName: Run Brakeman static analysis
+  inputs:
+    command: Run an image
+    imageName: $(IMAGE_NAME)
+    containerCommand: rails brakeman
+    runInBackground: false
+
+- task: Docker@1
   displayName: Tag image with current build number $(Build.BuildNumber)
   inputs:
     command: Tag image

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,37 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "854e9d393b838c1507ba122af11f348bdc993f1e1cef50c55fbef648a79fd0b7",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/sites/index.html.erb",
+      "line": 38,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => Provider.includes(:sites).where(:recruitment_cycle_year => params.fetch(:recruitment_cycle_year, Settings.current_cycle)).find(params[:provider_code]).first.sites.sort_by(&:location_name), {})",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "SitesController",
+          "method": "index",
+          "line": 25,
+          "file": "app/controllers/sites_controller.rb",
+          "rendered": {
+            "name": "sites/index",
+            "file": "app/views/sites/index.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "sites/index"
+      },
+      "user_input": "params[:provider_code]",
+      "confidence": "Weak",
+      "note": "It is not possible for users to see the locations of organisations they do not have permission to see. Site responds with 403 page"
+    }
+  ],
+  "updated": "2019-11-12 09:57:32 +0000",
+  "brakeman_version": "4.7.1"
+}

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -1,0 +1,12 @@
+task :brakeman do
+  sh <<~EOSHELL
+    mkdir -p tmp && \
+    (brakeman --no-progress -5 --quiet --color --output tmp/brakeman.out --exit-on-warn && \
+    echo "No warnings or errors") || \
+    (cat tmp/brakeman.out; exit 1)
+  EOSHELL
+end
+
+if %w[development test].include? Rails.env
+  task(:default).prerequisites << task(:brakeman)
+end


### PR DESCRIPTION
### Context
Static analysis is way to identifies security flaws in an application. _Brakeman_ is a gem that provides this functionality.

### Changes proposed in this pull request
- Add Brakeman gem
- Create rake task to run static analysis locally
- Add Brakeman rake task to default rake task
- Add static analysis as a build step on CI. Build will fail if static analysis does not pass.
- Ignored 'dynamic render' issue as it's not possible to view sites of other provider if you do have permission. _See recording below_

![accessing_sites](https://user-images.githubusercontent.com/5256922/68661860-92a55080-0533-11ea-8d2d-039ed749ba34.gif)


### Running locally
```
bundle exec brakeman
```

#### Local output

<img width="1598" alt="brakman" src="https://user-images.githubusercontent.com/5256922/68596167-b49ac680-0492-11ea-8b3c-430587a10e6d.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
