### PR TITLE
[2561] Handle validation errors on course creation

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -59,6 +59,10 @@ private
     @course.errors.messages.select { |key, _message| error_keys.include?(key) }
   end
 
+  def error_keys
+    []
+  end
+
   def build_provider
     @provider = Provider
                   .where(recruitment_cycle_year: params[:recruitment_cycle_year])

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -36,7 +36,7 @@ module CourseBasicDetailConcern
   def continue
     @errors = errors
 
-    if @errors.present?
+    if @errors.any?
       render :new
     elsif params[:goto_confirmation].present?
       redirect_to confirmation_provider_recruitment_cycle_courses_path(path_params)
@@ -53,6 +53,10 @@ private
       provider_code: @provider.provider_code,
       course: course_params.to_unsafe_hash,
     )
+  end
+
+  def errors
+    @course.errors.messages.select { |key, _message| error_keys.include?(key) }
   end
 
   def build_provider

--- a/app/controllers/courses/accredited_body_controller.rb
+++ b/app/controllers/courses/accredited_body_controller.rb
@@ -74,6 +74,10 @@ module Courses
                     .first
     end
 
+    def error_keys
+      []
+    end
+
     def redirect_to_provider_search
       redirect_to(
         accredited_body_search_provider_recruitment_cycle_course_path(
@@ -99,8 +103,6 @@ module Courses
     def current_step
       :accredited_body
     end
-
-    def errors; end
 
     def build_course_params
       @accredited_body = params[:course].delete(:accredited_body)

--- a/app/controllers/courses/accredited_body_controller.rb
+++ b/app/controllers/courses/accredited_body_controller.rb
@@ -75,7 +75,7 @@ module Courses
     end
 
     def error_keys
-      []
+      [:accrediting_provider_code]
     end
 
     def redirect_to_provider_search

--- a/app/controllers/courses/age_range_controller.rb
+++ b/app/controllers/courses/age_range_controller.rb
@@ -30,6 +30,10 @@ module Courses
 
   private
 
+    def error_keys
+      [:age_range_in_years]
+    end
+
     def update_age_range_param
       params[:course][:age_range_in_years] = "#{age_from_param}_to_#{age_to_param}" if valid_custom_age_range?
     end
@@ -117,8 +121,6 @@ module Courses
     def current_step
       :age_range
     end
-
-    def errors; end
 
     def build_course
       @course = Course

--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -63,5 +63,9 @@ module Courses
     def current_step
       :applications_open
     end
+
+    def error_keys
+      [:applications_open_from]
+    end
   end
 end

--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -11,8 +11,6 @@ module Courses
 
   private
 
-    def errors; end
-
     def actual_params
       params.require(:course)
         .except(

--- a/app/controllers/courses/apprenticeship_controller.rb
+++ b/app/controllers/courses/apprenticeship_controller.rb
@@ -7,5 +7,9 @@ module Courses
     def current_step
       :apprenticeship
     end
+
+    def error_keys
+      [:funding_type]
+    end
   end
 end

--- a/app/controllers/courses/apprenticeship_controller.rb
+++ b/app/controllers/courses/apprenticeship_controller.rb
@@ -7,7 +7,5 @@ module Courses
     def current_step
       :apprenticeship
     end
-
-    def errors; end
   end
 end

--- a/app/controllers/courses/entry_requirements_controller.rb
+++ b/app/controllers/courses/entry_requirements_controller.rb
@@ -17,6 +17,10 @@ module Courses
       :entry_requirements
     end
 
+    def error_keys
+      course.gcse_subjects_required.map(&:to_sym)
+    end
+
     def errors
       course.gcse_subjects_required
         .reject { |subject| params.dig(:course, subject) }

--- a/app/controllers/courses/fee_or_salary_controller.rb
+++ b/app/controllers/courses/fee_or_salary_controller.rb
@@ -7,5 +7,9 @@ module Courses
     def current_step
       :fee_or_salary
     end
+
+    def error_keys
+      [:funding_type]
+    end
   end
 end

--- a/app/controllers/courses/fee_or_salary_controller.rb
+++ b/app/controllers/courses/fee_or_salary_controller.rb
@@ -7,7 +7,5 @@ module Courses
     def current_step
       :fee_or_salary
     end
-
-    def errors; end
   end
 end

--- a/app/controllers/courses/level_controller.rb
+++ b/app/controllers/courses/level_controller.rb
@@ -4,7 +4,9 @@ module Courses
 
   private
 
-    def errors; end
+    def error_keys
+      [:level]
+    end
 
     def current_step
       :level

--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -52,8 +52,6 @@ module Courses
       end
     end
 
-    def errors; end
-
     def build_course
       @course = Course
                   .includes(:subjects, :site_statuses)

--- a/app/controllers/courses/outcome_controller.rb
+++ b/app/controllers/courses/outcome_controller.rb
@@ -11,5 +11,9 @@ module Courses
     def errors
       params.dig(:course, :qualification) ? {} : { qualification: ["Pick an outcome"] }
     end
+
+    def error_keys
+      [:qualification]
+    end
   end
 end

--- a/app/controllers/courses/sites_controller.rb
+++ b/app/controllers/courses/sites_controller.rb
@@ -41,8 +41,6 @@ module Courses
       :location
     end
 
-    def errors; end
-
     def set_default_site
       params["course"] ||= {}
       params["course"]["sites_ids"] = [@provider.sites.first.id]

--- a/app/controllers/courses/start_date_controller.rb
+++ b/app/controllers/courses/start_date_controller.rb
@@ -7,5 +7,9 @@ module Courses
     def current_step
       :start_date
     end
+
+    def error_keys
+      [:start_date]
+    end
   end
 end

--- a/app/controllers/courses/start_date_controller.rb
+++ b/app/controllers/courses/start_date_controller.rb
@@ -7,7 +7,5 @@ module Courses
     def current_step
       :start_date
     end
-
-    def errors; end
   end
 end

--- a/app/controllers/courses/subjects_controller.rb
+++ b/app/controllers/courses/subjects_controller.rb
@@ -66,6 +66,10 @@ module Courses
       :subjects
     end
 
+    def error_keys
+      [:subjects]
+    end
+
     def build_course
       @course = Course
                   .includes(:subjects, :site_statuses)

--- a/app/controllers/courses/subjects_controller.rb
+++ b/app/controllers/courses/subjects_controller.rb
@@ -66,8 +66,6 @@ module Courses
       :subjects
     end
 
-    def errors; end
-
     def build_course
       @course = Course
                   .includes(:subjects, :site_statuses)

--- a/spec/features/courses/age_range_in_years/new_spec.rb
+++ b/spec/features/courses/age_range_in_years/new_spec.rb
@@ -55,6 +55,20 @@ feature "new course age range", type: :feature do
     expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
+  context "Error handling" do
+    let(:course) do
+      c = build(:course, provider: provider, level: :secondary, age_range_in_years: nil)
+      c.errors.add(:age_range_in_years, "Invalid")
+      c
+    end
+
+    scenario do
+      visit_new_age_range_page
+      new_age_range_page.continue.click
+      expect(new_outcome_page.error_flash.text).to include("Age range in years Invalid")
+    end
+  end
+
   def visit_new_age_range_page(**query_params)
     visit signin_path
     visit new_provider_recruitment_cycle_courses_age_range_path(

--- a/spec/features/courses/applications_open/new_spec.rb
+++ b/spec/features/courses/applications_open/new_spec.rb
@@ -69,6 +69,21 @@ feature "new course applications open", type: :feature do
     end
   end
 
+  context "Error handling" do
+    let(:course) do
+      c = build(:course, provider: provider, start_date: nil)
+      c.errors.add(:applications_open_from, "Invalid")
+      c
+    end
+
+    scenario do
+      visit_new_applications_open_page
+      new_applications_open_page.applications_open_field.click
+      new_applications_open_page.continue.click
+      expect(new_applications_open_page.error_flash.text).to include("Applications open from Invalid")
+    end
+  end
+
   def visit_new_applications_open_page(**query_params)
     visit signin_path
     visit new_provider_recruitment_cycle_courses_applications_open_path(

--- a/spec/features/courses/apprenticeship/new_spec.rb
+++ b/spec/features/courses/apprenticeship/new_spec.rb
@@ -64,6 +64,21 @@ feature "new course apprenticeship", type: :feature do
     it_behaves_like "a course creation page"
   end
 
+  context "Error handling" do
+    let(:course) do
+      c = build(:course, provider: provider)
+      c.errors.add(:funding_type, "Invalid")
+      c
+    end
+
+    scenario do
+      visit_new_apprenticeship_page
+      new_apprenticeship_page.funding_type_fields.apprenticeship.click
+      new_apprenticeship_page.continue.click
+      expect(new_apprenticeship_page.error_flash.text).to include("Funding type Invalid")
+    end
+  end
+
   def visit_new_apprenticeship_page(**query_params)
     visit new_provider_recruitment_cycle_courses_apprenticeship_path(provider.provider_code, provider.recruitment_cycle_year, query_params)
   end

--- a/spec/features/courses/entry_requirements/new_spec.rb
+++ b/spec/features/courses/entry_requirements/new_spec.rb
@@ -172,6 +172,30 @@ feature "new course entry_requirements", type: :feature do
     end
   end
 
+  context "Error handling" do
+    let(:course) do
+      c = build(:course,
+                provider: provider,
+                level: :primary,
+                gcse_subjects_required_using_level: true,
+                maths: nil,
+                english: nil,
+                science: nil)
+      c.errors.add(:maths, "Invalid")
+      c.errors.add(:english, "Invalid")
+      c.errors.add(:science, "Invalid")
+      c
+    end
+
+    scenario do
+      visit_new_entry_requirements
+      new_entry_requirements_page.continue.click
+      expect(new_entry_requirements_page.error_flash.text).to include("Pick an option for Maths")
+      expect(new_entry_requirements_page.error_flash.text).to include("Pick an option for English")
+      expect(new_entry_requirements_page.error_flash.text).to include("Pick an option for Science")
+    end
+  end
+
   def visit_new_entry_requirements(**query_params)
     visit signin_path
     visit new_provider_recruitment_cycle_courses_entry_requirements_path(

--- a/spec/features/courses/fee_or_salary/new_spec.rb
+++ b/spec/features/courses/fee_or_salary/new_spec.rb
@@ -53,6 +53,21 @@ feature "new course fee or salary", type: :feature do
     expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
+  context "Error handling" do
+    let(:course) do
+      c = build(:course, provider: provider)
+      c.errors.add(:funding_type, "Invalid")
+      c
+    end
+
+    scenario do
+      visit_fee_or_salary
+      new_fee_or_salary_page.funding_type_fields.fee.click
+      new_fee_or_salary_page.continue.click
+      expect(new_fee_or_salary_page.error_flash.text).to include("Funding type Invalid")
+    end
+  end
+
   def visit_fee_or_salary(**query_params)
     visit new_provider_recruitment_cycle_courses_fee_or_salary_path(
       provider.provider_code,

--- a/spec/features/courses/level/new_spec.rb
+++ b/spec/features/courses/level/new_spec.rb
@@ -26,41 +26,56 @@ feature "New course level", type: :feature do
     stub_api_v2_resource(provider)
     stub_api_v2_new_resource(course)
     stub_api_v2_build_course
-    stub_api_v2_build_course(is_send: 0, level: "secondary")
-
-    visit_new_level_page
   end
 
-  scenario "sends user to entry requirements" do
-    new_level_page.level_fields.secondary.choose
-    new_level_page.continue.click
-
-    expect(current_path).to eq new_provider_recruitment_cycle_courses_subjects_path(provider.provider_code, provider.recruitment_cycle_year)
-  end
-
-  scenario "sends user back to course confirmation" do
-    visit_new_level_page(goto_confirmation: true)
-
-    new_level_page.level_fields.secondary.choose
-    new_level_page.continue.click
-
-    expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
-  end
-
-  context "Selecting primary" do
-    let(:next_step_page) do
-      PageObjects::Page::Organisations::Courses::NewSubjectsPage.new
-    end
-    let(:selected_fields) { { level: "primary", is_send: "0" } }
-    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
-
+  context "With no validation errors" do
     before do
-      build_course_with_selected_value_request
-      new_level_page.level_fields.primary.click
-      new_level_page.continue.click
+      stub_api_v2_build_course(is_send: 0, level: "secondary")
+      visit_new_level_page
     end
 
-    it_behaves_like "a course creation page"
+    scenario "sends user back to course confirmation" do
+      visit_new_level_page(goto_confirmation: true)
+
+      new_level_page.level_fields.secondary.choose
+      new_level_page.continue.click
+
+      expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+    end
+
+    context "Selecting primary" do
+      let(:next_step_page) do
+        PageObjects::Page::Organisations::Courses::NewSubjectsPage.new
+      end
+      let(:selected_fields) { { level: "primary", is_send: "0" } }
+      let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
+
+      before do
+        build_course_with_selected_value_request
+        new_level_page.level_fields.primary.click
+        new_level_page.continue.click
+      end
+
+      it_behaves_like "a course creation page"
+    end
+  end
+
+  context "Error handling" do
+    before do
+      stub_api_v2_build_course(is_send: 0)
+      visit_new_level_page
+    end
+
+    let(:course) do
+      c = build(:course, provider: provider, is_send: nil, level: nil)
+      c.errors.add(:level, "Invalid")
+      c
+    end
+
+    scenario do
+      new_level_page.continue.click
+      expect(new_level_page.error_flash.text).to include("Level Invalid")
+    end
   end
 
 private

--- a/spec/features/courses/outcome/new_spec.rb
+++ b/spec/features/courses/outcome/new_spec.rb
@@ -61,6 +61,19 @@ feature "new course outcome", type: :feature do
     end
   end
 
+  context "Error handling" do
+    let(:course) do
+      c = build(:course, provider: provider, qualification: nil)
+      c.errors.add(:qualification, "Invalid")
+      c
+    end
+
+    scenario do
+      new_outcome_page.continue.click
+      expect(new_outcome_page.error_flash.text).to include("Pick an outcome")
+    end
+  end
+
 private
 
   def visit_new_outcome_page(**query_params)

--- a/spec/features/courses/start_date/new_spec.rb
+++ b/spec/features/courses/start_date/new_spec.rb
@@ -34,6 +34,21 @@ feature "New course start date", type: :feature do
     expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 
+  context "Error handling" do
+    let(:course) do
+      c = build(:course, provider: provider, start_date: nil)
+      c.errors.add(:start_date, "Invalid")
+      c
+    end
+
+    scenario do
+      visit_new_start_date_page
+      select "September #{Settings.current_cycle}"
+      new_start_date_page.continue.click
+      expect(new_start_date_page.error_flash.text).to include("Start date Invalid")
+    end
+  end
+
 private
 
   def visit_new_start_date_page(**query_params)

--- a/spec/features/courses/study_mode/new_spec.rb
+++ b/spec/features/courses/study_mode/new_spec.rb
@@ -81,6 +81,20 @@ feature "new course study mode", type: :feature do
     end
   end
 
+  context "Error handling" do
+    let(:course) do
+      c = build(:course, provider: provider, study_mode: nil)
+      c.errors.add(:study_mode, "Invalid")
+      c
+    end
+
+    scenario do
+      visit_new_study_mode_page
+      new_study_mode_page.continue.click
+      expect(new_study_mode_page.error_flash.text).to include("Pick full time, part time or full time and part time")
+    end
+  end
+
 private
 
   def visit_new_study_mode_page(**query_params)

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -43,6 +43,23 @@ feature "New course level", type: :feature do
     it_behaves_like "a course creation page"
   end
 
+  context "Error handling" do
+    let(:course) do
+      c = build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true, edit_options: edit_options)
+      c.errors.add(:subjects, "Invalid")
+      c
+    end
+
+    before do
+      stub_api_v2_build_course(subjects_ids: [nil])
+    end
+
+    scenario do
+      new_subjects_page.continue.click
+      expect(new_subjects_page.error_flash.text).to include("Subjects Invalid")
+    end
+  end
+
   context "Page title" do
     context "For a primary course" do
       let(:level) { :primary }

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -145,7 +145,7 @@ module Helpers
   def stub_api_v2_build_course(params = {})
     jsonapi_response = course.to_jsonapi(include: %i[subjects sites])
     jsonapi_response[:data][:meta] = course.meta
-    jsonapi_response[:data][:errors] = []
+    jsonapi_response[:data][:errors] = course_errors_to_json_api(course)
     stub_api_v2_request(
       url_for_build_course_with_params(params),
       jsonapi_response,
@@ -157,6 +157,20 @@ module Helpers
   end
 
 private
+
+  def course_errors_to_json_api(course)
+    errors = []
+    course.errors.messages.each do |error_key, _|
+      course.errors.full_messages_for(error_key).each do |error_message|
+        errors << {
+          "title" => "Invalid #{error_key}",
+          "detail" => error_message,
+          "source" => { "pointer" => "/data/attributes/#{error_key}" },
+        }
+      end
+    end
+    errors
+  end
 
   def url_for_resource(resource)
     base_url = url_for_resource_collection(resource)


### PR DESCRIPTION
### Context

Course creation did not handle validation as there was none implemented in the backend, this PR will now take into account any validation errors on the API (or in the frontend where there already exists some)

### Changes proposed in this pull request

- Add method to filter out errors from the API to the appropriate page
- Add tests to pages with validation
- Keep current frontend validation

### Guidance to review

1. Check out this branch
2. Go through pages and attempt to get through them with nothing selected where possible
3. It _should_ display validation errors where the backend returns them
    - There are some instances where the validation is not implemented on the backend

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
