### PR TITLE
[2370] Hook up back links for new course flow

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ruby 2.6.1
 yarn 1.12.3
-nodejs 8.11.2
+nodejs 8.16.2

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -6,6 +6,7 @@ module CourseBasicDetailConcern
     before_action :build_provider, :build_new_course, only: %i[new continue]
     before_action :build_previous_course_creation_params, only: %i[new continue]
     before_action :build_meta_course_creation_params, only: %i[new continue]
+    before_action :build_back_link, only: %i[new continue]
     before_action :build_course, only: %i[edit update]
   end
 
@@ -141,8 +142,23 @@ private
     { course: course_params }
   end
 
+  def build_back_link
+    previous_step = PreviousCourseCreationStepService.new.execute(current_step: current_step, current_provider: @provider)
+    previous_path = course_creation_path_for(previous_step)
+
+    if previous_path.nil?
+      raise "No path defined for next step: #{previous_step}"
+    end
+
+    @back_link_path = previous_path
+  end
+
   def course_creation_path_for(page)
     case page
+    when :courses_list
+      provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    when :level
+      new_provider_recruitment_cycle_courses_level_path(path_params)
     when :apprenticeship
       new_provider_recruitment_cycle_courses_apprenticeship_path(path_params)
     when :location

--- a/app/controllers/courses/accredited_body_controller.rb
+++ b/app/controllers/courses/accredited_body_controller.rb
@@ -2,7 +2,6 @@ module Courses
   class AccreditedBodyController < ApplicationController
     before_action :build_course_params, only: :continue
     include CourseBasicDetailConcern
-    before_action :build_back_link, only: :new
 
     decorates_assigned :provider
 
@@ -106,14 +105,6 @@ module Courses
     def build_course_params
       @accredited_body = params[:course].delete(:accredited_body)
       @autocompleted_provider_code = params[:course].delete(:autocompleted_provider_code)
-    end
-
-    def build_back_link
-      @back_link_path = if @provider.sites.count > 1
-                          new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)
-                        else
-                          new_provider_recruitment_cycle_courses_study_mode_path(course: @course_creation_params)
-                        end
     end
 
     def errors_for_search_query(code, query)

--- a/app/controllers/courses/accredited_body_controller.rb
+++ b/app/controllers/courses/accredited_body_controller.rb
@@ -2,6 +2,7 @@ module Courses
   class AccreditedBodyController < ApplicationController
     before_action :build_course_params, only: :continue
     include CourseBasicDetailConcern
+    before_action :build_back_link, only: :new
 
     decorates_assigned :provider
 
@@ -105,6 +106,14 @@ module Courses
     def build_course_params
       @accredited_body = params[:course].delete(:accredited_body)
       @autocompleted_provider_code = params[:course].delete(:autocompleted_provider_code)
+    end
+
+    def build_back_link
+      @back_link_path = if @provider.sites.count > 1
+                          new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)
+                        else
+                          new_provider_recruitment_cycle_courses_study_mode_path(course: @course_creation_params)
+                        end
     end
 
     def errors_for_search_query(code, query)

--- a/app/controllers/courses/accredited_body_controller.rb
+++ b/app/controllers/courses/accredited_body_controller.rb
@@ -66,6 +66,14 @@ module Courses
 
   private
 
+    def build_provider
+      @provider = Provider
+                    .includes(:sites)
+                    .where(recruitment_cycle_year: params[:recruitment_cycle_year])
+                    .find(params[:provider_code])
+                    .first
+    end
+
     def redirect_to_provider_search
       redirect_to(
         accredited_body_search_provider_recruitment_cycle_course_path(

--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -1,23 +1,9 @@
 module Courses
   class EntryRequirementsController < ApplicationController
     include CourseBasicDetailConcern
-    before_action :build_back_link, only: :new
-
     before_action :not_found_if_no_gcse_subjects_required, except: :continue
 
   private
-
-    def build_back_link
-      @back_link_path = if @provider.accredited_body?
-                          if @provider.sites.count > 1
-                            new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)
-                          else
-                            new_provider_recruitment_cycle_courses_study_mode_path(course: @course_creation_params)
-                          end
-                        else
-                          new_provider_recruitment_cycle_courses_accredited_body_path(course: @course_creation_params)
-                        end
-    end
 
     def build_provider
       @provider = Provider

--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -1,10 +1,23 @@
 module Courses
   class EntryRequirementsController < ApplicationController
     include CourseBasicDetailConcern
+    before_action :build_back_link, only: :new
 
     before_action :not_found_if_no_gcse_subjects_required, except: :continue
 
   private
+
+    def build_back_link
+      @back_link_path = if @provider.accredited_body?
+                          if @provider.sites.count > 1
+                            new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)
+                          else
+                            new_provider_recruitment_cycle_courses_study_mode_path(course: @course_creation_params)
+                          end
+                        else
+                          new_provider_recruitment_cycle_courses_accredited_body_path(course: @course_creation_params)
+                        end
+    end
 
     def build_provider
       @provider = Provider

--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -6,6 +6,14 @@ module Courses
 
   private
 
+    def build_provider
+      @provider = Provider
+                    .includes(:sites)
+                    .where(recruitment_cycle_year: params[:recruitment_cycle_year])
+                    .find(params[:provider_code])
+                    .first
+    end
+
     def current_step
       :entry_requirements
     end

--- a/app/controllers/courses/study_mode_controller.rb
+++ b/app/controllers/courses/study_mode_controller.rb
@@ -1,6 +1,7 @@
 module Courses
   class StudyModeController < ApplicationController
     include CourseBasicDetailConcern
+    before_action :build_back_link, only: :new
 
     def update
       if params[:course][:study_mode] == "full_time_or_part_time"
@@ -11,6 +12,14 @@ module Courses
     end
 
   private
+
+    def build_back_link
+      @back_link_path = if @provider.accredited_body?
+                          new_provider_recruitment_cycle_courses_apprenticeship_path(course: @course_creation_params)
+                        else
+                          new_provider_recruitment_cycle_courses_fee_or_salary_path(course: @course_creation_params)
+                        end
+    end
 
     def current_step
       :full_or_part_time

--- a/app/controllers/courses/study_mode_controller.rb
+++ b/app/controllers/courses/study_mode_controller.rb
@@ -1,7 +1,6 @@
 module Courses
   class StudyModeController < ApplicationController
     include CourseBasicDetailConcern
-    before_action :build_back_link, only: :new
 
     def update
       if params[:course][:study_mode] == "full_time_or_part_time"
@@ -12,14 +11,6 @@ module Courses
     end
 
   private
-
-    def build_back_link
-      @back_link_path = if @provider.accredited_body?
-                          new_provider_recruitment_cycle_courses_apprenticeship_path(course: @course_creation_params)
-                        else
-                          new_provider_recruitment_cycle_courses_fee_or_salary_path(course: @course_creation_params)
-                        end
-    end
 
     def current_step
       :full_or_part_time

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -5,11 +5,11 @@ module ViewHelper
     end
   end
 
-  def course_creation_back_button
+  def course_creation_back_button(back_path)
     if params[:goto_confirmation]
       govuk_back_link_to confirmation_provider_recruitment_cycle_courses_path(course: @course_creation_params)
     else
-      yield
+      govuk_back_link_to back_path
     end
   end
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -5,6 +5,14 @@ module ViewHelper
     end
   end
 
+  def course_creation_back_button
+    if params[:goto_confirmation]
+      govuk_back_link_to confirmation_provider_recruitment_cycle_courses_path(course: @course_creation_params)
+    else
+      yield
+    end
+  end
+
   def govuk_link_to(body, url = body, html_options = { class: "govuk-link" })
     link_to body, url, html_options
   end

--- a/app/services/previous_course_creation_step_service.rb
+++ b/app/services/previous_course_creation_step_service.rb
@@ -1,0 +1,46 @@
+class PreviousCourseCreationStepService
+  def execute(current_step:, current_provider:)
+    case current_step
+    when :level
+      :courses_list
+    when :subjects
+      :level
+    when :age_range
+      :subjects
+    when :outcome
+      :age_range
+    when :apprenticeship
+      :outcome
+    when :fee_or_salary
+      :outcome
+    when :location
+      :full_or_part_time
+    when :full_or_part_time
+      if current_provider.accredited_body?
+        :apprenticeship
+      else
+        :fee_or_salary
+      end
+    when :entry_requirements
+      if current_provider.accredited_body?
+        if current_provider.sites.count > 1
+          :location
+        else
+          :full_or_part_time
+        end
+      else
+        :accredited_body
+      end
+    when :accredited_body
+      if current_provider.sites.count > 1
+        :location
+      else
+        :full_or_part_time
+      end
+    when :applications_open
+      :entry_requirements
+    when :start_date
+      :applications_open
+    end
+  end
+end

--- a/app/services/previous_course_creation_step_service.rb
+++ b/app/services/previous_course_creation_step_service.rb
@@ -16,31 +16,43 @@ class PreviousCourseCreationStepService
     when :location
       :full_or_part_time
     when :full_or_part_time
-      if current_provider.accredited_body?
-        :apprenticeship
-      else
-        :fee_or_salary
-      end
+      handle_full_or_part_time(current_provider)
     when :entry_requirements
-      if current_provider.accredited_body?
-        if current_provider.sites.count > 1
-          :location
-        else
-          :full_or_part_time
-        end
-      else
-        :accredited_body
-      end
+      handle_entry_requirements(current_provider)
     when :accredited_body
-      if current_provider.sites.count > 1
-        :location
-      else
-        :full_or_part_time
-      end
+      handle_accredited_body(current_provider)
     when :applications_open
       :entry_requirements
     when :start_date
       :applications_open
+    end
+  end
+
+private
+
+  def handle_full_or_part_time(current_provider)
+    if current_provider.accredited_body?
+      :apprenticeship
+    else
+      :fee_or_salary
+    end
+  end
+
+  def handle_accredited_body(current_provider)
+    if current_provider.sites.count > 1
+      :location
+    else
+      :full_or_part_time
+    end
+  end
+
+  def handle_entry_requirements(current_provider)
+    return :accredited_body unless current_provider.accredited_body?
+
+    if current_provider.sites.count > 1
+      :location
+    else
+      :full_or_part_time
     end
   end
 end

--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -1,11 +1,7 @@
 <%= content_for :page_title, "Pick an accredited body" %>
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <% if @provider.sites.count > 1 %>
-      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)) %>
-    <% else %>
-      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_study_mode_path(course: @course_creation_params)) %>
-    <% end %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "Pick an accredited body" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -1,4 +1,14 @@
 <%= content_for :page_title, "Pick an accredited body" %>
+<% content_for :before_content do %>
+  <% course_creation_back_button do %>
+    <% if @provider.sites.count > 1 %>
+      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)) %>
+    <% else %>
+      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_study_mode_path(course: @course_creation_params)) %>
+    <% end %>
+  <% end %>
+<% end %>
+
 <%= render 'shared/errors' %>
 
 <div class="govuk-grid-row">

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "Specify an age range" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Specify an age range" %>
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_subjects_path(course: @course_creation_params)) %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -1,6 +1,8 @@
 <%= content_for :page_title, "Specify an age range" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_subjects_path(course: @course_creation_params)) %>
+  <% course_creation_back_button do %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_subjects_path(course: @course_creation_params)) %>
+  <% end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -1,9 +1,6 @@
 <%= content_for :page_title, "Specify an age range" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(
-                           @provider.provider_code,
-                           @provider.recruitment_cycle_year
-                        )) %>
+  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_subjects_path(course: @course_creation_params)) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -1,9 +1,6 @@
 <%= content_for :page_title, "When will applications open?" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(
-                           @provider.provider_code,
-                           @provider.recruitment_cycle_year
-                        )) %>
+  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_entry_requirements_path(course: @course_creation_params)) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "When will applications open?" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "When will applications open?" %>
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_entry_requirements_path(course: @course_creation_params)) %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -1,6 +1,8 @@
 <%= content_for :page_title, "When will applications open?" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_entry_requirements_path(course: @course_creation_params)) %>
+  <% course_creation_back_button do %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_entry_requirements_path(course: @course_creation_params)) %>
+  <% end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/apprenticeship/new.html.erb
+++ b/app/views/courses/apprenticeship/new.html.erb
@@ -1,10 +1,7 @@
 <%= content_for :page_title, "Is this a teaching apprenticeship?" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(
-                           @provider.provider_code,
-                           @provider.recruitment_cycle_year
-                        )) %>
+  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_outcome_path(course: @course_creation_params)) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/apprenticeship/new.html.erb
+++ b/app/views/courses/apprenticeship/new.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_outcome_path(course: @course_creation_params)) %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/app/views/courses/apprenticeship/new.html.erb
+++ b/app/views/courses/apprenticeship/new.html.erb
@@ -1,9 +1,7 @@
 <%= content_for :page_title, "Is this a teaching apprenticeship?" %>
 
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/apprenticeship/new.html.erb
+++ b/app/views/courses/apprenticeship/new.html.erb
@@ -1,7 +1,9 @@
 <%= content_for :page_title, "Is this a teaching apprenticeship?" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_outcome_path(course: @course_creation_params)) %>
+  <% course_creation_back_button do %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_outcome_path(course: @course_creation_params)) %>
+  <% end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -1,10 +1,12 @@
 <%= content_for :page_title, "GCSE requirements for applicants" %>
 <% content_for :before_content do %>
-  <% if @provider.accredited_body? %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)) %>
-  <% else %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_accredited_body_path(course: @course_creation_params)) %>
-  <%end %>
+  <% course_creation_back_button do %>
+    <% if @provider.accredited_body? %>
+      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)) %>
+    <% else %>
+      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_accredited_body_path(course: @course_creation_params)) %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -2,7 +2,11 @@
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
     <% if @provider.accredited_body? %>
-      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)) %>
+      <% if @provider.sites.count > 1 %>
+        <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)) %>
+      <% else %>
+        <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_study_mode_path(course: @course_creation_params)) %>
+      <% end %>
     <% else %>
       <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_accredited_body_path(course: @course_creation_params)) %>
     <% end %>

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -1,9 +1,10 @@
 <%= content_for :page_title, "GCSE requirements for applicants" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(
-    @provider.provider_code,
-    @provider.recruitment_cycle_year
- )) %>
+  <% if @provider.accredited_body? %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)) %>
+  <% else %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_accredited_body_path(course: @course_creation_params)) %>
+  <%end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -1,15 +1,7 @@
 <%= content_for :page_title, "GCSE requirements for applicants" %>
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <% if @provider.accredited_body? %>
-      <% if @provider.sites.count > 1 %>
-        <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_locations_path(course: @course_creation_params)) %>
-      <% else %>
-        <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_study_mode_path(course: @course_creation_params)) %>
-      <% end %>
-    <% else %>
-      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_accredited_body_path(course: @course_creation_params)) %>
-    <% end %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "GCSE requirements for applicants" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/fee_or_salary/new.html.erb
+++ b/app/views/courses/fee_or_salary/new.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "Edit Fee or Salary" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/fee_or_salary/new.html.erb
+++ b/app/views/courses/fee_or_salary/new.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Edit Fee or Salary" %>
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_outcome_path(course: @course_creation_params)) %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/app/views/courses/fee_or_salary/new.html.erb
+++ b/app/views/courses/fee_or_salary/new.html.erb
@@ -1,9 +1,8 @@
 <%= content_for :page_title, "Edit Fee or Salary" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(
-                           @provider.provider_code,
-                           @provider.recruitment_cycle_year
-                        )) %>
+  <% course_creation_back_button do %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_outcome_path(course: @course_creation_params)) %>
+  <% end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -1,6 +1,8 @@
 <%= content_for :page_title, "Pick a course type" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+  <% course_creation_back_button do %>
+    <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+  <% end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Pick a course type" %>
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -1,4 +1,7 @@
 <%= content_for :page_title, "Pick a course type" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+<% end %>
 
 <%= render 'shared/errors' %>
 

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "Pick a course type" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "Pick a course outcome" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Pick a course outcome" %>
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_age_range_path(course: @course_creation_params)) %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -1,9 +1,6 @@
 <%= content_for :page_title, "Pick a course outcome" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(
-                           @provider.provider_code,
-                           @provider.recruitment_cycle_year
-                        )) %>
+  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_age_range_path(course: @course_creation_params)) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -1,6 +1,8 @@
 <%= content_for :page_title, "Pick a course outcome" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_age_range_path(course: @course_creation_params)) %>
+  <% course_creation_back_button do %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_age_range_path(course: @course_creation_params)) %>
+  <% end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -1,4 +1,9 @@
 <%= content_for :page_title, "Pick the training locations for this course" %>
+<% content_for :before_content do %>
+  <% course_creation_back_button do %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_study_mode_path(course: @course_creation_params)) %>
+  <% end %>
+<% end %>
 
 <h1 class="govuk-heading-xl">Pick the training locations for this course</h1>
 

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Pick the training locations for this course" %>
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_study_mode_path(course: @course_creation_params)) %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "Pick the training locations for this course" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <h1 class="govuk-heading-xl">Pick the training locations for this course</h1>

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Pick a start date" %>
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_applications_open_path(course: @course_creation_params)) %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "Pick a start date" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -1,6 +1,8 @@
 <%= content_for :page_title, "Pick a start date" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_applications_open_path(course: @course_creation_params)) %>
+  <% course_creation_back_button do %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_applications_open_path(course: @course_creation_params)) %>
+  <% end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -1,4 +1,7 @@
 <%= content_for :page_title, "Pick a start date" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_applications_open_path(course: @course_creation_params)) %>
+<% end %>
 
 <%= render 'shared/errors' %>
 

--- a/app/views/courses/study_mode/new.html.erb
+++ b/app/views/courses/study_mode/new.html.erb
@@ -1,10 +1,12 @@
 <%= content_for :page_title, "Full time of part time" %>
 <% content_for :before_content do %>
-  <% if @provider.accredited_body? %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_apprenticeship_path(course: @course_creation_params)) %>
-  <% else %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_fee_or_salary_path(course: @course_creation_params)) %>
-  <%end %>
+  <% course_creation_back_button do %>
+    <% if @provider.accredited_body? %>
+      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_apprenticeship_path(course: @course_creation_params)) %>
+    <% else %>
+      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_fee_or_salary_path(course: @course_creation_params)) %>
+    <%end %>
+  <% end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/study_mode/new.html.erb
+++ b/app/views/courses/study_mode/new.html.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "Full time of part time" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/study_mode/new.html.erb
+++ b/app/views/courses/study_mode/new.html.erb
@@ -1,9 +1,10 @@
 <%= content_for :page_title, "Full time of part time" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(
-                           @provider.provider_code,
-                           @provider.recruitment_cycle_year
-                        )) %>
+  <% if @provider.accredited_body? %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_apprenticeship_path(course: @course_creation_params)) %>
+  <% else %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_fee_or_salary_path(course: @course_creation_params)) %>
+  <%end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/study_mode/new.html.erb
+++ b/app/views/courses/study_mode/new.html.erb
@@ -1,11 +1,7 @@
 <%= content_for :page_title, "Full time of part time" %>
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <% if @provider.accredited_body? %>
-      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_apprenticeship_path(course: @course_creation_params)) %>
-    <% else %>
-      <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_fee_or_salary_path(course: @course_creation_params)) %>
-    <%end %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -1,8 +1,6 @@
 <%= content_for :page_title, "Select subject" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button do %>
-    <%= govuk_back_link_to(@back_link_path) %>
-  <% end %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -1,4 +1,7 @@
 <%= content_for :page_title, "Select subject" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_level_path(course: @course_creation_params)) %>
+<% end %>
 
 <%= render 'shared/errors' %>
 

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -1,6 +1,8 @@
 <%= content_for :page_title, "Select subject" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_level_path(course: @course_creation_params)) %>
+  <% course_creation_back_button do %>
+    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_level_path(course: @course_creation_params)) %>
+  <% end %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Select subject" %>
 <% content_for :before_content do %>
   <% course_creation_back_button do %>
-    <%= govuk_back_link_to(new_provider_recruitment_cycle_courses_level_path(course: @course_creation_params)) %>
+    <%= govuk_back_link_to(@back_link_path) %>
   <% end %>
 <% end %>
 

--- a/spec/features/courses/accredited_body/edit_spec.rb
+++ b/spec/features/courses/accredited_body/edit_spec.rb
@@ -20,7 +20,7 @@ feature "Edit accredited body", type: :feature do
   before do
     stub_omniauth
     stub_api_v2_resource(current_recruitment_cycle)
-    stub_api_v2_resource(provider)
+    stub_api_v2_resource(provider, include: "sites")
     stub_api_v2_resource(course)
     stub_api_v2_resource(course, include: "accrediting_provider")
     stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")

--- a/spec/features/courses/accredited_body/new_spec.rb
+++ b/spec/features/courses/accredited_body/new_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "Edit accredited body" do
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
-  let(:provider) { build(:provider) }
+  let(:provider) { build(:provider, sites: [build(:site)]) }
   let(:course) { build(:course, provider: provider) }
   let(:new_accredited_body_page) { PageObjects::Page::Organisations::Courses::NewAccreditedBodyPage.new }
   let(:new_accredited_body_search_page) { PageObjects::Page::Organisations::Courses::NewAccreditedBodySearchPage.new }
@@ -18,6 +18,7 @@ feature "Edit accredited body" do
   before do
     stub_omniauth(provider: provider)
     stub_api_v2_resource(provider)
+    stub_api_v2_resource(provider, include: "sites")
     stub_api_v2_resource(current_recruitment_cycle)
     stub_api_v2_build_course
     stub_api_v2_build_course(level: "primary")

--- a/spec/features/courses/accredited_body/new_spec.rb
+++ b/spec/features/courses/accredited_body/new_spec.rb
@@ -54,6 +54,27 @@ feature "Edit accredited body" do
       include_examples "a course creation page"
     end
 
+    context "It allows the user to go back" do
+      context "With a single site" do
+        let(:new_study_mode_page) { PageObjects::Page::Organisations::Courses::NewStudyModePage.new }
+
+        it "Returns to the study mode page" do
+          new_accredited_body_page.back.click
+          expect(new_study_mode_page).to be_displayed
+        end
+      end
+
+      context "with multiple sites" do
+        let(:provider) { build(:provider, sites: [build(:site), build(:site)]) }
+        let(:new_locations_page) { PageObjects::Page::Organisations::Courses::NewLocationsPage.new }
+
+        it "Returns to the locations page" do
+          new_accredited_body_page.back.click
+          expect(new_locations_page).to be_displayed
+        end
+      end
+    end
+
     context "Searching for a new accredited body" do
       context "with some results" do
         before do

--- a/spec/features/courses/entry_requirements/new_spec.rb
+++ b/spec/features/courses/entry_requirements/new_spec.rb
@@ -5,7 +5,7 @@ feature "new course entry_requirements", type: :feature do
   let(:new_entry_requirements_page) do
     PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new
   end
-  let(:provider) { build(:provider) }
+  let(:provider) { build(:provider, sites: [build(:site)]) }
   let(:level) { :further_education }
   let(:course)  do
     build(:course,
@@ -21,6 +21,7 @@ feature "new course entry_requirements", type: :feature do
   before do
     stub_omniauth(provider: provider)
     stub_api_v2_resource(provider)
+    stub_api_v2_resource(provider, include: "sites")
     stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_new_resource(course)
     stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")

--- a/spec/features/courses/entry_requirements/new_spec.rb
+++ b/spec/features/courses/entry_requirements/new_spec.rb
@@ -5,7 +5,7 @@ feature "new course entry_requirements", type: :feature do
   let(:new_entry_requirements_page) do
     PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new
   end
-  let(:provider) { build(:provider, sites: [build(:site)]) }
+  let(:provider) { build(:provider, accredited_body?: true, sites: [build(:site)]) }
   let(:level) { :further_education }
   let(:course)  do
     build(:course,
@@ -136,6 +136,41 @@ feature "new course entry_requirements", type: :feature do
     end
   end
 
+  context "Going back" do
+    let(:level) { :primary }
+    before { visit_new_entry_requirements }
+
+    context "With an accredited body" do
+      context "With a single site" do
+        let(:new_study_mode_page) { PageObjects::Page::Organisations::Courses::NewStudyModePage.new }
+
+        it "Returns to the study mode page" do
+          new_entry_requirements_page.back.click
+          expect(new_study_mode_page).to be_displayed
+        end
+      end
+
+      context "with multiple sites" do
+        let(:provider) { build(:provider, accredited_body?: true, sites: [build(:site), build(:site)]) }
+        let(:new_locations_page) { PageObjects::Page::Organisations::Courses::NewLocationsPage.new }
+
+        it "Returns to the locations page" do
+          new_entry_requirements_page.back.click
+          expect(new_locations_page).to be_displayed
+        end
+      end
+    end
+
+    context "With an non accredited body" do
+      let(:provider) { build(:provider, accredited_body?: false) }
+      let(:new_accredited_body_page) { PageObjects::Page::Organisations::Courses::NewAccreditedBodyPage.new }
+
+      it "Returns to the accredited body page" do
+        new_entry_requirements_page.back.click
+        expect(new_accredited_body_page).to be_displayed
+      end
+    end
+  end
 
   def visit_new_entry_requirements(**query_params)
     visit signin_path

--- a/spec/features/courses/study_mode/new_spec.rb
+++ b/spec/features/courses/study_mode/new_spec.rb
@@ -58,6 +58,29 @@ feature "new course study mode", type: :feature do
     expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
+  context "It allows the user to go back" do
+    context "When they are an accredited body" do
+      let(:provider) { build(:provider, accredited_body?: true) }
+      let(:new_apprenticeship_page) { PageObjects::Page::Organisations::Courses::NewApprenticeshipPage.new }
+
+      it "Returns to the study mode page" do
+        visit_new_study_mode_page
+        new_study_mode_page.back.click
+        expect(new_apprenticeship_page).to be_displayed
+      end
+    end
+
+    context "when they are not an accredited body" do
+      let(:new_fee_or_salary_page) { PageObjects::Page::Organisations::Courses::NewFeeOrSalaryPage.new }
+
+      it "Returns to the locations page" do
+        visit_new_study_mode_page
+        new_study_mode_page.back.click
+        expect(new_fee_or_salary_page).to be_displayed
+      end
+    end
+  end
+
 private
 
   def visit_new_study_mode_page(**query_params)

--- a/spec/services/previous_course_creation_step_service_spec.rb
+++ b/spec/services/previous_course_creation_step_service_spec.rb
@@ -189,7 +189,6 @@ private
     end
   end
 
-
   def handle_outcome(provider)
     if provider.accredited_body?
       :apprenticeship

--- a/spec/services/previous_course_creation_step_service_spec.rb
+++ b/spec/services/previous_course_creation_step_service_spec.rb
@@ -1,0 +1,208 @@
+describe PreviousCourseCreationStepService do
+  let(:service) { described_class.new }
+
+  shared_examples "previous step" do
+    it "Returns the correct previous step" do
+      previous_step = service.execute(
+        current_step: current_step,
+        current_provider: provider,
+      )
+      expect(previous_step).to eq(expected_previous_step)
+    end
+  end
+
+  context "All providers" do
+    let(:provider) { build(:provider) }
+
+    context "Current step: Level" do
+      let(:current_step) { :level }
+      let(:expected_previous_step) { :courses_list }
+
+      include_examples "previous step"
+    end
+
+    context "Current step: Subjects" do
+      let(:current_step) { :subjects }
+      let(:expected_previous_step) { :level }
+
+      include_examples "previous step"
+    end
+
+    context "Current step: Age Range" do
+      let(:current_step) { :age_range }
+      let(:expected_previous_step) { :subjects }
+
+      include_examples "previous step"
+    end
+
+    context "Current step: Outcome" do
+      let(:current_step) { :outcome }
+      let(:expected_previous_step) { :age_range }
+
+      include_examples "previous step"
+    end
+
+    context "Current step: Outcome" do
+      let(:current_step) { :outcome }
+      let(:expected_previous_step) { :age_range }
+
+      include_examples "previous step"
+    end
+
+    context "current step: location" do
+      let(:current_step) { :location }
+      let(:expected_previous_step) { :full_or_part_time }
+
+      include_examples "previous step"
+    end
+
+    context "current step: Applications open" do
+      let(:current_step) { :applications_open }
+      let(:expected_previous_step) { :entry_requirements }
+
+      include_examples "previous step"
+    end
+
+    context "current step: Start date" do
+      let(:current_step) { :start_date }
+      let(:expected_previous_step) { :applications_open }
+
+      include_examples "previous step"
+    end
+  end
+
+  context "Accredited bodies" do
+    let(:provider) { build(:provider, accredited_body?: true) }
+
+    context "Current step: Apprenticeship" do
+      let(:current_step) { :apprenticeship }
+      let(:expected_previous_step) { :outcome }
+
+      include_examples "previous step"
+    end
+
+    context "Current step: Full or part time" do
+      let(:current_step) { :full_or_part_time }
+      let(:expected_previous_step) { :apprenticeship }
+
+      include_examples "previous step"
+    end
+
+    context "With a single site" do
+      let(:provider) { build(:provider, accredited_body?: true, sites: [build(:site)]) }
+
+      context "Current step: Entry requirements" do
+        let(:current_step) { :entry_requirements }
+        let(:expected_previous_step) { :full_or_part_time }
+
+        include_examples "previous step"
+      end
+    end
+
+    context "With multiple sites" do
+      let(:provider) { build(:provider, accredited_body?: true, sites: [build(:site), build(:site)]) }
+
+      context "Current step: Entry requirements" do
+        let(:current_step) { :entry_requirements }
+        let(:expected_previous_step) { :location }
+
+        include_examples "previous step"
+      end
+    end
+  end
+
+  context "Non-accredited bodies" do
+    let(:provider) { build(:provider, accredited_body?: false) }
+
+    context "Current step: Fee or Salary" do
+      let(:current_step) { :fee_or_salary }
+      let(:expected_previous_step) { :outcome }
+
+      include_examples "previous step"
+    end
+
+    context "Current step: Full or part time" do
+      let(:current_step) { :full_or_part_time }
+      let(:expected_previous_step) { :fee_or_salary }
+
+      include_examples "previous step"
+    end
+
+    context "Current step: Entry requirements" do
+      let(:current_step) { :entry_requirements }
+      let(:expected_previous_step) { :accredited_body }
+
+      include_examples "previous step"
+    end
+
+    context "With a single site" do
+      let(:provider) { build(:provider, accredited_body?: true, sites: [build(:site)]) }
+
+      context "Current step: Accredited Body" do
+        let(:current_step) { :accredited_body }
+        let(:expected_previous_step) { :full_or_part_time }
+
+        include_examples "previous step"
+      end
+    end
+
+    context "With a multiple sites" do
+      let(:provider) { build(:provider, accredited_body?: true, sites: [build(:site), build(:site)]) }
+
+      context "Current step: Accredited Body" do
+        let(:current_step) { :accredited_body }
+        let(:expected_previous_step) { :location }
+
+        include_examples "previous step"
+      end
+    end
+  end
+
+private
+
+  def execute(current_step:, current_provider:)
+    case current_step
+    when :level
+      :subjects
+    when :subjects
+      :age_range
+    when :age_range
+      :outcome
+    when :outcome
+      handle_outcome(current_provider)
+    when :fee_or_salary
+      :full_or_part_time
+    when :apprenticeship
+      :full_or_part_time
+    when :full_or_part_time
+      :location
+    when :location
+      handle_location(current_provider)
+    when :accredited_body
+      :entry_requirements
+    when :entry_requirements
+      :applications_open
+    when :applications_open
+      :start_date
+    when :start_date
+      :confirmation
+    end
+  end
+
+
+  def handle_outcome(provider)
+    if provider.accredited_body?
+      :apprenticeship
+    else
+      :fee_or_salary
+    end
+  end
+
+  def handle_location(provider)
+    if provider.accredited_body?
+      :entry_requirements
+    else
+      :accredited_body
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/course_base.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_base.rb
@@ -11,6 +11,7 @@ module PageObjects
         element :flash, ".govuk-success-summary"
         element :error_flash, ".govuk-error-summary"
         element :warning_message, "[data-copy-course=warning]"
+        element :back, ".govuk-back-link"
 
         section :copy_content, PageObjects::Section::CopyContentSection
       end


### PR DESCRIPTION

![preview](https://user-images.githubusercontent.com/976254/68879096-b79aee80-0700-11ea-8745-700ad6f34c01.gif)

### Context

When going through the new course flow, the user should be able to see and use a `back` link to go to their previous steps, with the following circumstances:

- Going through the flow normally
- Going back to the confirmation page
- Going back past locations if there is only a single location
- Going back to different pages depending on the user being an accredited body

### Changes proposed in this pull request

- Add in correct back links
- Add in view helper for doing back links with confirmation

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
