### PR TITLE
[2536] Fixed terms page to be publicly available

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate, only: %i[guidance accessibility]
+  skip_before_action :authenticate, only: %i[guidance accessibility terms]
 
   def accessibility; end
 

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -19,8 +19,6 @@ RSpec.feature "View pages", type: :feature do
   end
 
   scenario "Navigate to /terms-conditions" do
-    stub_omniauth
-
     visit "/terms-conditions"
     expect(find("h1")).to have_content("Terms and Conditions")
   end


### PR DESCRIPTION
### Context
The terms and condition show be viewable without user having to login.

### Changes proposed in this pull request
Fixed terms page to be publicly available

### Guidance to review
https://localhost:3000/terms-conditions

:ship: 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
