### PR TITLE
2589 start date style fixes

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -218,6 +218,14 @@ class CourseDecorator < ApplicationDecorator
     subjects.map { |subject| subject["id"] }.include?(subject_to_find["id"])
   end
 
+  def return_start_date
+    if start_date.present?
+      start_date
+    else
+      "September #{Settings.current_cycle}"
+    end
+  end
+
 private
 
   def not_on_find

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -174,7 +174,9 @@
                 Course starts
               </dt>
               <dd class="govuk-summary-list__value" data-qa="course__start_date">
-                <%= l(course.start_date&.to_date, format: :short) %>
+                <% if course.start_date.present? %>
+                  <%= l(course.start_date&.to_date, format: :short) %>
+                <% end %>
               </dd>
               <dd class="govuk-summary-list__actions">
                 <%= course_creation_change_button(

--- a/app/views/courses/start_date/_form_fields.html.erb
+++ b/app/views/courses/start_date/_form_fields.html.erb
@@ -1,4 +1,4 @@
 <%= render "shared/form_field",
   form: form, field: :start_date, label: "Course start date" do |field, options| %>
-  <%= form.select field, @course.meta["edit_options"]["start_dates"], {}, options.merge(class: 'govuk-select') %>
+  <%= form.select field, options_for_select(@course.meta["edit_options"]["start_dates"], course.return_start_date), { include_blank: true }, data: { qa: 'start_date' }, class: 'govuk-select'%>
 <% end %>

--- a/app/views/courses/start_date/edit.html.erb
+++ b/app/views/courses/start_date/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Specify course start date – #{course.name_and_code}" %>
+<%= content_for :page_title, "When does the course start?}" %>
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
@@ -6,7 +6,7 @@
 <%= render 'shared/errors' %>
 
 <h1 class="govuk-heading-xl">
-  When does the course start
+  When does the course start?
 </h1>
 
 <div class="govuk-grid-row">

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Pick a start date" %>
+<%= content_for :page_title, "When does the course start?" %>
 <% content_for :before_content do %>
   <%= course_creation_back_button(@back_link_path) %>
 <% end %>
@@ -6,7 +6,7 @@
 <%= render 'shared/errors' %>
 
 <h1 class="govuk-heading-xl">
-  When does the course start
+  When does the course start?
 </h1>
 
 <div class="govuk-grid-row">

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -15,7 +15,7 @@ describe CourseDecorator do
           name: "Mathematics",
           qualification: "pgce_with_qts",
           study_mode: "full_time",
-          start_date: Time.zone.local(2019),
+          start_date: start_date,
           site_statuses: [site_status],
           provider: provider,
           accrediting_provider: provider,
@@ -25,7 +25,7 @@ describe CourseDecorator do
           last_published_at: "2019-03-05T14:42:34Z",
           recruitment_cycle: current_recruitment_cycle
   end
-
+  let(:start_date) { Time.zone.local(2019) }
   let(:site) { build(:site) }
   let(:site_status) do
     build(:site_status, :full_time_and_part_time, site: site)
@@ -518,6 +518,21 @@ describe CourseDecorator do
         it "returns true" do
           expect(decorated_course.has_early_career_payments?).to eq(true)
         end
+      end
+    end
+  end
+
+  describe "return_start_date" do
+    context "when the course has a start date" do
+      it "should return the course's start date" do
+        expect(decorated_course.return_start_date).to eq(course.start_date)
+      end
+    end
+
+    context 'when the course has no start date' do
+      let(:start_date) { nil }
+      it "should return the September of the current cycle" do
+        expect(decorated_course.return_start_date).to eq("September #{Settings.current_cycle}")
       end
     end
   end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -529,7 +529,7 @@ describe CourseDecorator do
       end
     end
 
-    context 'when the course has no start date' do
+    context "when the course has no start date" do
       let(:start_date) { nil }
       it "should return the September of the current cycle" do
         expect(decorated_course.return_start_date).to eq("September #{Settings.current_cycle}")

--- a/spec/features/courses/start_date/edit_spec.rb
+++ b/spec/features/courses/start_date/edit_spec.rb
@@ -61,7 +61,7 @@ feature "Edit course start date", type: :feature do
         start_date: "October 2019",
         content_status: "draft",
         edit_options: {
-          start_dates: ["October 2019", "November 2019"],
+          start_dates: ["September 2019", "October 2019", "November 2019"],
           show_start_date: true,
         },
         provider: provider,
@@ -79,6 +79,10 @@ feature "Edit course start date", type: :feature do
       expect(start_date_page).to be_displayed
       click_on "Back"
       expect(course_details_page).to be_displayed
+    end
+
+    scenario "defaults to the current value" do
+      expect(start_date_page.start_date_field.value).to eq "October 2019"
     end
 
     scenario "presents a choice for each start date" do

--- a/spec/features/courses/start_date/new_spec.rb
+++ b/spec/features/courses/start_date/new_spec.rb
@@ -4,7 +4,7 @@ feature "New course start date", type: :feature do
   let(:new_start_date_page) { PageObjects::Page::Organisations::CourseStartDate.new }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, provider: provider) }
+  let(:course) { build(:course, provider: provider, start_date: nil) }
 
   before do
     stub_omniauth
@@ -13,13 +13,21 @@ feature "New course start date", type: :feature do
     stub_api_v2_resource(recruitment_cycle)
     stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_build_course
-    stub_api_v2_build_course(start_date: "September #{Settings.current_cycle}")
+    stub_api_v2_build_course(start_date: "October #{Settings.current_cycle}")
+  end
+
+  scenario "default to September of the current recruitment cycle" do
+    build_course_with_default_request = stub_api_v2_build_course(start_date: "September #{Settings.current_cycle}")
+    visit_new_start_date_page
+
+    new_start_date_page.continue.click
+    expect(build_course_with_default_request).to have_been_made.times(2)
   end
 
   scenario "choose course start date" do
     visit_new_start_date_page
 
-    select "September #{Settings.current_cycle}"
+    select "October #{Settings.current_cycle}"
     click_on "Continue"
 
     expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
@@ -28,7 +36,7 @@ feature "New course start date", type: :feature do
   scenario "sends user back to course confirmation" do
     visit_new_start_date_page(goto_confirmation: true)
 
-    select "September #{Settings.current_cycle}"
+    select "October #{Settings.current_cycle}"
     new_start_date_page.continue.click
 
     expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)


### PR DESCRIPTION
### Context
Style fixes for the start date page to bring it in line with the prototype

### Changes proposed in this pull request
- Default drop-down to the current start date or the Sept of the next cycle.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
