### PR TITLE
[2485] Don't escape html on course confirmation page

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,7 +1,7 @@
 module ViewHelper
   def course_creation_change_button(display_name, property_name, path)
     link_to send(path, @provider.provider_code, course.recruitment_cycle_year, params.to_unsafe_h.merge(goto_confirmation: true)), class: "govuk-link", data: { qa: "course__edit_#{property_name}_link" } do
-      "Change<span class=\"govuk-visually-hidden\"> #{display_name}</span>"
+      raw("Change<span class=\"govuk-visually-hidden\"> #{display_name}</span>")
     end
   end
 


### PR DESCRIPTION
### Context

HTML was showing up in the change link

### Changes proposed in this pull request

- Ensure HTML doesn't show up in the change link

### Guidance to review

- Go to the [course confirmation page](https://localhost:3000/organisations/2AT/2020/courses/confirmation?course%5Bage_range_in_years%5D=11_to_18&course%5Bapplications_open_from%5D=2010-10-08&course%5Benglish%5D=must_have_qualification_at_application_time&course%5Bfunding_type%5D=apprenticeship&course%5Bis_send%5D=1&course%5Blevel%5D=secondary&course%5Bmaths%5D=must_have_qualification_at_application_time&course%5Bqualification%5D=qts&course%5Bstart_date%5D=October+2019&course%5Bstudy_mode%5D=full_time)
- Look at the change confirmation link

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
