### PR TITLE
[2510] - Add Request ID support to MCBE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,8 @@ group :development, :test do
   # Run specs locally in parallel
   gem "parallel_tests"
 
+  gem "request_store"
+
   # Testing framework
   gem "rspec-rails", "~> 4.0.0.beta3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -485,6 +485,7 @@ DEPENDENCIES
   rails-controller-testing
   rails_semantic_logger
   redcarpet
+  request_store
   rspec-rails (~> 4.0.0.beta3)
   rspec_junit_formatter
   rubocop
@@ -506,4 +507,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -9,7 +9,10 @@ class Base < JsonApiClient::Resource
         request_method,
         path,
         params: params,
-        headers: headers.update("Authorization" => authorization),
+        headers: headers.update(
+          "Authorization" => authorization,
+          "X-Request-Id" => RequestStore.store[:request_id],
+        ),
         body: body
       )
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -176,11 +176,11 @@ describe ApplicationController, type: :controller do
         uid: SecureRandom.uuid,
       }.with_indifferent_access
     end
+
     let(:payload) { {} }
 
     before :each do
-      allow(controller).to receive(:current_user)
-                             .and_return(current_user)
+      allow(controller).to receive(:current_user).and_return(current_user)
     end
 
     it "sets the user id in the payload" do
@@ -193,6 +193,27 @@ describe ApplicationController, type: :controller do
       controller.__send__(:append_info_to_payload, payload)
 
       expect(payload[:user][:sign_in_user_id]).to eq current_user[:uid]
+    end
+
+    it "sets the request_id in the payload to the request uuid" do
+      request_uuid = SecureRandom.uuid
+      allow(request).to receive(:uuid).and_return(request_uuid)
+      controller.__send__(:append_info_to_payload, payload)
+
+      expect(payload[:request_id]).to eq request_uuid
+    end
+  end
+
+  describe "#store_request_id" do
+    it "stores the request id" do
+      request_uuid = SecureRandom.uuid
+
+      allow(request).to receive(:uuid).and_return(request_uuid)
+      allow(RequestStore).to receive(:store).and_return({})
+
+      controller.__send__(:store_request_id)
+
+      expect(RequestStore.store).to eq(request_id: request_uuid)
     end
   end
 end


### PR DESCRIPTION
### Context
When a request comes in, add the value of the X-Request-ID to the logs, and ensure this value gets sent to the MCBE. This so we can track a requests journey through the system.

### Changes proposed in this pull request
- Add RequestStore gem to store the request id safely (in a manner that is thread-safe)
- Log the request id
- Add the request id to the headers when making backend API requests

NB: Pull request on the back end is required to make this work

### Kibana-rama
You can see the request id is now being tracked across the front and back end. 

<img width="698" alt="kibana" src="https://user-images.githubusercontent.com/5256922/68877195-95ec3800-06fd-11ea-91a1-3d955dda49a7.png">

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally

