### PR TITLE
Setup google maps on course preview for locations

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -4,7 +4,7 @@ class Site < Base
   has_one :site_status
 
   properties :code, :location_name, :address1, :address2, :address3
-  properties :address4, :postcode
+  properties :address4, :postcode, :latitude, :longitude
 
   REGIONS = [
     ["London", :london],

--- a/app/views/courses/preview/_apply.html.erb
+++ b/app/views/courses/preview/_apply.html.erb
@@ -1,3 +1,7 @@
+<%= content_for :head do %>
+  <script src="https://maps.googleapis.com/maps/api/js?key=<%= Settings.google.maps_api_key %>&callback=initLocationsMap" async defer></script>
+<% end %>
+
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-apply">Apply</h2>
   <p class="govuk-body">
@@ -25,6 +29,8 @@
   <h3 class="govuk-heading-m">Choose a training location</h3>
   <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>
 
+  <div id="locations-map" class="app-google-map" data-qa="course__locations_map"></div>
+
   <table class="govuk-table app-table--vertical-align-middle" data-qa="course__choose_a_training_location">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
@@ -50,3 +56,18 @@
     </tbody>
   </table>
 </div>
+
+<script>
+  window.trainingLocations = [
+    <% course.preview_site_statuses.each do |site_status| %>
+      {
+        "code": "<%= site_status.site.code %>",
+        "name": "<%= site_status.site.location_name %>",
+        "lat": "<%= site_status.site.latitude.present? ? site_status.site.latitude : @provider.latitude %>",
+        "lng": "<%= site_status.site.longitude.present? ? site_status.site.longitude : @provider.longitude %>",
+        "address": "<%= site_status.site.full_address %>",
+        "vacancies": "<%= site_status.has_vacancies? ? "" : "No vacancies" %>"
+      },
+    <% end %>
+  ]
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,7 @@
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-WCZDP65');
     </script>
+    <%= yield(:head) %>
   </head>
 
   <body class="govuk-template__body <%= content_for(:body_classes) %>">

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -7,8 +7,11 @@ import CookieMessage from "scripts/cookie-banner";
 import FormCheckLeave from "scripts/form-check-leave";
 import { triggerFormAnalytics } from "scripts/form-error-tracking";
 import initAutocomplete from "scripts/autocomplete";
+import initLocationsMap from "scripts/locations-map";
 
 initAll();
+
+window.initLocationsMap = initLocationsMap;
 
 var $cookieMessage = document.querySelector('[data-module="cookie-message"]');
 new CookieMessage($cookieMessage).init();

--- a/app/webpacker/scripts/locations-map.js
+++ b/app/webpacker/scripts/locations-map.js
@@ -1,0 +1,98 @@
+import createPopupClass from "./map-popup";
+
+const initLocationsMap = () => {
+  const $map = document.getElementById("locations-map");
+  const trainingLocations = window.trainingLocations
+    .filter(({lat, lng}) => lat !== "" && lng !== "")
+    .map(location => {
+      location.lat = parseFloat(location.lat);
+      location.lng = parseFloat(location.lng);
+      return location;
+    })
+
+  if (trainingLocations.length === 0) {
+    console.error("Failed to initialise map: center is impossible to display, because none of the locations have a lat/lng.");
+    $map.style.display = 'none';
+    return;
+  }
+
+  const Popup = createPopupClass();
+  const bounds = new google.maps.LatLngBounds();
+
+  const centerLat = trainingLocations[0].lat;
+  const centerLng = trainingLocations[0].lng;
+
+  const map = new google.maps.Map($map, {
+    mapTypeId: google.maps.MapTypeId.ROADMAP,
+    mapTypeControl: false,
+    scaleControl: false,
+    streetViewControl: false,
+    rotateControl: false,
+    fullscreenControl: true,
+    fullscreenControlOptions: {
+      position: google.maps.ControlPosition.RIGHT_BOTTOM
+    },
+    zoom: 11,
+    center: {
+      lat: centerLat,
+      lng: centerLng
+    },
+    styles: [
+      {
+        featureType: "poi.business",
+        stylers: [
+          {
+            visibility: "off"
+          }
+        ]
+      },
+      {
+        featureType: "poi.park",
+        elementType: "labels.text",
+        stylers: [
+          {
+            visibility: "off"
+          }
+        ]
+      }
+    ]
+  });
+
+  const locations = window.trainingLocations;
+
+  for (let i = 0, length = locations.length; i < length; i++) {
+    const location = locations[i];
+    const latLng = new google.maps.LatLng(location.lat, location.lng);
+
+    const closedContent = document.createElement("div");
+    closedContent.innerHTML = location.name;
+
+    const openContent = document.createElement("div");
+    if (location.vacancies) {
+      openContent.insertAdjacentHTML(
+        "beforeend",
+        `<div class="govuk-tag govuk-tag--no-content govuk-!-margin-bottom-2">${ location.vacancies }</div>`
+      );
+    }
+    if (location.address) {
+      openContent.insertAdjacentHTML(
+        "beforeend",
+        `<p class="govuk-body">${location.address}</p>`
+      );
+    }
+
+    const popup = new Popup(latLng, closedContent, openContent);
+    popup.setMap(map);
+
+    // Extend the bounds by the locations so we get a decent number as part of the first view.
+    bounds.extend(latLng);
+  }
+
+  // Use provider address to center and zoom when only one location
+  if (locations.length > 1) {
+    map.fitBounds(bounds);
+    map.panToBounds(bounds);
+  }
+};
+
+export default initLocationsMap;

--- a/app/webpacker/scripts/map-popup.js
+++ b/app/webpacker/scripts/map-popup.js
@@ -1,0 +1,101 @@
+// Based on: https://developers.google.com/maps/documentation/javascript/examples/overlay-popup
+
+const createPopupClass = () => {
+  const panToWithOffset = function(map, latlng, offsetX, offsetY) {
+    const ov = new google.maps.OverlayView();
+    ov.onAdd = function() {
+      const proj = this.getProjection();
+      const aPoint = proj.fromLatLngToContainerPixel(latlng);
+      aPoint.x = aPoint.x + offsetX;
+      aPoint.y = aPoint.y + offsetY;
+      map.panTo(proj.fromContainerPixelToLatLng(aPoint));
+    };
+    ov.draw = function() {};
+    ov.setMap(map);
+  };
+
+  const Popup = function(position, closedContent, openContent) {
+    this.position = position;
+    const content = document.createElement("div");
+    content.classList.add("map-marker__content");
+    content.insertAdjacentHTML(
+      "beforeend",
+      '<button class="map-marker__close">&times;<span class="govuk-visually-hidden">Close this popup</span></button>'
+    );
+    closedContent.classList.add("map-marker__title");
+    openContent.classList.add("map-marker__body");
+    content.appendChild(closedContent);
+    content.appendChild(openContent);
+
+    this.anchor = document.createElement("div");
+    this.anchor.classList.add("map-marker");
+    this.anchor.appendChild(content);
+
+    this.stopEventPropagation();
+
+    const $closeButton = content.querySelector(".map-marker__close");
+    $closeButton.addEventListener("click", e => {
+      this.closeOpenPopups();
+    });
+
+    closedContent.addEventListener("click", e => {
+      panToWithOffset(this.getMap(), this.position, 0, -70);
+      this.closeOpenPopups();
+      this.anchor.classList.toggle("open");
+      e.stopPropagation();
+    });
+  };
+
+  // NOTE: google.maps.OverlayView is only defined once the Maps API has
+  // loaded. That is why Popup is defined inside createPopupClass().
+  Popup.prototype = Object.create(google.maps.OverlayView.prototype);
+
+  // Called when the popup is added to the map.
+  Popup.prototype.onAdd = function() {
+    this.getPanes().floatPane.appendChild(this.anchor);
+  };
+
+  // Called when the popup is removed from the map.
+  Popup.prototype.onRemove = function() {
+    if (this.anchor.parentElement) {
+      this.anchor.parentElement.removeChild(this.anchor);
+    }
+  };
+
+  // Called when the popup needs to draw itself.
+  Popup.prototype.draw = function() {
+    const divPosition = this.getProjection().fromLatLngToDivPixel(this.position);
+    // Hide the popup when it is far out of view.
+    const display = Math.abs(divPosition.x) < 4000 && Math.abs(divPosition.y) < 4000 ? "block" : "none";
+
+    if (display === "block") {
+      this.anchor.style.left = divPosition.x + "px";
+      this.anchor.style.top = divPosition.y + "px";
+    }
+    if (this.anchor.style.display !== display) {
+      this.anchor.style.display = display;
+    }
+  };
+
+  Popup.prototype.closeOpenPopups = () => {
+    const $anchors = document.querySelectorAll(".map-marker.open");
+    for (let i = 0; i < $anchors.length; i++) {
+      $anchors[i].classList.remove("open");
+    }
+  };
+
+  // Stops clicks/drags from bubbling up to the map.
+  Popup.prototype.stopEventPropagation = function() {
+    const anchor = this.anchor;
+    anchor.style.cursor = "auto";
+    ["click", "dblclick", "contextmenu", "wheel", "mousedown", "touchstart", "pointerdown"].forEach(function(event) {
+      anchor.addEventListener(event, function(e) {
+        e.stopPropagation();
+      });
+    });
+  };
+
+  return Popup;
+};
+
+export default createPopupClass;

--- a/app/webpacker/stylesheets/_map.scss
+++ b/app/webpacker/stylesheets/_map.scss
@@ -1,0 +1,107 @@
+.map-marker {
+  height: 0;
+  position: absolute;
+  width: 200px;
+
+  &:after {
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+    border-top: 8px solid govuk-colour("white");
+    bottom: 0;
+    content: "";
+    height: 0;
+    left: 0;
+    position: absolute;
+    top: 0;
+    transform: translate(-50%, -1px);
+    width: 0;
+    z-index: 1;
+  }
+
+  &__close {
+    background: none;
+    border: none;
+    color: govuk-colour("black");
+    cursor: pointer;
+    display: none;
+    font-size: 25px;
+    height: 30px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 30px;
+    z-index: 1;
+  }
+
+  &__title {
+    @include govuk-font($size: 14, $line-height: 1.2, $weight: bold);
+    cursor: pointer;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__content {
+    background-color: govuk-colour("white");
+    border: 1px solid $govuk-border-colour;
+    box-shadow: 0 1px 2px 1px rgba(govuk-colour("black"), 0.2);
+    left: 0;
+    max-height: 60px;
+    max-width: 120px;
+    padding: govuk-spacing(1);
+    position: absolute;
+    top: 0;
+    transform: translate(-50%, -100%);
+    overflow-x: hidden;
+    z-index: 1;
+  }
+
+  &__body {
+    display: none;
+    position: relative;
+
+    @include mq($from: desktop) {
+      min-width: 300px;
+    }
+  }
+
+  &.open {
+    z-index: 2;
+
+    .map-marker__content {
+      max-width: none;
+      max-height: none;
+      padding: govuk-spacing(2);
+    }
+
+    .map-marker__title {
+      @include govuk-font($size: 19, $line-height: 1.5, $weight: bold);
+      @include govuk-responsive-margin(2, "bottom");
+      padding-right: 20px;
+    }
+
+    .map-marker__body {
+      display: block;
+    }
+
+    .map-marker__close {
+      display: inline-block;
+    }
+  }
+
+  .govuk-heading-s {
+    @include govuk-responsive-margin(2, "bottom");
+    padding-right: 20px;
+  }
+
+  .govuk-body,
+  .govuk-list {
+    @include govuk-font($size: 16, $line-height: 1.5);
+    @include govuk-responsive-margin(2, "bottom");
+  }
+
+  .govuk-list {
+    margin-bottom: -10px;
+  }
+}

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -23,6 +23,7 @@ $button-colour: #00823b;
 @import "warning-summary";
 @import "definition-list";
 @import "environments";
+@import "map";
 
 .app-text-decoration-underline-dotted {
   text-decoration: underline dotted;
@@ -131,4 +132,15 @@ wbr:after {
 .app-table--vertical-align-middle .govuk-table__header,
 .app-table--vertical-align-middle .govuk-table__cell {
   vertical-align: middle;
+}
+
+.app-google-map {
+  display: none;
+
+  .js-enabled & {
+    display: block;
+    margin-bottom: govuk-spacing(6);
+    padding-bottom: 66.6%;
+    width: 100%;
+  }
 }

--- a/azure/template.json
+++ b/azure/template.json
@@ -100,6 +100,12 @@
         "description": "Auth secret for manage backend."
       }
     },
+    "settingsGoogleMapsAPIKey": {
+      "type": "string",
+      "metadata": {
+        "description": "API Key for Google Maps"
+      }
+    },
     "sentryDSN": {
       "type": "string",
       "metadata": {
@@ -247,6 +253,10 @@
               {
                 "name": "SETTINGS__MANAGE_BACKEND__SECRET",
                 "value": "[parameters('settingsManageBackendSecret')]"
+              },
+              {
+                "name": "SETTINGS__GOOGLE_MAPS_API_KEY",
+                "value": "[parameters('settingsGoogleMapsAPIKey')]"
               },
               {
                 "name": "SENTRY_DSN",

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -59,3 +59,5 @@ logstash:
   port: # Our port here
   ssl_enable: true
 log_level: info
+google:
+  maps_api_key: replace_me

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -23,6 +23,8 @@ FactoryBot.define do
     address3 { nil }
     address4 { nil }
     postcode { nil }
+    latitude { nil }
+    longitude { nil }
     recruitment_cycle_year { "2019" }
     last_published_at { DateTime.new(2019).utc.iso8601 }
     content_status { "Published" }

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -12,6 +12,8 @@ FactoryBot.define do
     address3 { nil }
     address4 { nil }
     postcode { nil }
+    latitude { nil }
+    longitude { nil }
     recruitment_cycle_year { Settings.current_cycle }
 
     after :build do |course, evaluator|

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -220,6 +220,8 @@ feature "Preview course", type: :feature do
         .to have_selector("tbody tr:nth-child(#{index + 1}) td", text: has_vacancies_string)
     end
 
+    expect(preview_course_page).to have_locations_map
+
     expect(preview_course_page).to have_course_advice
   end
 

--- a/spec/site_prism/page_objects/page/organisations/course_preview.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_preview.rb
@@ -39,6 +39,7 @@ module PageObjects
         element :course_advice, "#section-advice"
         element :course_apply, "#section-apply"
         element :choose_a_training_location_table, "[data-qa=course__choose_a_training_location]"
+        element :locations_map, "[data-qa=course__locations_map]"
       end
     end
   end


### PR DESCRIPTION
### Context
Maps on course#preview

### Changes proposed in this pull request
Add google map for locations on course#preview to match the course page on FIND (search and compare ui)

### Guidance to review
Any course#preview page i.e. `/organisations/XXX/2020/courses/XXXX/preview`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
