### PR TITLE
[2609] Make accrediting body page pass hidden fields

### DIFF
--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -11,51 +11,49 @@
       Who is the accredited body?
     </h1>
 
-    <%= form_with model: course,
-                  url: continue_provider_recruitment_cycle_courses_accredited_body_path(
+    <%= form_with url: continue_provider_recruitment_cycle_courses_accredited_body_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
                   ),
-      method: :get do |form| %>
+                  method: :get do |form| %>
 
-      <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_body">
-        <% if provider.accredited_bodies.length > 0 %>
-          <%= render partial: "provider_suggestion",
-            collection: provider.accredited_bodies,
-            locals: { form: form }
-          %>
-          <%= render 'shared/course_creation_hidden_fields',
-            form: form,
-            course_creation_params: @course_creation_params,
-            except_keys: [:accrediting_provider_code]
-          %>
+      <%= render "courses/new_fields_holder", form: form, except_keys: [:accrediting_provider_code] do |fields| %>
+        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_body">
+          <% if provider.accredited_bodies.length > 0 %>
+            <%= render partial: "provider_suggestion",
+              collection: provider.accredited_bodies,
+              locals: { form: fields }
+            %>
+            <%= render 'shared/course_creation_hidden_fields',
+              form: fields,
+              course_creation_params: @course_creation_params,
+              except_keys: [:accrediting_provider_code]
+            %>
 
-          <div class="govuk-radios__divider">or</div>
+            <div class="govuk-radios__divider">or</div>
 
-          <div class="govuk-radios__item">
-            <%= form.radio_button :accrediting_provider_code,
-              'other',
-              class: 'govuk-radios__input',
-              data: { "aria-controls" => "other-container" },
-              checked: @errors && @errors[:accredited_body]&.any?  %>
-            <%= form.label :accrediting_provider_code,
-              "A new accredited body you’re working with",
-              for: 'course_accrediting_provider_code_other',
-              value: false,
-              class: 'govuk-label govuk-radios__label' %>
-          </div>
+            <div class="govuk-radios__item">
+              <%= fields.radio_button :accrediting_provider_code,
+                'other',
+                class: 'govuk-radios__input',
+                data: { "aria-controls" => "other-container" },
+                checked: @errors && @errors[:accredited_body]&.any?  %>
+              <%= fields.label :accrediting_provider_code,
+                "A new accredited body you’re working with",
+                for: 'course_accrediting_provider_code_other',
+                value: false,
+                class: 'govuk-label govuk-radios__label' %>
+            </div>
 
-          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="other-container">
-            <%= render "provider_search_field", form: form %>
-          </div>
-        <% else %>
-          <%= form.hidden_field :accrediting_provider_code, value: :other %>
-          <%= render "provider_search_field", form: form %>
-        <% end %>
-      </div>
-
-      <%= form.submit "Continue", class: "govuk-button govuk-!-margin-top-3", data: { qa: 'course__save' } %>
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="other-container">
+              <%= render "provider_search_field", form: fields %>
+            </div>
+          <% else %>
+            <%= fields.hidden_field :accrediting_provider_code, value: :other %>
+            <%= render "provider_search_field", form: fields %>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>
-


### PR DESCRIPTION
### Context
As it stands the entry requirements page does not work during course creation because it is not having the appropriate hidden fields passed to it.

### Changes proposed in this pull request
Pass hidden fields from the accrediting body page during course creation.

### Guidance to review
Needs tests, not yet sure why the tests didn't pick it up before.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
