### PR TITLE
[2588] Applications open style fix

### DIFF
--- a/app/views/courses/applications_open/_form_fields.html.erb
+++ b/app/views/courses/applications_open/_form_fields.html.erb
@@ -16,7 +16,7 @@
             aria: { 'controls': 'other-container' },  data: { qa: 'applications_open_from_other' }
       %>
       <%= form.label :applications_open_from,
-            value: 'other',
+            value: 'On a specific date',
             class: 'govuk-label govuk-radios__label'
       %>
     </div>


### PR DESCRIPTION
### Context

Same as before. The new and edit applications open pages are slightly out of line with the prototype

### Changes proposed in this pull request
- Change the value of the applications_open_from label from "Other" to "On a specific date"

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
