### PR TITLE
[2530] - revert running specs in parallel on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ steps:
     runInBackground: false
 
 - bash: |
-    docker run --rm $(IMAGE_NAME) rails parallel:spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
+    docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
     test_result=$?
     cat rspec-results.xml
     sed -i '$d;1,5d' rspec-results.xml


### PR DESCRIPTION
Reverting recent change to Azure pipeline config to run specs in parallel in order to unblock CI. Caused by suspected puma upgrade issue -
https://trello.com/c/rVx1gcbf/2530-investigate-puma-upgrade-issue

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
