### PR TITLE
[2530] - compile Webpack once only when running specs in parallel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ steps:
     runInBackground: false
 
 - bash: |
-    docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
+    docker run --rm $(IMAGE_NAME) rails parallel:spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
     test_result=$?
     cat rspec-results.xml
     sed -i '$d;1,5d' rspec-results.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,14 +32,6 @@ steps:
     arguments: '--cache-from $(IMAGE_NAME):latest'
     addDefaultLabels: false
 
-- task: Docker@1
-  displayName: Run webpack
-  inputs:
-    command: Run an image
-    imageName: $(IMAGE_NAME)
-    containerCommand: rails webpacker:compile
-    runInBackground: false
-
 - bash: |
     docker run --rm $(IMAGE_NAME) rails parallel:spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
     test_result=$?

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -77,7 +77,11 @@ development:
 
 test:
   <<: *default
-  compile: true
+  # Azure pre-compiles packs prior to running the tests.
+  # Also avoids race conditions in parallel_tests.
+  compile: false
+  
+  public_output_path: packs-test
 
 production: &production
   <<: *default

--- a/spec/support/webpacker.rb
+++ b/spec/support/webpacker.rb
@@ -1,0 +1,36 @@
+module WebpackerTest
+  TIMESTAMP_FILE = Rails.root.join("tmp", "webpacker-#{Rails.env}-timestamp")
+
+  def self.compile_once
+    digest_file = Rails.root.join("tmp/webpacker_#{Rails.env}_digest")
+
+    app_code = Dir[Webpacker.config.source_path.join("**/*")]
+    npm_code = Dir[Rails.root.join("yarn.lock")]
+
+    packable_contents = (app_code + npm_code)
+      .sort
+      .map { |filename| File.read(filename) if File.file?(filename) }
+      .join
+    digest = Digest::SHA256.hexdigest(packable_contents)
+
+    return if digest_file.exist? && digest_file.read == digest
+
+    if ENV["TEST_ENV_NUMBER"].to_i < 1
+      public_output_path = Webpacker.config.public_output_path
+      FileUtils.rm_r(public_output_path) if File.exist?(public_output_path)
+      puts "Removed Webpack output directory #{public_output_path}"
+
+      Webpacker.compile
+
+      digest_file.write(digest)
+    else
+      loop do
+        break if digest_file.exist? && digest_file.read == digest
+
+        sleep 0.1
+      end
+    end
+  end
+end
+
+WebpackerTest.compile_once


### PR DESCRIPTION
### Context
When running specs in parallel we want to avoid workers compiling the same files at the same time. Believe this was the reason for this bug 👉 https://trello.com/c/rVx1gcbf/2530-investigate-puma-upgrade-issue

### Changes proposed in this pull request
- Add a spec helper that compiles assets only once when running specs in parallel. It does this by creating a hexdigest of all webpacker assets and compiling only when this value changes.
- Run specs in parallel on CI (again!)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
