### PR TITLE
[2567] Add ability add a subordinate subject to course creation

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -109,6 +109,7 @@ private
           :start_date,
           :age_range_in_years,
           :master_subject_id,
+          :subordinate_subject_id,
           :funding_type,
           :accrediting_provider_code,
           sites_ids: [],

--- a/app/controllers/courses/subjects_controller.rb
+++ b/app/controllers/courses/subjects_controller.rb
@@ -78,8 +78,11 @@ module Courses
     end
 
     def build_course_params
-      params[:course][:subjects_ids] = [params[:course][:master_subject_id]]
-      params[:course].delete :master_subject_id
+      params[:course][:subjects_ids] = []
+      params[:course][:subjects_ids] << params[:course][:master_subject_id]
+      params[:course][:subjects_ids] << params[:course][:subordinate_subject_id] if params[:course][:subordinate_subject_id].present?
+      params[:course].delete(:master_subject_id)
+      params[:course].delete(:subordinate_subject_id)
     end
   end
 end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -214,6 +214,10 @@ class CourseDecorator < ApplicationDecorator
     meta["edit_options"]["subjects"].map { |subject| [subject["attributes"]["subject_name"], subject["id"]] }
   end
 
+  def selectable_subordinate_subjects
+    selectable_master_subjects + [%w[None None]]
+  end
+
   def subject_present?(subject_to_find)
     subjects.map { |subject| subject["id"] }.include?(subject_to_find["id"])
   end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -210,12 +210,8 @@ class CourseDecorator < ApplicationDecorator
     end
   end
 
-  def selectable_master_subjects
+  def selectable_subjects
     meta["edit_options"]["subjects"].map { |subject| [subject["attributes"]["subject_name"], subject["id"]] }
-  end
-
-  def selectable_subordinate_subjects
-    selectable_master_subjects + [%w[None None]]
   end
 
   def subject_present?(subject_to_find)

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -1,1 +1,25 @@
-<%= form.select :master_subject_id, options_for_select(course.selectable_master_subjects, @course.subjects.first&.id), { include_blank: true }, data: { qa: 'course__subjects' }, class: "govuk-select" %>
+<div class="govuk-form-group">
+  <%= form.label :master_subject_id, 'Subject', class: 'govuk-label' %>
+  <%= form.select :master_subject_id, options_for_select(course.selectable_master_subjects, @course.subjects.first&.id), { include_blank: true }, data: { qa: 'course__subjects' }, class: "govuk-select" %>
+</div>
+
+<% if course.level == "secondary" %>
+  <div style="margin-bottom: -20px">
+    <details class="govuk-details" role="group" data-qa="course__subordinate_subject_accordion">
+      <summary class="govuk-details__summary" role="button">
+        <span class="govuk-details__summary-text">
+          Add a second subject (optional)
+        </span>
+      </summary>
+      <div class="govuk-details__text" id="details-content-c2b172cf-d259-4213-90bc-50d9d169a20f" aria-hidden="true">
+        <p>Your first subject is the main one. It’ll appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
+
+        <div class="govuk-form-group">
+          <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>
+          <span class="govuk-hint">For example ‘Physics with Mathematics’</span>
+          <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subordinate_subjects, @course.subjects.second&.id || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
+        </div>
+      </div>
+    </details>
+  </div>
+<% end %>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -12,7 +12,7 @@
         </span>
       </summary>
       <div class="govuk-details__text" id="details-content-c2b172cf-d259-4213-90bc-50d9d169a20f" aria-hidden="true">
-        <p>Your first subject is the main one. It’ll appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
+        <p>Your first subject is the main one. It will appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
 
         <div class="govuk-form-group">
           <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-form-group">
   <%= form.label :master_subject_id, 'Subject', class: 'govuk-label' %>
-  <%= form.select :master_subject_id, options_for_select(course.selectable_master_subjects, @course.subjects.first&.id), { include_blank: true }, data: { qa: 'course__subjects' }, class: "govuk-select" %>
+  <%= form.select :master_subject_id, options_for_select(course.selectable_subjects, @course.subjects.first&.id), { include_blank: true }, data: { qa: 'course__subjects' }, class: "govuk-select" %>
 </div>
 
 <% if course.level == "secondary" %>
@@ -17,7 +17,7 @@
         <div class="govuk-form-group">
           <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>
           <span class="govuk-hint">For example ‘Physics with Mathematics’</span>
-          <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subordinate_subjects, @course.subjects.second&.id || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
+          <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subjects, @course.subjects.second&.id || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
         </div>
       </div>
     </details>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -16,7 +16,6 @@
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
-
       <%= render 'shared/course_creation_hidden_fields',
         form: form,
         course_creation_params: @course_creation_params,

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -171,7 +171,7 @@ describe CourseDecorator do
     end
   end
 
-  describe "#selectable_master_subjects" do
+  describe "#selectable_subjects" do
     let(:course) do
       build(:course, edit_options: {
         subjects: subjects.map do |subject|
@@ -181,7 +181,7 @@ describe CourseDecorator do
     end
 
     it "gets the name and id" do
-      expect(decorated_course.selectable_master_subjects).to eq([
+      expect(decorated_course.selectable_subjects).to eq([
         [english.subject_name, english.id],
         [mathematics.subject_name, mathematics.id],
       ])

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -12,7 +12,6 @@ feature "New course level", type: :feature do
   let(:biology) { build(:subject, :biology) }
   let(:subjects) { [english, biology] }
   let(:edit_options) { { subjects: subjects, age_range_in_years: [] } }
-  let(:level) { :secondary }
   let(:course) { build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true, edit_options: edit_options) }
 
   before do
@@ -26,21 +25,68 @@ feature "New course level", type: :feature do
     "/courses/subjects/new"
   end
 
-  context "Selecting primary" do
-    let(:selected_fields) { { subjects_ids: [english.id] } }
-    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
+  context "with a secondary course" do
+    let(:level) { :secondary }
+    context "Selecting master subject" do
+      let(:selected_fields) { { subjects_ids: [english.id] } }
+      let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
 
-    before do
-      build_course_with_selected_value_request
-      new_subjects_page.subjects_fields.select(english.subject_name).click
-      new_subjects_page.continue.click
+      before do
+        build_course_with_selected_value_request
+        new_subjects_page.subjects_fields.select(english.subject_name).click
+        new_subjects_page.continue.click
+      end
+
+      scenario "sends user to new outcome page" do
+        expect(next_step_page).to be_displayed
+      end
+
+      it_behaves_like "a course creation page"
     end
 
-    scenario "sends user to new outcome page" do
-      expect(next_step_page).to be_displayed
+    context "Selecting master & subordinate subject" do
+      let(:selected_fields) { { subjects_ids: [english.id, biology.id] } }
+      let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
+
+      before do
+        build_course_with_selected_value_request
+        new_subjects_page.subjects_fields.select(english.subject_name).click
+        new_subjects_page.subordinate_subject_accordion.click
+        new_subjects_page.subordinate_subjects_fields.select(biology.subject_name).click
+        new_subjects_page.continue.click
+      end
+
+      scenario "sends user to new outcome page" do
+        expect(next_step_page).to be_displayed
+      end
+
+      it_behaves_like "a course creation page"
+    end
+  end
+
+  context "with a primary course" do
+    let(:level) { :primary }
+    scenario "Only displays the master subject field" do
+      expect(new_subjects_page).to have_subjects_fields
+      expect(new_subjects_page).not_to have_subordinate_subject_accordion
     end
 
-    it_behaves_like "a course creation page"
+    context "Selecting master subject" do
+      let(:selected_fields) { { subjects_ids: [english.id] } }
+      let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
+
+      before do
+        build_course_with_selected_value_request
+        new_subjects_page.subjects_fields.select(english.subject_name).click
+        new_subjects_page.continue.click
+      end
+
+      scenario "sends user to new outcome page" do
+        expect(next_step_page).to be_displayed
+      end
+
+      it_behaves_like "a course creation page"
+    end
   end
 
   context "Page title" do

--- a/spec/site_prism/page_objects/page/organisations/courses/new_subjects_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_subjects_page.rb
@@ -6,6 +6,8 @@ module PageObjects
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/subjects/new{?query*}"
 
           element :subjects_fields, '[data-qa="course__subjects"]'
+          element :subordinate_subject_accordion, '[data-qa="course__subordinate_subject_accordion"]'
+          element :subordinate_subjects_fields, '[data-qa="course__subordinate_subjects"]'
           element :continue, '[data-qa="course__save"]'
         end
       end

--- a/spec/support/shared_examples/course_creation.rb
+++ b/spec/support/shared_examples/course_creation.rb
@@ -7,7 +7,7 @@ shared_examples_for "a course creation page" do
   end
 
   scenario "stores the selected field" do
-    expect(next_step_page.url_matches["query"].to_query).to eq(
+    expect(URI::parse(next_step_page.current_url).query).to eq(
       selected_fields.to_query(:course),
     )
   end


### PR DESCRIPTION
### Context  
https://manage-courses-prototype.herokuapp.com/new/V978/subject (go back and select a level first)  
Secondary courses need to be able to have a subordinate subject in addition to the master subject.  

### Changes proposed in this pull request
Add a second subject dropdown to the subjects/new page.

### Guidance to review
![image](https://user-images.githubusercontent.com/41294831/69647824-1433cd00-1062-11ea-9993-6e51a9f6c94c.png)


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
