### PR TITLE
[2534] - Don't use Simplecov-console gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,7 +120,6 @@ group :test do
 
   # Show test coverage %
   gem "simplecov", require: false
-  gem "simplecov-console"
 
   # Make diffs of Ruby objects much more readable
   gem "super_diff"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,6 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.0.1)
-    ansi (1.5.0)
     application_insights (0.5.6)
     ast (2.4.0)
     attr_extras (6.2.1)
@@ -374,10 +373,6 @@ GEM
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-console (0.6.0)
-      ansi
-      simplecov
-      terminal-table
     simplecov-html (0.10.2)
     site_prism (3.4.1)
       addressable (~> 2.5)
@@ -406,8 +401,6 @@ GEM
       activesupport (>= 3)
       attr_required (>= 0.0.5)
       httpclient (>= 2.4)
-    terminal-table (1.8.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     trollop (1.16.2)
@@ -491,7 +484,6 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven
   simplecov
-  simplecov-console
   site_prism
   spring
   spring-commands-rspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,13 +3,12 @@ require "capybara"
 require "capybara/rspec"
 require "site_prism"
 require "simplecov"
-require "simplecov-console"
 
-SimpleCov.formatter = SimpleCov::Formatter::Console
+SimpleCov.minimum_coverage 95
 SimpleCov.start
 # If running specs in parallel this ensures SimpleCov results appears
 # upon completion of all specs
-if ENV["PARALLEL_TEST_GROUPS"]
+if ENV["TEST_ENV_NUMBER"]
   SimpleCov.at_exit do
     result = SimpleCov.result
     result.format! if ParallelTests.number_of_running_processes <= 1
@@ -32,6 +31,8 @@ end
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  # Reduce noise in console when running specs in parallel
+  config.silence_filter_announcements = true if ENV["TEST_ENV_NUMBER"]
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
### Context

The `simplecov-console` gem was added recently in order to print results to the console rather than publish results to the 'coverage' folder. However following discussion with team have concluded this is too noisy so am reverting back to the previous method.

### Changes proposed in this pull request

- remove `simplecov-console` gem and associated config.
- threshold added for passing Simplecov (95%). Currently coverage is just over 95%.
- reduced noise in console when running specs in parallel

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
