### PR TITLE
[2611] Add access request count to header

### DIFF
--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -1,6 +1,10 @@
 class AccessRequest < Base
   custom_endpoint :approve, on: :member, request_method: :post
 
+  def self.return_count
+    select { |request| request["status"] == "requested" }.count
+  end
+
   def recipient
     User.new(first_name: first_name, last_name: last_name, email: email_address)
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -28,7 +28,7 @@
           </li>
           <% if current_user.present? && current_user["admin"] %>
             <li class="govuk-header__navigation-item">
-              <%= link_to "Access Requests", access_requests_path, class: "govuk-header__link", data: { qa: "access_requests_link" } %>
+              <%= link_to "Access Requests (#{AccessRequest.return_count})", access_requests_path, class: "govuk-header__link", data: { qa: "access_requests_link" } %>
             </li>
           <% end %>
         </ul>

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -44,6 +44,7 @@ feature "Access Requests", type: :feature do
         stub_api_v2_resource(current_recruitment_cycle)
         stub_api_v2_resource(provider, include: "courses.accrediting_provider")
         stub_api_v2_resource_collection([access_request], include: "requester")
+        stub_api_v2_resource_collection([access_request])
 
         visit provider_courses_path(provider.provider_code)
         organisations_page.access_requests_link.click


### PR DESCRIPTION
### Context
The access request used to display the count of requested requests.

This was lost when it was ported to publish.

### Changes proposed in this pull request
- Add the count back in

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
