### PR TITLE
Move RequestStore gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem "sentry-raven"
 # Decorate logic to keep it of the views and helper methods
 gem "draper"
 
+# Threadsafe storage
+gem "request_store"
+
 # Render nice markdown
 gem "redcarpet"
 
@@ -77,8 +80,6 @@ group :development, :test do
 
   # Run specs locally in parallel
   gem "parallel_tests"
-
-  gem "request_store"
 
   # Testing framework
   gem "rspec-rails", "~> 4.0.0.beta3"


### PR DESCRIPTION
Move RequestStore gem out of the test/development group so that it is accessible in production

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
