### PR TITLE
[2573] - Determine which courses are excluded from bursaries

### DIFF
--- a/app/views/courses/preview/_financial_support.html.erb
+++ b/app/views/courses/preview/_financial_support.html.erb
@@ -3,6 +3,8 @@
 
   <% if course.salaried? %>
     <%= render partial: 'courses/preview/financial_support/salaried' %>
+  <% elsif course.excluded_from_bursary? %>
+    <%= render partial: 'courses/preview/financial_support/loan', locals: { course: course } %>
   <% elsif course.bursary_only? %>
     <%= render partial: 'courses/preview/financial_support/bursary', locals: { course: course } %>
   <% elsif course.has_scholarship_and_bursary? %>

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -243,6 +243,15 @@ describe CourseDecorator do
 
         it { is_expected.to eq("Student finance if you’re eligible") }
       end
+
+      context "Courses excluded from bursaries" do
+        let(:pe) { build(:subject) }
+        let(:english) { build(:subject, :english, bursary_amount: "3000") }
+
+        let(:course) { build :course, name: "Drama with English", subjects: [pe, english] }
+
+        it { is_expected.to eq("Student finance if you’re eligible") }
+      end
     end
 
     describe "#subject_name" do
@@ -313,7 +322,6 @@ describe CourseDecorator do
       end
     end
 
-
     describe "#bursary_only" do
       let(:subject) { decorated_course }
 
@@ -360,6 +368,108 @@ describe CourseDecorator do
 
         it "returns the maximum bursary amount" do
           expect(decorated_course.bursary_amount).to eq("4000")
+        end
+      end
+    end
+
+    describe "#excluded_from_bursary?" do
+      let(:subject) { decorated_course }
+
+      context "course name does not qualify for exclusion" do
+        let(:course) { build(:course, name: "Mathematics") }
+
+        it { is_expected.to_not be_excluded_from_bursary }
+      end
+
+      context "course name contains 'with'" do
+        context "Drama" do
+          let(:english) { build :subject, bursary_amount: "30000" }
+          let(:drama) { build :subject, subject_name: "Drama" }
+          let(:subjects) { [english, drama] }
+
+          context "Drama with English" do
+            let(:course) { build(:course, name: "Drama with English", subjects: subjects) }
+
+            it { is_expected.to be_excluded_from_bursary }
+          end
+
+          context "English with Drama" do
+            let(:course) { build(:course, name: "English with Drama", subjects: subjects) }
+
+            it { is_expected.to_not be_excluded_from_bursary }
+          end
+        end
+
+        context "PE" do
+          let(:english) { build :subject, bursary_amount: "30000" }
+          let(:pe) { build :subject, subject_name: "PE" }
+          let(:subjects) { [english, pe] }
+
+          context "PE with English" do
+            let(:course) { build(:course, name: "PE with English", subjects: subjects) }
+
+            it { is_expected.to be_excluded_from_bursary }
+          end
+
+          context "English with PE" do
+            let(:course) { build(:course, name: "English with PE", subjects: subjects) }
+
+            it { is_expected.to_not be_excluded_from_bursary }
+          end
+        end
+
+        context "Physical Education" do
+          let(:english) { build :subject, bursary_amount: "30000" }
+          let(:physical_education) { build :subject, subject_name: "Physical Education" }
+          let(:subjects) { [english, physical_education] }
+
+          context "Physical Education with English" do
+            let(:course) { build(:course, name: "Physical Education with English", subjects: subjects) }
+
+            it { is_expected.to be_excluded_from_bursary }
+          end
+
+          context "English with Physical Education" do
+            let(:course) { build(:course, name: "English with Physical Education", subjects: subjects) }
+
+            it { is_expected.to_not be_excluded_from_bursary }
+          end
+        end
+
+        context "Media Studies" do
+          let(:english) { build :subject, bursary_amount: "30000" }
+          let(:media_studies) { build :subject, subject_name: "Media Studies" }
+          let(:subjects) { [english, media_studies] }
+
+          context "Media Studies with English" do
+            let(:course) { build(:course, name: "Media Studies with English", subjects: subjects) }
+
+            it { is_expected.to be_excluded_from_bursary }
+          end
+
+          context "English with Media Studies" do
+            let(:course) { build(:course, name: "English with Media Studies", subjects: subjects) }
+
+            it { is_expected.to_not be_excluded_from_bursary }
+          end
+        end
+      end
+
+      context "course name contains 'and'" do
+        let(:english) { build :subject, bursary_amount: "30000" }
+        let(:drama) { build :subject, subject_name: "Drama" }
+        let(:subjects) { [english, drama] }
+
+        context "Drama and English" do
+          let(:course) { build(:course, name: "Drama and English", subjects: subjects) }
+
+          it { is_expected.to_not be_excluded_from_bursary }
+        end
+
+        context "English and Drama" do
+          let(:course) { build(:course, name: "English and Drama", subjects: subjects) }
+
+          it { is_expected.to_not be_excluded_from_bursary }
         end
       end
     end

--- a/spec/views/preview.html.erb_spec.rb
+++ b/spec/views/preview.html.erb_spec.rb
@@ -15,6 +15,20 @@ describe "Rendering financial support information" do
     end
   end
 
+  context "course is excluded from offering bursaries" do
+    it "renders the 'loan' partial" do
+      english = build(:subject, subject_name: "English", busary_amount: "3000")
+      pe = build(:subject, subject_name: "PE")
+      course = build(:course, name: "PE with English", subjects: [english, pe])
+
+      render "courses/preview/financial_support", course: course.decorate
+
+      preview_course_page.load(rendered)
+
+      expect(preview_course_page).to have_selector("[data-qa=course__loan_details]")
+    end
+  end
+
   context "course has a bursary" do
     it "renders the 'bursary' partial" do
       mathematics = build(:subject, :mathematics, bursary_amount: "3000")


### PR DESCRIPTION
### Context

If a course is excluded from the bursary the course preview page will not display bursary information in the Financial Support sections, rather, it will display loan information only.

Courses are excluded from bursaries if:

- They have two subjects

- The course name contains 'with' and starts with a subject that is on the exclusion list (PE, Physical Education, Media Studies, Drama)

E.g.

- Drama with English => excluded
- English with Drama => not excluded
- Drama and English - not excluded

### Changes proposed in this pull request
- update 'financial options' and 'funding support' sections

### Guidance to review
I expect as least 5 rejections

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

