### PR TITLE
[2566] Add modern languages to course creation

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -166,6 +166,8 @@ private
   def course_back_path_for(page)
     if page == :location
       back_provider_recruitment_cycle_courses_locations_path(path_params)
+    elsif page == :modern_languages
+      back_provider_recruitment_cycle_courses_modern_languages_path(path_params)
     else
       course_creation_path_for(page)
     end

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -88,6 +88,7 @@ private
           :course_age_range_in_years_other_from,
           :course_age_range_in_years_other_to,
           :goto_confirmation,
+          :language_ids,
         )
         .permit(
           :page,
@@ -176,6 +177,8 @@ private
       provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)
     when :level
       new_provider_recruitment_cycle_courses_level_path(path_params)
+    when :modern_languages
+      new_provider_recruitment_cycle_courses_modern_languages_path(path_params)
     when :apprenticeship
       new_provider_recruitment_cycle_courses_apprenticeship_path(path_params)
     when :location

--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -1,8 +1,15 @@
 module Courses
   class ModernLanguagesController < ApplicationController
-    include CourseBasicDetailConcern
     decorates_assigned :course
     before_action :build_course, only: %i[edit update]
+    before_action :build_course_params, only: [:continue]
+    include CourseBasicDetailConcern
+
+    def new
+      return unless @course.meta[:edit_options][:modern_languages].nil?
+
+      redirect_to next_step
+    end
 
     def edit
       return unless @course.meta[:edit_options][:modern_languages].nil?
@@ -34,6 +41,10 @@ module Courses
       end
     end
 
+    def current_step
+      :modern_languages
+    end
+
   private
 
     def strip_non_language_subjects
@@ -63,6 +74,11 @@ module Courses
                   .where(provider_code: params[:provider_code])
                   .find(params[:code])
                   .first
+    end
+
+    def build_course_params
+      params[:course][:subjects_ids] += params[:course][:language_ids]
+      params[:course].delete :language_ids
     end
   end
 end

--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -41,6 +41,14 @@ module Courses
       end
     end
 
+    def back
+      if @course.meta[:edit_options][:modern_languages].nil?
+        redirect_to @back_link_path
+      else
+        redirect_to new_provider_recruitment_cycle_courses_modern_languages_path(path_params)
+      end
+    end
+
     def current_step
       :modern_languages
     end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -38,7 +38,7 @@ module ViewHelper
   end
 
   def govuk_back_link_to(url)
-    govuk_link_to("Back", url, class: "govuk-back-link")
+    govuk_link_to("Back", url, class: "govuk-back-link", data: {qa: "page-back"})
   end
 
   def search_ui_url(relative_path)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -38,7 +38,7 @@ module ViewHelper
   end
 
   def govuk_back_link_to(url)
-    govuk_link_to("Back", url, class: "govuk-back-link", data: {qa: "page-back"})
+    govuk_link_to("Back", url, class: "govuk-back-link", data: { qa: "page-back" })
   end
 
   def search_ui_url(relative_path)

--- a/app/services/course_creation_step_service.rb
+++ b/app/services/course_creation_step_service.rb
@@ -32,6 +32,7 @@ class CourseCreationStepService
     %i[
       level
       subjects
+      modern_languages
       age_range
       outcome
       fee_or_salary
@@ -49,6 +50,7 @@ class CourseCreationStepService
     %i[
       level
       subjects
+      modern_languages
       age_range
       outcome
       apprenticeship

--- a/app/views/courses/modern_languages/new.html.erb
+++ b/app/views/courses/modern_languages/new.html.erb
@@ -6,7 +6,7 @@
 <%= render 'shared/errors' %>
 
 <h1 class="govuk-heading-xl">
-  Select modern languages
+  Pick modern languages
 </h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/courses/modern_languages/new.html.erb
+++ b/app/views/courses/modern_languages/new.html.erb
@@ -1,0 +1,24 @@
+<%= content_for :page_title, "Select modern languages" %>
+<% content_for :before_content do %>
+  <% course_creation_back_button(@back_link_path) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<h1 class="govuk-heading-xl">
+  Select modern languages
+</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: continue_provider_recruitment_cycle_courses_modern_languages_path(
+                    @provider.provider_code,
+                    @provider.recruitment_cycle_year
+                  ),
+                  method: :get do |form| %>
+
+      <%= render "courses/new_fields_holder", form: form, except_keys: [:modern_languages] do |fields| %>
+        <%= render 'form_fields', form: fields %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/courses/modern_languages/new.html.erb
+++ b/app/views/courses/modern_languages/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Select modern languages" %>
+<%= content_for :page_title, "Pick modern languages" %>
 <% content_for :before_content do %>
   <% course_creation_back_button(@back_link_path) %>
 <% end %>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -2,7 +2,6 @@
 <% content_for :before_content do %>
   <%= course_creation_back_button(@back_link_path) %>
 <% end %>
-
 <%= render 'shared/errors' %>
 
 <h1 class="govuk-heading-xl">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
           get "continue"
         end
         resource :modern_languages, on: :member, only: %i[new], controller: "courses/modern_languages", path: "modern-languages" do
+          get "back"
           get "continue"
         end
         resource :apprenticeship, on: :member, only: %i[new], controller: "courses/apprenticeship" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,9 @@ Rails.application.routes.draw do
         resource :subjects, on: :member, only: %i[new], controller: "courses/subjects", path: "subjects" do
           get "continue"
         end
+        resource :modern_languages, on: :member, only: %i[new], controller: "courses/modern_languages", path: "modern-languages" do
+          get "continue"
+        end
         resource :apprenticeship, on: :member, only: %i[new], controller: "courses/apprenticeship" do
           get "continue"
         end

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -64,7 +64,7 @@ feature "Access Requests", type: :feature do
         stub_api_v2_resource_collection([access_request], include: "requester")
 
         visit provider_courses_path(provider.provider_code)
-        expect { organisations_page.access_requests_link }.to raise_error(Capybara::ElementNotFound)
+        expect(organisations_page).to have_no_access_requests_link
       end
     end
   end

--- a/spec/features/courses/details_spec.rb
+++ b/spec/features/courses/details_spec.rb
@@ -83,8 +83,8 @@ feature "Course details", type: :feature do
     expect(course_details_page.edit_locations_link).to have_content(
       "Change location",
     )
-    expect(course_details_page).not_to have_manage_provider_locations_link
-    expect { course_details_page.apprenticeship }.to raise_error(Capybara::ElementNotFound)
+    expect(course_details_page).to have_no_manage_provider_locations_link
+    expect(course_details_page).to have_no_apprenticeship
     expect(course_details_page.funding).to have_content(
       "Fee paying (no salary)",
     )

--- a/spec/features/courses/modern_languages/edit_spec.rb
+++ b/spec/features/courses/modern_languages/edit_spec.rb
@@ -146,7 +146,7 @@ feature "Edit course modern languages", type: :feature do
 
       languages_page.load_with_course(course)
       languages_page.save.click
-      expect { languages_page.error_flash }.not_to raise_error
+      expect(languages_page).to have_error_flash
     end
   end
 

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+feature "new course fee or salary", type: :feature do
+  let(:new_modern_languages_page) do
+    PageObjects::Page::Organisations::Courses::NewModernLanguagesPage.new
+  end
+  let(:next_step_page) do
+    PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
+  end
+
+  let(:course) { build(:course, :new, provider: provider) }
+  let(:provider) { build(:provider) }
+  let(:modern_languages_subject) { build(:subject, :modern_languages) }
+  let(:other_subject) { build(:subject, :mathematics) }
+  let(:russian) { build(:subject, :russian) }
+  let(:modern_languages) { [russian] }
+  let(:subjects) { [modern_languages_subject] }
+  let(:course) do
+    build(:course,
+          provider: provider,
+          edit_options: {
+            subjects: subjects,
+            modern_languages: modern_languages,
+            age_range_in_years: %w[
+                11_to_16
+                11_to_18
+                14_to_19
+              ],
+          })
+  end
+  let(:recruitment_cycle) { build(:recruitment_cycle) }
+
+  before do
+    stub_omniauth(provider: provider)
+    stub_api_v2_resource(provider)
+    stub_api_v2_build_course
+    stub_api_v2_resource(recruitment_cycle)
+    stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_build_course
+
+    visit signin_path
+  end
+
+  context "with modern language selected" do
+    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id, russian.id]) }
+
+    scenario "presents the languages" do
+      visit_modern_languages
+      expect { new_modern_languages_page.language_checkbox("Russian") }.not_to raise_error
+    end
+
+    scenario "selecting a language" do
+      stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id])
+      build_course_with_selected_value_request
+      visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id] })
+      new_modern_languages_page.language_checkbox("Russian").click
+      new_modern_languages_page.continue.click
+      # Executes an additional time when rendering the next step
+      expect(build_course_with_selected_value_request).to have_been_requested.twice
+    end
+  end
+
+  context "without modern language selected" do
+    let(:modern_languages) { nil }
+    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(subjects_ids: [other_subject.id, russian.id]) }
+
+    scenario "redirects to the next step" do
+      stub_api_v2_build_course(subjects_ids: [other_subject.id])
+      build_course_with_selected_value_request
+      visit_modern_languages(course: { subjects_ids: [other_subject.id] })
+      # Executes an additional time when rendering the next step
+      expect(next_step_page).to be_displayed
+    end
+  end
+
+  def visit_modern_languages(**query_params)
+    visit new_provider_recruitment_cycle_courses_modern_languages_path(
+      provider.provider_code,
+      provider.recruitment_cycle_year,
+      query_params,
+    )
+  end
+end

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -61,7 +61,7 @@ feature "new modern language", type: :feature do
 
     scenario "presents the languages" do
       visit_modern_languages
-      expect { new_modern_languages_page.language_checkbox("Russian") }.not_to raise_error
+      expect(new_modern_languages_page).to have_no_language_checkbox("Russian")
     end
 
     scenario "selecting a language" do

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
-feature "new course fee or salary", type: :feature do
+feature "new modern language", type: :feature do
+  let(:back_new_modern_languages_page) do
+    PageObjects::Page::Organisations::Courses::BackNewModernLanguagesPage.new
+  end
+  let(:previous_step_page) do
+    PageObjects::Page::Organisations::Courses::NewSubjectsPage.new
+  end
   let(:new_modern_languages_page) do
     PageObjects::Page::Organisations::Courses::NewModernLanguagesPage.new
   end
@@ -64,8 +70,20 @@ feature "new course fee or salary", type: :feature do
       visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id] })
       new_modern_languages_page.language_checkbox("Russian").click
       new_modern_languages_page.continue.click
-      # Executes an additional time when rendering the next step
+      # When rendering the next step an additional bulid course request will
+      # fire off, so it will have been requested twice in total
       expect(build_course_with_selected_value_request).to have_been_requested.twice
+    end
+
+    scenario "does not redirect to the previous step" do
+      stub_api_v2_build_course(subjects_ids: [other_subject.id])
+      build_course_with_selected_value_request
+      back_new_modern_languages_page.load(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: recruitment_cycle.year,
+        course: {},
+      )
+      expect(new_modern_languages_page).to be_displayed
     end
   end
 
@@ -77,8 +95,18 @@ feature "new course fee or salary", type: :feature do
       stub_api_v2_build_course(subjects_ids: [other_subject.id])
       build_course_with_selected_value_request
       visit_modern_languages(course: { subjects_ids: [other_subject.id] })
-      # Executes an additional time when rendering the next step
       expect(next_step_page).to be_displayed
+    end
+
+    scenario "redirects to the previous step" do
+      stub_api_v2_build_course(subjects_ids: [other_subject.id])
+      build_course_with_selected_value_request
+      back_new_modern_languages_page.load(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: recruitment_cycle.year,
+        course: {},
+      )
+      expect(previous_step_page).to be_displayed
     end
   end
 

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -4,9 +4,6 @@ feature "new course fee or salary", type: :feature do
   let(:new_modern_languages_page) do
     PageObjects::Page::Organisations::Courses::NewModernLanguagesPage.new
   end
-  let(:previous_step_page) do
-    PageObjects::Page::Organisations::Courses::NewSubjectsPage.new
-  end
   let(:next_step_page) do
     PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
   end
@@ -44,6 +41,15 @@ feature "new course fee or salary", type: :feature do
     visit signin_path
   end
 
+  context "Page title" do
+    scenario "It displays the correct title" do
+      visit_modern_languages
+
+      expect(page.title).to start_with("Pick modern languages")
+      expect(new_modern_languages_page.title.text).to eq("Pick modern languages")
+    end
+  end
+
   context "with modern language selected" do
     let(:build_course_with_selected_value_request) { stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id, russian.id]) }
 
@@ -61,13 +67,6 @@ feature "new course fee or salary", type: :feature do
       # Executes an additional time when rendering the next step
       expect(build_course_with_selected_value_request).to have_been_requested.twice
     end
-
-    scenario "does not send the user back to the previous page" do
-      stub_api_v2_build_course(subjects_ids: [other_subject.id])
-      visit_back_modern_languages(course: { subjects_ids: [other_subject.id] })
-
-      expect(new_modern_languages_page).to be_displayed
-    end
   end
 
   context "without modern language selected" do
@@ -78,27 +77,13 @@ feature "new course fee or salary", type: :feature do
       stub_api_v2_build_course(subjects_ids: [other_subject.id])
       build_course_with_selected_value_request
       visit_modern_languages(course: { subjects_ids: [other_subject.id] })
+      # Executes an additional time when rendering the next step
       expect(next_step_page).to be_displayed
-    end
-
-    scenario "sends user back to the previous page" do
-      stub_api_v2_build_course(subjects_ids: [other_subject.id])
-      visit_back_modern_languages(course: { subjects_ids: [other_subject.id] })
-
-      expect(previous_step_page).to be_displayed
     end
   end
 
   def visit_modern_languages(**query_params)
     visit new_provider_recruitment_cycle_courses_modern_languages_path(
-      provider.provider_code,
-      provider.recruitment_cycle_year,
-      query_params,
-    )
-  end
-
-  def visit_back_modern_languages(**query_params)
-    visit back_provider_recruitment_cycle_courses_modern_languages_path(
       provider.provider_code,
       provider.recruitment_cycle_year,
       query_params,

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -4,6 +4,9 @@ feature "new course fee or salary", type: :feature do
   let(:new_modern_languages_page) do
     PageObjects::Page::Organisations::Courses::NewModernLanguagesPage.new
   end
+  let(:previous_step_page) do
+    PageObjects::Page::Organisations::Courses::NewSubjectsPage.new
+  end
   let(:next_step_page) do
     PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
   end
@@ -58,6 +61,13 @@ feature "new course fee or salary", type: :feature do
       # Executes an additional time when rendering the next step
       expect(build_course_with_selected_value_request).to have_been_requested.twice
     end
+
+    scenario "does not send the user back to the previous page" do
+      stub_api_v2_build_course(subjects_ids: [other_subject.id])
+      visit_back_modern_languages(course: { subjects_ids: [other_subject.id] })
+
+      expect(new_modern_languages_page).to be_displayed
+    end
   end
 
   context "without modern language selected" do
@@ -71,10 +81,25 @@ feature "new course fee or salary", type: :feature do
       # Executes an additional time when rendering the next step
       expect(next_step_page).to be_displayed
     end
+
+    scenario "sends user back to the previous page" do
+      stub_api_v2_build_course(subjects_ids: [other_subject.id])
+      visit_back_modern_languages(course: { subjects_ids: [other_subject.id] })
+
+      expect(previous_step_page).to be_displayed
+    end
   end
 
   def visit_modern_languages(**query_params)
     visit new_provider_recruitment_cycle_courses_modern_languages_path(
+      provider.provider_code,
+      provider.recruitment_cycle_year,
+      query_params,
+    )
+  end
+
+  def visit_back_modern_languages(**query_params)
+    visit back_provider_recruitment_cycle_courses_modern_languages_path(
       provider.provider_code,
       provider.recruitment_cycle_year,
       query_params,

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -78,7 +78,6 @@ feature "new course fee or salary", type: :feature do
       stub_api_v2_build_course(subjects_ids: [other_subject.id])
       build_course_with_selected_value_request
       visit_modern_languages(course: { subjects_ids: [other_subject.id] })
-      # Executes an additional time when rendering the next step
       expect(next_step_page).to be_displayed
     end
 

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -8,6 +8,9 @@ feature "new course", type: :feature do
   let(:new_subjects_page) do
     PageObjects::Page::Organisations::Courses::NewSubjectsPage.new
   end
+  let(:new_modern_languages) do
+    PageObjects::Page::Organisations::Courses::NewModernLanguagesPage.new
+  end
   let(:new_age_range_page) do
     PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
   end

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -121,7 +121,7 @@ feature "new course", type: :feature do
         end
       end
 
-      scenario "creates the correct course", :focus do
+      scenario "creates the correct course" do
         # This is intended to be a test which will go through the entire flow
         # and ensure that the correct page gets displayed at the end
         # with the correct course being created
@@ -243,7 +243,7 @@ feature "new course", type: :feature do
           study_mode: "full_time",
           funding_type: "fee",
           sites_ids: [site1.id],
-          applications_open_from: "2018-10-09"
+          applications_open_from: "2018-10-09",
         }
       end
 
@@ -269,7 +269,7 @@ feature "new course", type: :feature do
         visit new_provider_recruitment_cycle_courses_start_date_path(
           provider.provider_code,
           provider.recruitment_cycle_year,
-          course: course_creation_params
+          course: course_creation_params,
         )
 
         new_start_date_page.back.click
@@ -302,7 +302,7 @@ feature "new course", type: :feature do
           study_mode: "full_time",
           funding_type: "fee",
           sites_ids: [site1.id, site2.id],
-          applications_open_from: "2018-10-09"
+          applications_open_from: "2018-10-09",
         }
       end
 
@@ -329,7 +329,7 @@ feature "new course", type: :feature do
         visit new_provider_recruitment_cycle_courses_start_date_path(
           provider.provider_code,
           provider.recruitment_cycle_year,
-          course: course_creation_params
+          course: course_creation_params,
         )
 
         new_start_date_page.back.click

--- a/spec/features/courses/sites/new_spec.rb
+++ b/spec/features/courses/sites/new_spec.rb
@@ -84,7 +84,7 @@ feature "New course sites", :focus do
       end
     end
 
-    it "does not go back to the previosu step" do
+    scenario "does not go back to the previous step" do
       back_new_locations_page.load(
         provider_code: provider.provider_code,
         recruitment_cycle_year: current_recruitment_cycle.year,

--- a/spec/features/courses/sites/new_spec.rb
+++ b/spec/features/courses/sites/new_spec.rb
@@ -88,7 +88,7 @@ feature "New course sites" do
       back_new_locations_page.load(
         provider_code: provider.provider_code,
         recruitment_cycle_year: current_recruitment_cycle.year,
-        course: {}
+        course: {},
       )
       expect(new_locations_page).to be_displayed
     end
@@ -102,7 +102,7 @@ feature "New course sites" do
       back_new_locations_page.load(
         provider_code: provider.provider_code,
         recruitment_cycle_year: current_recruitment_cycle.year,
-        course: {}
+        course: {},
       )
       expect(full_or_part_time).to be_displayed
     end

--- a/spec/features/courses/sites/new_spec.rb
+++ b/spec/features/courses/sites/new_spec.rb
@@ -1,17 +1,19 @@
 require "rails_helper"
 
-feature "New course sites" do
+feature "New course sites", :focus do
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+  let(:back_new_locations_page) { PageObjects::Page::Organisations::Courses::BackNewLocationsPage.new }
   let(:new_locations_page) { PageObjects::Page::Organisations::Courses::NewLocationsPage.new }
   let(:new_entry_requirements_page) { PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new }
   let(:new_accredited_body_page) { PageObjects::Page::Organisations::Courses::NewAccreditedBodyPage.new }
   let(:site1) { build(:site, location_name: "Site one") }
   let(:site2) { build(:site, location_name: "Site two") }
   let(:site3) { build(:site, location_name: "Another site") }
+  let(:sites) { [site1, site2, site3] }
   let(:provider) do
     build(
       :provider,
-      sites: [site1, site2, site3],
+      sites: sites,
       accredited_body?: true,
       recruitment_cycle: current_recruitment_cycle,
     )
@@ -35,49 +37,74 @@ feature "New course sites" do
     new_locations_page.load(provider_code: provider.provider_code, recruitment_cycle_year: current_recruitment_cycle.year, course: {})
   end
 
-  scenario "It loads the page" do
-    expect(new_locations_page).to be_displayed
-  end
+  context "with multiple sites" do
+    scenario "It loads the page" do
+      expect(new_locations_page).to be_displayed
+    end
 
-  context "Page title" do
-    scenario "It displays the correct title" do
-      expect(page.title).to start_with("Pick the locations for this course")
-      expect(new_locations_page.title.text).to eq("Pick the locations for this course")
+    context "Page title" do
+      scenario "It displays the correct title" do
+        expect(page.title).to start_with("Pick the locations for this course")
+        expect(new_locations_page.title.text).to eq("Pick the locations for this course")
+      end
+    end
+
+    scenario "It displays the providers sites" do
+      displayed_site_names = new_locations_page.site_names.collect(&:text)
+      expect(displayed_site_names).to eq(["Another site", "Site one", "Site two"])
+    end
+
+    scenario "It builds a new course with the selected site" do
+      new_locations_page.check(site2.location_name)
+      new_locations_page.continue.click
+
+      expect(build_course_with_sites_request).to have_been_made.at_least_once
+    end
+
+    scenario "It builds a new course with two selected sites" do
+      new_locations_page.check(site1.location_name)
+      new_locations_page.check(site2.location_name)
+      new_locations_page.continue.click
+
+      expect(build_course_with_two_sites_request).to have_been_made.at_least_once
+    end
+
+    scenario "It transitions to the entry requirements page" do
+      new_locations_page.check(site2.location_name)
+      new_locations_page.continue.click
+
+      expect(new_entry_requirements_page).to be_displayed
+    end
+
+    context "with site ids already selected" do
+      let(:course) { build(:course, provider: provider, sites: [site3]) }
+
+      scenario "It pre-checks the site" do
+        expect(new_locations_page).to have_checked_field(site3.location_name)
+      end
+    end
+
+    it "does not go back to the previosu step" do
+      back_new_locations_page.load(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: current_recruitment_cycle.year,
+        course: {}
+      )
+      expect(new_locations_page).to be_displayed
     end
   end
 
-  scenario "It displays the providers sites" do
-    displayed_site_names = new_locations_page.site_names.collect(&:text)
-    expect(displayed_site_names).to eq(["Another site", "Site one", "Site two"])
-  end
+  context "with only one site" do
+    let(:full_or_part_time) { PageObjects::Page::Organisations::Courses::NewStudyModePage.new }
+    let(:sites) { [site2] }
 
-  scenario "It builds a new course with the selected site" do
-    new_locations_page.check(site2.location_name)
-    new_locations_page.continue.click
-
-    expect(build_course_with_sites_request).to have_been_made.at_least_once
-  end
-
-  scenario "It builds a new course with two selected sites" do
-    new_locations_page.check(site1.location_name)
-    new_locations_page.check(site2.location_name)
-    new_locations_page.continue.click
-
-    expect(build_course_with_two_sites_request).to have_been_made.at_least_once
-  end
-
-  scenario "It transitions to the entry requirements page" do
-    new_locations_page.check(site2.location_name)
-    new_locations_page.continue.click
-
-    expect(new_entry_requirements_page).to be_displayed
-  end
-
-  context "with site ids already selected" do
-    let(:course) { build(:course, provider: provider, sites: [site3]) }
-
-    scenario "It pre-checks the site" do
-      expect(new_locations_page).to have_checked_field(site3.location_name)
+    it "sends you to the previous step" do
+      back_new_locations_page.load(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: current_recruitment_cycle.year,
+        course: {}
+      )
+      expect(full_or_part_time).to be_displayed
     end
   end
 end

--- a/spec/features/courses/sites/new_spec.rb
+++ b/spec/features/courses/sites/new_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "New course sites", :focus do
+feature "New course sites" do
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
   let(:back_new_locations_page) { PageObjects::Page::Organisations::Courses::BackNewLocationsPage.new }
   let(:new_locations_page) { PageObjects::Page::Organisations::Courses::NewLocationsPage.new }

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -5,13 +5,19 @@ feature "New course level", type: :feature do
     PageObjects::Page::Organisations::Courses::NewSubjectsPage.new
   end
   let(:next_step_page) do
-    PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
+    PageObjects::Page::Organisations::Courses::NewModernLanguagesPage.new
   end
   let(:provider) { build(:provider) }
   let(:english) { build(:subject, :english) }
   let(:biology) { build(:subject, :biology) }
   let(:subjects) { [english, biology] }
-  let(:edit_options) { { subjects: subjects, age_range_in_years: [] } }
+  let(:edit_options) do
+    {
+      subjects: subjects,
+      age_range_in_years: [],
+      modern_languages: [build(:subject, :russian)],
+    }
+  end
   let(:course) do
     build(:course,
           :new,

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -9,7 +9,7 @@ feature "View helpers", type: :helper do
 
   describe "#govuk_back_link_to" do
     it "returns an anchor tag with the govuk-back-link class" do
-      expect(helper.govuk_back_link_to("https://localhost:44364/organisations/A0")).to eq("<a class=\"govuk-back-link\" href=\"https://localhost:44364/organisations/A0\">Back</a>")
+      expect(helper.govuk_back_link_to("https://localhost:44364/organisations/A0")).to eq("<a class=\"govuk-back-link\" data-qa=\"page-back\" href=\"https://localhost:44364/organisations/A0\">Back</a>")
     end
   end
 

--- a/spec/services/course_creation_step_service_spec.rb
+++ b/spec/services/course_creation_step_service_spec.rb
@@ -28,6 +28,14 @@ describe CourseCreationStepService do
       let(:sites) { [build(:site), build(:site)] }
       let(:provider) { build(:provider, accredited_body?: false, sites: sites) }
 
+      context "Current step: Subjects" do
+        include_examples "next step", :subjects, :modern_languages
+      end
+
+      context "Current step: Modern languages" do
+        include_examples "next step", :modern_languages, :age_range
+      end
+
       context "Current step: Outcome" do
         include_examples "next step", :outcome, :fee_or_salary
       end
@@ -61,12 +69,17 @@ describe CourseCreationStepService do
       let(:level) { "primary" }
       let(:sites) { [build(:site), build(:site)] }
       let(:provider) { build(:provider, accredited_body?: true, sites: sites) }
-      context "Current step: Level" do
-        include_examples "next step", :level, :subjects
-      end
 
       context "Current step: Subjects" do
-        include_examples "next step", :subjects, :age_range
+        include_examples "next step", :subjects, :modern_languages
+      end
+
+      context "Current step: Modern languages" do
+        include_examples "next step", :modern_languages, :age_range
+      end
+
+      context "Current step: Level" do
+        include_examples "next step", :level, :subjects
       end
 
       context "Current step: Age range" do
@@ -138,6 +151,14 @@ describe CourseCreationStepService do
       let(:level) { "primary" }
       let(:provider) { build(:provider, accredited_body?: false) }
 
+      context "Current step: Modern languages" do
+        include_examples "previous step", :modern_languages, :subjects
+      end
+
+      context "Current step: Age range" do
+        include_examples "previous step", :age_range, :modern_languages
+      end
+
       context "Current step: Fee or salary" do
         include_examples "previous step", :fee_or_salary, :outcome
       end
@@ -171,8 +192,12 @@ describe CourseCreationStepService do
         include_examples "previous step", :subjects, :level
       end
 
+      context "Current step: Modern languages" do
+        include_examples "previous step", :modern_languages, :subjects
+      end
+
       context "Current step: Age range" do
-        include_examples "previous step", :age_range, :subjects
+        include_examples "previous step", :age_range, :modern_languages
       end
 
       context "Current step: Outcome" do

--- a/spec/site_prism/page_objects/page/organisations/course_base.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_base.rb
@@ -11,7 +11,7 @@ module PageObjects
         element :flash, ".govuk-success-summary"
         element :error_flash, ".govuk-error-summary"
         element :warning_message, "[data-copy-course=warning]"
-        element :back, ".govuk-back-link"
+        element :back, '[data-qa="page-back"]'
         element :success_summary, ".govuk-success-summary"
 
         section :copy_content, PageObjects::Section::CopyContentSection

--- a/spec/site_prism/page_objects/page/organisations/courses/back_new_locations_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/back_new_locations_page.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class BackNewLocationsPage < NewCourseBase
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/locations/back{?query*}"
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/back_new_modern_languages_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/back_new_modern_languages_page.rb
@@ -2,7 +2,7 @@ module PageObjects
   module Page
     module Organisations
       module Courses
-        class NewModernLanguagesPage < NewCourseBase
+        class BackNewModernLanguagesPage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/modern-languages/back{?query*}"
         end
       end

--- a/spec/site_prism/page_objects/page/organisations/courses/back_new_modern_languages_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/back_new_modern_languages_page.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class NewModernLanguagesPage < NewCourseBase
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/modern-languages/back{?query*}"
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_course_base.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_course_base.rb
@@ -6,6 +6,7 @@ module PageObjects
           element :success_summary, ".govuk-success-summary"
           element :error_flash, ".govuk-error-summary"
           element :continue, '[data-qa="course__save"]'
+          element :back, '[data-qa="page-back"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_modern_languages_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_modern_languages_page.rb
@@ -10,6 +10,10 @@ module PageObjects
           def language_checkbox(name)
             languages_fields.find("[data-qa=\"checkbox_language_#{name}\"]")
           end
+
+          def has_no_language_checkbox?(name)
+            languages_fields.has_css?("[data-qa=\"checkbox_language_#{name}\"]")
+          end
         end
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_modern_languages_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_modern_languages_page.rb
@@ -1,0 +1,17 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        class NewModernLanguagesPage < NewCourseBase
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/modern-languages/new{?query*}"
+
+          element :languages_fields, '[data-qa="course__languages"]'
+
+          def language_checkbox(name)
+            languages_fields.find("[data-qa=\"checkbox_language_#{name}\"]")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
As it stands standard subjects can be added during course creation but this neglects modern language subjects which require an additional page and set of functionality.

### Changes proposed in this pull request
Add the modern language subjects page to course creation and insert it into the workflow. Also adds the back endpoint to decide whether or not to skip the step when going backwards.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
