### PR TITLE
[2582] Make labels bold on outcome page

### DIFF
--- a/app/views/courses/outcome/_form_fields.html.erb
+++ b/app/views/courses/outcome/_form_fields.html.erb
@@ -11,4 +11,5 @@
            form: form,
            legend: legend,
            key: 'qualifications',
-           field: :qualification %>
+           field: :qualification,
+           bold_labels: true %>

--- a/app/views/shared/_edit_options_radio_buttons.html.erb
+++ b/app/views/shared/_edit_options_radio_buttons.html.erb
@@ -1,4 +1,5 @@
 <% legend ||= false %>
+<% bold_labels ||= false %>
 <div
   class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[field]&.any?) %>"
   data-qa="course__<%= field %>">
@@ -20,7 +21,7 @@
         <%= form.label field,
               label,
               value: value,
-              class: 'govuk-label govuk-radios__label'
+              class: "govuk-label govuk-radios__label #{"govuk-!-font-weight-bold" if bold_labels}"
         %>
         <span id="<%= "#{field}-#{value}-help" %>" class="govuk-hint govuk-radios__hint">
           <%= help %>


### PR DESCRIPTION
### Context

Update the outcome page to match the prototype

### Changes proposed in this pull request

- Make the labels bold
- **Does not** change the ordering of the labels, that will need to happen in the edit options in manage courses backend

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x]  Tested by running locally
