### PR TITLE
2578 primary subject page style fixes

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -23,6 +23,16 @@ module ViewHelper
     end
   end
 
+  def subject_input_label(course)
+    if course.level == "primary"
+      "Primary subject"
+    elsif course.level == "secondary"
+      "Secondary subject"
+    else
+      "Select a subject"
+    end
+  end
+
   def govuk_link_to(body, url = body, html_options = { class: "govuk-link" })
     link_to body, url, html_options
   end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -13,6 +13,16 @@ module ViewHelper
     end
   end
 
+  def subject_page_title(course)
+    if course.level == "primary"
+      "Select a primary subject"
+    elsif course.level == "secondary"
+      "Select a secondary subject"
+    else
+      "Select a subject"
+    end
+  end
+
   def govuk_link_to(body, url = body, html_options = { class: "govuk-link" })
     link_to body, url, html_options
   end

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -1,1 +1,1 @@
-<%= form.select :master_subject_id, options_for_select(course.selectable_master_subjects, @course.subjects.first&.id), {}, data: { qa: 'course__subjects' }, class: "govuk-select" %>
+<%= form.select :master_subject_id, options_for_select(course.selectable_master_subjects, @course.subjects.first&.id), { include_blank: true }, data: { qa: 'course__subjects' }, class: "govuk-select" %>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -16,14 +16,17 @@
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
-      <h2 class="govuk-heading-m remove-top-margin">Subject</h2>
 
       <%= render 'shared/course_creation_hidden_fields',
         form: form,
         course_creation_params: @course_creation_params,
         except_keys: []
       %>
-      <%= render 'form_fields', form: form %>
+
+      <div class="govuk-form-group">
+        <label class="govuk-label"><%= subject_input_label(@course) %></label>
+        <%= render 'form_fields', form: form %>
+      </div>
 
       <%= form.submit "Continue",
                       class: "govuk-button",

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Select subject" %>
+<%= content_for :page_title, subject_page_title(@course) %>
 <% content_for :before_content do %>
   <%= course_creation_back_button(@back_link_path) %>
 <% end %>
@@ -6,7 +6,7 @@
 <%= render 'shared/errors' %>
 
 <h1 class="govuk-heading-xl">
-  Select subject
+  <%= subject_page_title(@course) %>
 </h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -12,7 +12,8 @@ feature "New course level", type: :feature do
   let(:biology) { build(:subject, :biology) }
   let(:subjects) { [english, biology] }
   let(:edit_options) { { subjects: subjects, age_range_in_years: [] } }
-  let(:course) { build(:course, :new, provider: provider, level: :secondary, gcse_subjects_required_using_level: true, edit_options: edit_options) }
+  let(:level) { :secondary }
+  let(:course) { build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true, edit_options: edit_options) }
 
   before do
     stub_omniauth
@@ -40,5 +41,25 @@ feature "New course level", type: :feature do
     end
 
     it_behaves_like "a course creation page"
+  end
+
+  context "Page title" do
+    context "For a primary course" do
+      let(:level) { :primary }
+
+      scenario "It displays the correct title" do
+        expect(page.title).to start_with("Select a primary subject")
+        expect(new_subjects_page.title.text).to eq("Select a primary subject")
+      end
+    end
+
+    context "For a secondary course" do
+      let(:level) { :secondary }
+
+      scenario "It displays the correct title" do
+        expect(page.title).to start_with("Select a secondary subject")
+        expect(new_subjects_page.title.text).to eq("Select a secondary subject")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

The subject select page needed to be brought in line with the prototype

### Changes proposed in this pull request

- Display the correct title on the subjects page
- Default to blank select box
- Move the button below the select box
- Display the correct label

![image](https://user-images.githubusercontent.com/976254/69643836-bc926300-105b-11ea-8744-fdc40f45b219.png)


### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
