### PR TITLE
[2633] - Fix Rspec formatting on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,12 +32,7 @@ steps:
     arguments: '--cache-from $(IMAGE_NAME):latest'
     addDefaultLabels: false
 
-- bash: |
-    docker run --rm $(IMAGE_NAME) rails parallel:spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
-    test_result=$?
-    cat rspec-results.xml
-    sed -i '$d;1,5d' rspec-results.xml
-    if [ "$test_result" == "0" ] ; then true ; else false ; fi
+- script: docker run --rm $(IMAGE_NAME) rake "parallel:spec[,,--format progress --format RspecJunitFormatter --out rspec-results.xml --no-profile]"
   displayName: 'Run tests'
 
 - task: Docker@1


### PR DESCRIPTION
### Context
Correction to Rspec formatting options on CI. At the moment it's just spitting out XML rather than just pretty printing results

### Before
<img width="1159" alt="xml" src="https://user-images.githubusercontent.com/5256922/70034215-bd218100-15a8-11ea-881d-c958976926ed.png">

### After
Output now pretty printing. Note also CI fails if test fails
<img width="1170" alt="failing" src="https://user-images.githubusercontent.com/5256922/70035482-cf9cba00-15aa-11ea-9c59-6c8d9093bd41.png">


- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
