### PR TITLE
[2570] Fix course create crashing when a provider has no courses

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,37 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "4bf033129a4b2f1589cde033da0f3eb2207c663b01dda63c0c142552e0b5de07",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/courses/preview.html.erb",
+      "line": 45,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(Provider.where(:recruitment_cycle_year => RecruitmentCycle.find(params.fetch(:recruitment_cycle_year, Settings.current_cycle)).first.year).find(params[:provider_code]).first.website, Provider.where(:recruitment_cycle_year => RecruitmentCycle.find(params.fetch(:recruitment_cycle_year, Settings.current_cycle)).first.year).find(params[:provider_code]).first.website, :class => \"govuk-link\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "CoursesController",
+          "method": "preview",
+          "line": 162,
+          "file": "app/controllers/courses_controller.rb",
+          "rendered": {
+            "name": "courses/preview",
+            "file": "app/views/courses/preview.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "courses/preview"
+      },
+      "user_input": "Provider.where(:recruitment_cycle_year => RecruitmentCycle.find(params.fetch(:recruitment_cycle_year, Settings.current_cycle)).first.year).find(params[:provider_code]).first.website",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "854e9d393b838c1507ba122af11f348bdc993f1e1cef50c55fbef648a79fd0b7",
@@ -30,8 +61,49 @@
       "user_input": "params[:provider_code]",
       "confidence": "Weak",
       "note": "It is not possible for users to see the locations of organisations they do not have permission to see. Site responds with 403 page"
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "acfec454e2a434a1a06060041ba4c604ab449d7d03e8fe159d8692b4c0293d6d",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/courses/preview/_contact_details.html.erb",
+      "line": 23,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(Provider.where(:recruitment_cycle_year => RecruitmentCycle.find(params.fetch(:recruitment_cycle_year, Settings.current_cycle)).first.year).find(params[:provider_code]).first.website, Provider.where(:recruitment_cycle_year => RecruitmentCycle.find(params.fetch(:recruitment_cycle_year, Settings.current_cycle)).first.year).find(params[:provider_code]).first.website, :class => \"govuk-link\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "CoursesController",
+          "method": "preview",
+          "line": 162,
+          "file": "app/controllers/courses_controller.rb",
+          "rendered": {
+            "name": "courses/preview",
+            "file": "app/views/courses/preview.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "courses/preview",
+          "line": 95,
+          "file": "app/views/courses/preview.html.erb",
+          "rendered": {
+            "name": "courses/preview/_contact_details",
+            "file": "app/views/courses/preview/_contact_details.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "courses/preview/_contact_details"
+      },
+      "user_input": "Provider.where(:recruitment_cycle_year => RecruitmentCycle.find(params.fetch(:recruitment_cycle_year, Settings.current_cycle)).first.year).find(params[:provider_code]).first.website",
+      "confidence": "Weak",
+      "note": ""
     }
   ],
-  "updated": "2019-11-12 09:57:32 +0000",
+  "updated": "2019-11-25 12:02:02 +0000",
   "brakeman_version": "4.7.1"
 }

--- a/spec/features/courses/accredited_body/edit_spec.rb
+++ b/spec/features/courses/accredited_body/edit_spec.rb
@@ -21,6 +21,7 @@ feature "Edit accredited body", type: :feature do
     stub_omniauth
     stub_api_v2_resource(current_recruitment_cycle)
     stub_api_v2_resource(provider, include: "sites")
+    stub_api_v2_resource(provider)
     stub_api_v2_resource(course)
     stub_api_v2_resource(course, include: "accrediting_provider")
     stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")

--- a/spec/features/courses/age_range_in_years/edit_spec.rb
+++ b/spec/features/courses/age_range_in_years/edit_spec.rb
@@ -8,18 +8,11 @@ feature "Edit course age range in years", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}",
-      current_recruitment_cycle.to_jsonapi,
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=subjects,courses.accrediting_provider",
-      build(:provider).to_jsonapi(include: %i[subjects courses accrediting_provider]),
-    )
-
-    stub_course_request
-    stub_course_details_tab
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "subjects,courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course)
     age_range_in_years_page.load_with_course(course)
   end
 
@@ -158,24 +151,5 @@ feature "Edit course age range in years", type: :feature do
          )
       end
     end
-  end
-
-  def stub_course_request
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}/courses" \
-      "/#{course.course_code}",
-      course.to_jsonapi,
-    )
-  end
-
-  def stub_course_details_tab
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
-    )
   end
 end

--- a/spec/features/courses/apprenticeship/edit_spec.rb
+++ b/spec/features/courses/apprenticeship/edit_spec.rb
@@ -8,18 +8,11 @@ feature "Edit course apprenticeship status", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}",
-      current_recruitment_cycle.to_jsonapi,
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-      provider.to_jsonapi(include: %i[courses accrediting_provider]),
-    )
-
-    stub_course_request
-    stub_course_details_tab
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course)
     apprenticeship_page.load_with_course(course)
   end
 
@@ -78,24 +71,5 @@ feature "Edit course apprenticeship status", type: :feature do
 
       expect(patch_stub).to have_been_requested
     end
-  end
-
-  def stub_course_request
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}/courses" \
-      "/#{course.course_code}",
-      course.to_jsonapi,
-    )
-  end
-
-  def stub_course_details_tab
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
-    )
   end
 end

--- a/spec/features/courses/delete_or_withdraw_spec.rb
+++ b/spec/features/courses/delete_or_withdraw_spec.rb
@@ -14,14 +14,9 @@ feature "Getting rid of a course", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request("/recruitment_cycles/#{course.recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}/" \
-      "providers/#{provider.provider_code}/" \
-      "courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: %i[subjects provider sites]),
-    )
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(provider)
 
     course_page.load(provider_code: provider.provider_code, recruitment_cycle_year: course.recruitment_cycle.year, course_code: course.course_code)
   end

--- a/spec/features/courses/destroy_spec.rb
+++ b/spec/features/courses/destroy_spec.rb
@@ -14,20 +14,10 @@ feature "Delete course", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request("/recruitment_cycles/#{course.recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}/" \
-      "providers/#{provider.provider_code}" \
-      "?include=courses.accrediting_provider",
-      provider.to_jsonapi(include: %i[courses accrediting_provider]),
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}/" \
-      "providers/#{provider.provider_code}/" \
-      "courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: %i[provider sites]),
-    )
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_request(
       "/recruitment_cycles/#{course.recruitment_cycle.year}/" \
       "providers/#{provider.provider_code}/" \

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -13,18 +13,11 @@ feature "Edit course entry requirements", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}",
-      current_recruitment_cycle.to_jsonapi,
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=subjects,courses.accrediting_provider",
-      build(:provider).to_jsonapi(include: %i[subjects courses accrediting_provider]),
-    )
-
-    stub_course_request
-    stub_course_details_tab
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course)
     entry_requirements_page.load_with_course(course)
   end
 

--- a/spec/features/courses/fee_or_salary/edit_spec.rb
+++ b/spec/features/courses/fee_or_salary/edit_spec.rb
@@ -8,17 +8,11 @@ feature "Edit course fee or salary status", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}",
-      current_recruitment_cycle.to_jsonapi,
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=subjects,courses.accrediting_provider",
-      provider.to_jsonapi(include: %i[subjects courses accrediting_provider]),
-    )
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(provider, include: "subjects,courses.accrediting_provider")
 
-    stub_course_request
+    stub_api_v2_resource(course)
     stub_course_details_tab
     fee_or_salary_page.load_with_course(course)
   end
@@ -81,15 +75,6 @@ feature "Edit course fee or salary status", type: :feature do
 
       expect(patch_stub).to have_been_requested
     end
-  end
-
-  def stub_course_request
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}/courses" \
-      "/#{course.course_code}",
-      course.to_jsonapi,
-    )
   end
 
   def stub_course_details_tab

--- a/spec/features/courses/fees_spec.rb
+++ b/spec/features/courses/fees_spec.rb
@@ -12,16 +12,11 @@ feature "Course fees", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request("/recruitment_cycles/#{course_1.recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-    stub_course_request(provider, course_1)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course_1.recruitment_cycle.year}" \
-      "/providers/A0" \
-      "?include=courses.accrediting_provider",
-      provider.to_jsonapi(
-        include: %i[courses accrediting_provider],
-      ),
-    )
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(course_1, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course_1, include: "sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
   end
 
   let(:course_fees_page) { PageObjects::Page::Organisations::CourseFees.new }
@@ -163,14 +158,11 @@ feature "Course fees", type: :feature do
     end
 
     before do
-      stub_course_request(provider, course_2)
-      stub_course_request(provider, course_3)
-      stub_api_v2_request(
-        "/recruitment_cycles/#{course_1.recruitment_cycle.year}" \
-        "/providers/A0" \
-        "?include=courses.accrediting_provider",
-        provider_for_copy_from_list.to_jsonapi(include: %i[courses accrediting_provider]),
-      )
+      stub_api_v2_resource(course_2, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(course_2, include: "sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(course_3, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(course_3, include: "sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(provider_for_copy_from_list, include: "courses.accrediting_provider")
     end
 
     scenario "all fields get copied if all were present" do
@@ -227,36 +219,8 @@ feature "Course fees", type: :feature do
 
 private
 
-  def stub_course_request(provider, course)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(
-        include: %i[subjects sites provider accrediting_provider],
-      ),
-    )
-
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(
-        include: %i[sites provider accrediting_provider],
-      ),
-    )
-  end
-
   def set_fees_request_stub_expectation(&attribute_validator)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course_1.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course_1.course_code}",
-      course_1.to_jsonapi,
-      :patch, 200
-    ) do |request_body_json|
+    stub_api_v2_resource(course_1, method: :patch) do |request_body_json|
       request_attributes = request_body_json["data"]["attributes"]
       attribute_validator.call(request_attributes)
     end

--- a/spec/features/courses/outcome/edit_spec.rb
+++ b/spec/features/courses/outcome/edit_spec.rb
@@ -8,18 +8,11 @@ feature "Edit course outcome", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}",
-      current_recruitment_cycle.to_jsonapi,
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-      build(:provider).to_jsonapi(include: %i[courses accrediting_provider]),
-    )
-
-    stub_course_request
-    stub_course_details_tab
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course)
     outcome_page.load_with_course(course)
   end
 
@@ -148,24 +141,5 @@ feature "Edit course outcome", type: :feature do
       expect(outcome_page).to have_selector("#qualification-error")
       expect(update_course_stub).to have_been_requested
     end
-  end
-
-  def stub_course_request
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}/courses" \
-      "/#{course.course_code}",
-      course.to_jsonapi,
-    )
-  end
-
-  def stub_course_details_tab
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
-    )
   end
 end

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "Preview course", type: :feature do
   let(:current_recruitment_cycle) { build :recruitment_cycle }
   let(:course) do
-    build :course,
+    build(:course,
           name: "English",
           provider: provider,
           accrediting_provider: accrediting_provider,
@@ -35,15 +35,15 @@ feature "Preview course", type: :feature do
             jsonapi_site_status("New site with no vacancies", :no_vacancies, "new_status"),
             jsonapi_site_status("Running site with no vacancies", :no_vacancies, "running"),
           ],
-          subjects: [subject]
+          subjects: [subject])
   end
 
   let(:subject) do
-    build :subject,
+    build(:subject,
           :english,
           scholarship: "2000",
           bursary_amount: "4000",
-          early_career_payments: "1000"
+          early_career_payments: "1000")
   end
 
   let(:provider) {
@@ -70,12 +70,9 @@ feature "Preview course", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request("/recruitment_cycles/#{course.recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-    stub_api_v2_request("/recruitment_cycles/#{course.recruitment_cycle.year}/recruitment_cycles", current_recruitment_cycle.to_jsonapi)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/A0/courses/#{course.course_code}?include=subjects,site_statuses.site,provider.sites,accrediting_provider",
-      course_response,
-    )
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(course, include: "subjects,site_statuses.site,provider.sites,accrediting_provider")
+    stub_api_v2_resource(provider)
   end
 
   let(:preview_course_page) { PageObjects::Page::Organisations::CoursePreview.new }

--- a/spec/features/courses/requirements_spec.rb
+++ b/spec/features/courses/requirements_spec.rb
@@ -22,14 +22,10 @@ feature "Course requirements", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-    stub_course_request(provider, course)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/A0" \
-      "?include=courses.accrediting_provider",
-      provider.to_jsonapi(include: %i[courses accrediting_provider]),
-    )
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
   end
 
   let(:course_requirements_page) { PageObjects::Page::Organisations::CourseRequirements.new }
@@ -123,8 +119,9 @@ feature "Course requirements", type: :feature do
     end
 
     before do
-      stub_course_request(provider, course_2)
-      stub_course_request(provider, course_3)
+      stub_api_v2_resource(course_2, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(course_3, include: "subjects,sites,provider.sites,accrediting_provider")
+
       stub_api_v2_request(
         "/recruitment_cycles/#{course.recruitment_cycle.year}" \
         "/providers/#{provider.provider_code}" \
@@ -173,15 +170,5 @@ feature "Course requirements", type: :feature do
       expect(course_requirements_page.personal_qualities.value).to eq(course_2.personal_qualities)
       expect(course_requirements_page.other_requirements.value).to eq(course_2.other_requirements)
     end
-  end
-
-  def stub_course_request(provider, course)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: %i[subjects sites provider accrediting_provider]),
-    )
   end
 end

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -18,17 +18,10 @@ feature "Course salary", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}",
-      current_recruitment_cycle.to_jsonapi,
-    )
-    stub_course_request(provider, course)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/A0" \
-      "?include=courses.accrediting_provider",
-      provider.to_jsonapi(include: %i[courses accrediting_provider]),
-    )
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
   end
 
   let(:course_salary_page) { PageObjects::Page::Organisations::CourseSalary.new }
@@ -115,8 +108,9 @@ feature "Course salary", type: :feature do
     end
 
     before do
-      stub_course_request(provider, course_2)
-      stub_course_request(provider, course_3)
+      stub_api_v2_resource(course_2, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(course_3, include: "subjects,sites,provider.sites,accrediting_provider")
+
       stub_api_v2_request(
         "/recruitment_cycles/#{course_2.recruitment_cycle.year}" \
         "/providers/A0" \
@@ -163,17 +157,5 @@ feature "Course salary", type: :feature do
       expect(course_salary_page.course_length_two_years).to be_checked
       expect(course_salary_page.course_salary_details.value).to eq(course_2.salary_details)
     end
-  end
-
-  def stub_course_request(provider, course)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(
-        include: %i[subjects sites provider accrediting_provider recruitment_cycle],
-      ),
-    )
   end
 end

--- a/spec/features/courses/send/edit_spec.rb
+++ b/spec/features/courses/send/edit_spec.rb
@@ -8,18 +8,12 @@ feature "Edit course SEND", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}",
-      current_recruitment_cycle.to_jsonapi,
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-      build(:provider).to_jsonapi(include: %i[courses accrediting_provider]),
-    )
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course)
 
-    stub_course_request
-    stub_course_details_tab
     send_page.load_with_course(course)
   end
 
@@ -89,24 +83,5 @@ feature "Edit course SEND", type: :feature do
     scenario "has the correct value selected" do
       expect(send_page.send_field.value).to eq("1")
     end
-  end
-
-  def stub_course_request
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}/courses" \
-      "/#{course.course_code}",
-      course.to_jsonapi,
-    )
-  end
-
-  def stub_course_details_tab
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
-    )
   end
 end

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -4,15 +4,24 @@ require "rails_helper"
 
 feature "Course show", type: :feature do
   let(:provider) do
-    build :provider,
+    build(:provider,
           accredited_body?: false,
           provider_name: "ACME SCITT A0",
-          provider_code: "A0"
+          provider_code: "A0")
   end
+
+  let(:rolled_over_provider) do
+    build(:provider,
+          recruitment_cycle: next_recruitment_cycle,
+          accredited_body?: false,
+          provider_name: "ACME SCITT A0",
+          provider_code: "A0")
+  end
+
   let(:current_recruitment_cycle) { build :recruitment_cycle }
   let(:next_recruitment_cycle) { build :recruitment_cycle, :next_cycle }
   let(:course) do
-    build :course,
+    build(:course,
           :with_fees,
           has_vacancies?: true,
           course_code: "C1",
@@ -30,13 +39,13 @@ feature "Course show", type: :feature do
           required_qualifications: "Foo",
           personal_qualities: "Foo",
           other_requirements: "Foo",
-          sites: [site]
+          sites: [site])
   end
   let(:site) { build :site, code: "Z" }
   let(:site_status) do
-    build :site_status,
+    build(:site_status,
           :full_time_and_part_time,
-          site: site
+          site: site)
   end
 
   let(:course_response) do
@@ -52,6 +61,8 @@ feature "Course show", type: :feature do
     stub_api_v2_resource next_recruitment_cycle
     stub_api_v2_resource course,
                          include: "subjects,sites,provider.sites,accrediting_provider"
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(rolled_over_provider)
 
     visit provider_recruitment_cycle_course_path(course.provider.provider_code,
                                                  course.recruitment_cycle.year,
@@ -172,7 +183,7 @@ feature "Course show", type: :feature do
   end
 
   context "when the course is running" do
-    let(:course) {
+    let(:course) do
       build :course,
             findable?: true,
             content_status: "published",
@@ -180,7 +191,7 @@ feature "Course show", type: :feature do
             has_vacancies?: true,
             open_for_applications?: true,
             provider: provider
-    }
+    end
 
     scenario "it displays a status panel" do
       expect(course_page).to have_status_panel
@@ -192,23 +203,16 @@ feature "Course show", type: :feature do
   end
 
   context "when the course has been rolled over" do
-    let(:rolled_over_provider) do
-      build :provider,
-            recruitment_cycle: next_recruitment_cycle,
-            accredited_body?: false,
-            provider_name: "ACME SCITT A0",
-            provider_code: "A0"
-    end
-    let(:course) {
-      build :course,
+    let(:course) do
+      build(:course,
             recruitment_cycle: next_recruitment_cycle,
             findable?: false,
             content_status: "rolled_over",
             ucas_status: "new",
             has_vacancies?: true,
             open_for_applications?: false,
-            provider: rolled_over_provider
-    }
+            provider: rolled_over_provider)
+    end
 
     scenario "it displays a status panel" do
       expect(course_page).to have_status_panel
@@ -219,13 +223,13 @@ feature "Course show", type: :feature do
   end
 
   context "when the course is withdrawn" do
-    let(:course) {
-      build :course,
+    let(:course) do
+      build(:course,
             findable?: false,
             content_status: "withdrawn",
             ucas_status: "not_running",
-            provider: provider
-    }
+            provider: provider)
+    end
 
     scenario "it displays a status panel" do
       expect(course_page).to have_status_panel

--- a/spec/features/courses/sites/edit_spec.rb
+++ b/spec/features/courses/sites/edit_spec.rb
@@ -25,29 +25,11 @@ feature "Edit course sites", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "?include=sites",
-      provider.to_jsonapi(include: [:sites]),
-    )
-
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=sites,provider.sites",
-      course.to_jsonapi(include: [:sites, provider: :sites]),
-    )
-
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:subjects, :accrediting_provider, :sites, provider: :sites]),
-    )
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course, include: "sites,provider.sites")
+    stub_api_v2_resource(provider, include: "sites")
+    stub_api_v2_resource(provider)
 
     course_details_page.load(provider_code: provider.provider_code, recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
     course_details_page.edit_locations_link.click

--- a/spec/features/courses/start_date/edit_spec.rb
+++ b/spec/features/courses/start_date/edit_spec.rb
@@ -8,18 +8,11 @@ feature "Edit course start date", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}",
-      current_recruitment_cycle.to_jsonapi,
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-      build(:provider).to_jsonapi(include: %i[courses accrediting_provider]),
-    )
-
-    stub_course_request
-    stub_course_details_tab
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course)
     start_date_page.load_with_course(course)
   end
 
@@ -116,24 +109,5 @@ feature "Edit course start date", type: :feature do
       expect(course_details_page.flash).to have_content("Your changes have been saved")
       expect(update_course_stub).to have_been_requested
     end
-  end
-
-  def stub_course_request
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}/courses" \
-      "/#{course.course_code}",
-      course.to_jsonapi,
-    )
-  end
-
-  def stub_course_details_tab
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
-    )
   end
 end

--- a/spec/features/courses/study_mode/edit_spec.rb
+++ b/spec/features/courses/study_mode/edit_spec.rb
@@ -9,18 +9,11 @@ feature "Edit course study mode", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}",
-      current_recruitment_cycle.to_jsonapi,
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-      build(:provider).to_jsonapi(include: %i[courses accrediting_provider]),
-    )
-
-    stub_course_request
-    stub_course_details_tab
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course)
     study_mode_page.load_with_course(course)
   end
 
@@ -104,24 +97,5 @@ feature "Edit course study mode", type: :feature do
       expect(course_request_change_page.title).to have_content("Request a change to this course")
       expect(update_course_stub).not_to have_been_requested
     end
-  end
-
-  def stub_course_request
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}/courses" \
-      "/#{course.course_code}",
-      course.to_jsonapi,
-    )
-  end
-
-  def stub_course_details_tab
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
-    )
   end
 end

--- a/spec/features/courses/withdraw_spec.rb
+++ b/spec/features/courses/withdraw_spec.rb
@@ -14,20 +14,10 @@ feature "Withdraw course", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_request("/recruitment_cycles/#{course.recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}/" \
-      "providers/#{provider.provider_code}" \
-      "?include=courses.accrediting_provider",
-      provider.to_jsonapi(include: %i[courses accrediting_provider]),
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}/" \
-      "providers/#{provider.provider_code}/" \
-      "courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: %i[subjects provider sites]),
-    )
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_request(
       "/recruitment_cycles/#{course.recruitment_cycle.year}/" \
       "providers/#{provider.provider_code}/" \

--- a/spec/requests/courses/about_spec.rb
+++ b/spec/requests/courses/about_spec.rb
@@ -14,14 +14,15 @@ describe "Courses", type: :request do
     let(:provider) { build :provider, accredited_body?: true, provider_code: "A0" }
     let(:course_response) { course.to_jsonapi(include: %i[subjects sites provider accrediting_provider recruitment_cycle]) }
 
-    let(:course_1) { build :course, name: "English", course_code: "EN01", include_nulls: [:accrediting_provider] }
+    let(:course_1) { build :course, provider: provider, name: "English", course_code: "EN01", include_nulls: [:accrediting_provider] }
     let(:course_2) do
-      build :course,
+      build(:course,
             name: "Biology",
+            provider: provider,
             include_nulls: [:accrediting_provider],
             about_course: "Foo",
             interview_process: "Foobar",
-            how_school_placements_work: "Foobarbar"
+            how_school_placements_work: "Foobarbar")
     end
     let(:course_2_response)   { course_2.to_jsonapi }
     let(:courses)             { [course_1, course_2] }
@@ -31,19 +32,12 @@ describe "Courses", type: :request do
     before do
       stub_omniauth
       get(auth_dfe_callback_path)
-      stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-      stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course_response,
-      )
-      stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course_2_response,
-      )
-      stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-        provider_2_response,
-      )
+      stub_api_v2_resource(current_recruitment_cycle)
+      stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(course_2, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(provider)
+      stub_api_v2_resource(provider2)
+      stub_api_v2_resource(provider2, include: "courses.accrediting_provider")
     end
 
     context "Default recruitment cycle" do
@@ -123,15 +117,10 @@ describe "Courses", type: :request do
     before do
       stub_omniauth
       get(auth_dfe_callback_path)
-      stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-      stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course_response,
-      )
-      stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-        provider.to_jsonapi,
-      )
+      stub_api_v2_resource(current_recruitment_cycle)
+      stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+      stub_api_v2_resource(provider)
     end
 
     context "without errors" do

--- a/spec/requests/courses/delete_spec.rb
+++ b/spec/requests/courses/delete_spec.rb
@@ -17,11 +17,9 @@ describe "Courses", type: :request do
     before do
       stub_omniauth
       get(auth_dfe_callback_path)
-      stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-      stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course_response,
-      )
+      stub_api_v2_resource(current_recruitment_cycle)
+      stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(provider)
     end
 
     it "renders the course delete" do

--- a/spec/requests/courses/fees_spec.rb
+++ b/spec/requests/courses/fees_spec.rb
@@ -11,8 +11,7 @@ describe "Courses", type: :request do
             include_nulls: [:accrediting_provider],
             recruitment_cycle: current_recruitment_cycle
     end
-    let(:provider)        { build(:provider, accredited_body?: true, provider_code: "A0") }
-    let(:course_response) { course.to_jsonapi(include: %i[subjects sites provider accrediting_provider recruitment_cycle]) }
+    let(:provider) { build(:provider, accredited_body?: true, provider_code: "A0") }
 
     let(:course_1) { build :course, name: "English", course_code: "EN01", include_nulls: [:accrediting_provider] }
     let(:course_2) do
@@ -29,6 +28,7 @@ describe "Courses", type: :request do
     let(:course_3) do
       build :course,
             name: "Chemistry",
+            provider: provider,
             include_nulls: [:accrediting_provider],
             fee_details: "Course 3 fees",
             financial_support: "Course 3 financial support"
@@ -40,23 +40,12 @@ describe "Courses", type: :request do
     before do
       stub_omniauth
       get(auth_dfe_callback_path)
-      stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-      stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course_response,
-      )
-      stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course_2.to_jsonapi(include: %i[sites provider accrediting_provider recruitment_cycle]),
-      )
-      stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_3.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course_3.to_jsonapi(include: %i[sites provider accrediting_provider recruitment_cycle]),
-      )
-      stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-        provider_2_response,
-      )
+      stub_api_v2_resource(current_recruitment_cycle)
+      stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(course_2, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(course_3, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(provider)
+      stub_api_v2_resource(provider2, include: "courses.accrediting_provider")
     end
 
     context "Default recruitment cycle" do

--- a/spec/requests/courses/requirements_spec.rb
+++ b/spec/requests/courses/requirements_spec.rb
@@ -14,35 +14,28 @@ describe "Courses", type: :request do
     let(:provider) { build(:provider, accredited_body?: true, provider_code: "A0") }
     let(:course_response) { course.to_jsonapi(include: %i[subjects sites provider accrediting_provider]) }
 
-    let(:course_1) { build :course, name: "English", course_code: "EN01", include_nulls: [:accrediting_provider] }
+    let(:course_1) { build :course, provider: provider, name: "English", course_code: "EN01", include_nulls: [:accrediting_provider] }
     let(:course_2) do
       build :course,
             name: "Biology",
+            provider: provider,
             include_nulls: [:accrediting_provider],
             required_qualifications: "Foo",
             personal_qualities: "Foobar",
             other_requirements: "Foobarbar"
     end
-    let(:courses)             { [course_1, course_2] }
-    let(:provider_2)          { build(:provider, courses: courses, accredited_body?: true, provider_code: "A0") }
+    let(:courses) { [course_1, course_2] }
+    let(:provider_2) { build(:provider, courses: courses, accredited_body?: true, provider_code: "A0") }
     let(:provider_2_response) { provider_2.to_jsonapi(include: %i[courses accrediting_provider]) }
 
     before do
       stub_omniauth
       get(auth_dfe_callback_path)
-      stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-      stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course_response,
-      )
-      stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course_2.to_jsonapi,
-      )
-      stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-        provider_2_response,
-      )
+      stub_api_v2_resource(current_recruitment_cycle)
+      stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(course_2, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(provider_2, include: "courses.accrediting_provider")
+      stub_api_v2_resource(provider)
     end
 
     context "Default recruitment cycle" do

--- a/spec/requests/courses/salary_spec.rb
+++ b/spec/requests/courses/salary_spec.rb
@@ -14,10 +14,11 @@ describe "Courses", type: :request do
     let(:provider)          { build(:provider, accredited_body?: true, provider_code: "A0") }
     let(:course_response)   { course.to_jsonapi(include: %i[sites provider accrediting_provider recruitment_cycle]) }
 
-    let(:course_1) { build :course, name: "English", course_code: "EN01", include_nulls: [:accrediting_provider] }
+    let(:course_1) { build :course, name: "English", provider: provider, course_code: "EN01", include_nulls: [:accrediting_provider] }
     let(:course_2) do
       build :course,
             name: "Biology",
+            provider: provider,
             include_nulls: [:accrediting_provider],
             course_length: "TwoYears",
             salary_details: "Some information about the salary"
@@ -28,19 +29,11 @@ describe "Courses", type: :request do
     before do
       stub_omniauth
       get(auth_dfe_callback_path)
-      stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-      stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course_response,
-      )
-      stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course_2.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course_2.to_jsonapi,
-      )
-      stub_api_v2_request(
-        "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}?include=courses.accrediting_provider",
-        provider_2.to_jsonapi(include: %i[courses accredited_body]),
-      )
+      stub_api_v2_resource(current_recruitment_cycle)
+      stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(course_2, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(provider_2, include: "courses.accrediting_provider")
+      stub_api_v2_resource(provider)
     end
 
     context "Default recruitment cycle" do

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -9,23 +9,15 @@ describe "Courses" do
     before do
       stub_omniauth
       get(auth_dfe_callback_path)
-      stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-      stub_api_v2_request(
-        "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=subjects,sites,provider.sites,accrediting_provider",
-        course.to_jsonapi(include: %i[sites provider accrediting_provider]),
-      )
+      stub_api_v2_resource(current_recruitment_cycle)
+      stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_resource(provider)
     end
 
     describe "GET search" do
       it "renders providers search" do
-        stub_api_v2_request(
-          "/recruitment_cycles/#{course.recruitment_cycle.year}/providers/#{provider.provider_code}/courses/#{course.course_code}?include=accrediting_provider",
-          course.to_jsonapi(include: %i[accrediting_provider]),
-        )
-        current_recruitment_cycle = build(:recruitment_cycle)
-        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}", provider.to_jsonapi)
-
+        stub_api_v2_resource(course, include: "accrediting_provider")
+        build(:recruitment_cycle)
         provider1 = build(:provider, provider_name: "asd")
         provider2 = build(:provider, provider_name: "aoe")
         stub_api_v2_request("/providers/suggest?query=a", resource_list_to_jsonapi([provider1, provider2]))

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -121,16 +121,20 @@ module Helpers
   end
 
   def stub_api_v2_resource_collection(resources,
+                                      endpoint: nil,
                                       jsonapi_response: nil,
                                       include: nil)
     query_params = {}
     query_params[:include] = include if include.present?
 
-    url = url_for_resource_collection(resources.first)
-    url += "?#{query_params.to_param}" if query_params.any?
+
+    if endpoint.nil?
+      endpoint = url_for_resource_collection(resources.first)
+      endpoint += "?#{query_params.to_param}" if query_params.any?
+    end
 
     jsonapi_response ||= resource_list_to_jsonapi(resources, include: include)
-    stub_api_v2_request(url, jsonapi_response)
+    stub_api_v2_request(endpoint, jsonapi_response)
   end
 
   def stub_api_v2_empty_resource_collection(resource,


### PR DESCRIPTION
### Context
Course creation was crashing due to the course creation controller pulling the provider details from the first course.

### Changes proposed in this pull request
Pull the provider details independently to avoid dependence on an existing course and fix broken tests.

### Guidance to review
Given that this test causes me to go over a number of tests I've taken the liberty of refactoring some older stubs.

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [x] Rebased master
- [X] Cleaned commit history
- [x] Tested by running locally
