### PR TITLE
[2484] Add header link to access requests page

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -26,6 +26,11 @@
               <%= link_to "Sign in", signin_path, class: "govuk-header__link" %>
             <% end %>
           </li>
+          <% if current_user.present? && current_user["admin"] %>
+            <li class="govuk-header__navigation-item">
+              <%= link_to "Access Requests", access_requests_path, class: "govuk-header__link", data: { qa: "access_requests_link" } %>
+            </li>
+          <% end %>
         </ul>
       </nav>
     </div>

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "View pages", type: :feature do
+feature "View pages", type: :feature do
   let(:new_features_page) { PageObjects::Page::NewFeaturesPage.new }
 
   scenario "Environment label and class are read from settings" do

--- a/spec/site_prism/page_objects/base.rb
+++ b/spec/site_prism/page_objects/base.rb
@@ -1,4 +1,5 @@
 module PageObjects
   class Base < SitePrism::Page
+    element :access_requests_link, "[data-qa=\"access_requests_link\"]"
   end
 end


### PR DESCRIPTION
### Context
In order to allow support to use deal with access requests in a straightforward manner we need to link to the page in an accessible place.  

### Changes proposed in this pull request
![image](https://user-images.githubusercontent.com/41294831/69071872-9dc01b00-0a22-11ea-9eee-492a4949e29c.png)

Adds a link to the access requests page that displays only if the user is an admin.  

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
