### PR TITLE
[2590] Confirmation page updates

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -25,6 +25,7 @@ class CoursesController < ApplicationController
     build_course_from_params
 
     if @course.save
+      flash[:success] = { title: "Your course has been created", body: "Add the rest of your details and publish the course, so that candidates can find and apply to it." }
       redirect_to(
         provider_recruitment_cycle_course_path(
           @course.provider_code,

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -25,7 +25,7 @@ class CoursesController < ApplicationController
     build_course_from_params
 
     if @course.save
-      flash[:success] = { title: "Your course has been created", body: "Add the rest of your details and publish the course, so that candidates can find and apply to it." }
+      flash[:success_with_body] = { title: "Your course has been created", body: "Add the rest of your details and publish the course, so that candidates can find and apply to it." }
       redirect_to(
         provider_recruitment_cycle_course_path(
           @course.provider_code,

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -83,9 +83,6 @@ class CoursesController < ApplicationController
   end
 
   def show
-    @published = flash[:success]
-    flash.delete(:success)
-
     @errors = flash[:error_summary]
     flash.delete(:error_summary)
   end

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -175,13 +175,13 @@
               </dd>
             </div>
 
-            <% if !@provider.accredited_body? %>
+            <% unless @provider.accredited_body? %>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
                   Accredited body
                 </dt>
                 <dd class="govuk-summary-list__value" data-qa="course__accredited_body">
-                  <%= course.accrediting_provider&.provider_name %>
+                  <%= course.accrediting_provider.provider_name %>
                 </dd>
                 <dd class="govuk-summary-list__actions">
                   <%= course_creation_change_button(

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -162,7 +162,11 @@
                 Applications open
               </dt>
               <dd class="govuk-summary-list__value" data-qa="course__application_open_from">
+              <% if course.applications_open_from == @recruitment_cycle.application_start_date %>
+                As soon as the course is on Find (recommended)
+              <% else %>
                 <%= l(course.applications_open_from&.to_date) %>
+              <% end %>
               </dd>
               <dd class="govuk-summary-list__actions">
                 <%= course_creation_change_button(

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -57,7 +57,11 @@
                 <%= course.sorted_subjects %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                  Change<span class="govuk-visually-hidden"> Subject</span>
+                <%= course_creation_change_button(
+                  "subjects",
+                  "subjects",
+                  :new_provider_recruitment_cycle_courses_subjects_path
+                ) %>
               </dd>
             </div>
 

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -175,6 +175,24 @@
               </dd>
             </div>
 
+            <% if !@provider.accredited_body? %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Accredited body
+                </dt>
+                <dd class="govuk-summary-list__value" data-qa="course__accredited_body">
+                  <%= course.accrediting_provider&.provider_name %>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                  <%= course_creation_change_button(
+                    "accredited body",
+                    "accredited_body",
+                    :new_provider_recruitment_cycle_courses_accredited_body_path
+                  ) %>
+                </dd>
+              </div>
+            <% end %>
+
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
                 Applications open

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -97,21 +97,39 @@
               </dd>
             </div>
 
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Apprenticeship
-              </dt>
-              <dd class="govuk-summary-list__value" data-qa="course__apprenticeship">
-                <%= course.apprenticeship? %>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <%= course_creation_change_button(
-                  "apprenticeship",
-                  "apprenticeship",
-                  :new_provider_recruitment_cycle_courses_apprenticeship_path
-                ) %>
-              </dd>
-            </div>
+            <% if @provider.accredited_body? %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Apprenticeship
+                </dt>
+                <dd class="govuk-summary-list__value" data-qa="course__apprenticeship">
+                  <%= course.apprenticeship? %>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                  <%= course_creation_change_button(
+                    "apprenticeship",
+                    "apprenticeship",
+                    :new_provider_recruitment_cycle_courses_apprenticeship_path
+                  ) %>
+                </dd>
+              </div>
+            <% else %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Fee or Salary
+                </dt>
+                <dd class="govuk-summary-list__value" data-qa="course__fee_or_salary">
+                  <%= course.funding %>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                  <%= course_creation_change_button(
+                    "fee or salary",
+                    "fee_or_salary",
+                    :new_provider_recruitment_cycle_courses_fee_or_salary_path
+                  ) %>
+                </dd>
+              </div>
+            <% end %>
 
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@errors.present? ? "Error: " : ""}New course" %>
+<%= content_for :page_title, "Check your answers before confirming" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -24,14 +24,6 @@
   </div>
 <% end %>
 
-<% if @published.present? %>
-  <div class="govuk-success-summary" aria-labelledby="success-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="success">
-    <h2 class="govuk-success-summary__title" id="success-summary-title">
-      <%= @published %>
-    </h2>
-  </div>
-<% end %>
-
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.description %></span>
   <%= course.name_and_code %>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-form-group">
-  <%= form.label :master_subject_id, 'Subject', class: 'govuk-label' %>
+  <%= form.label :master_subject_id, subject_input_label(@course), class: 'govuk-label' %>
   <%= form.select :master_subject_id, options_for_select(course.selectable_subjects, @course.subjects.first&.id), { include_blank: true }, data: { qa: 'course__subjects' }, class: "govuk-select" %>
 </div>
 

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -10,26 +10,15 @@
 </h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
-                  url: continue_provider_recruitment_cycle_courses_subjects_path(
+    <%= form_with url: continue_provider_recruitment_cycle_courses_subjects_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
-      <%= render 'shared/course_creation_hidden_fields',
-        form: form,
-        course_creation_params: @course_creation_params,
-        except_keys: []
-      %>
 
-      <div class="govuk-form-group">
-        <label class="govuk-label"><%= subject_input_label(@course) %></label>
-        <%= render 'form_fields', form: form %>
-      </div>
-
-      <%= form.submit "Continue",
-                      class: "govuk-button",
-                      data: { qa: 'course__save' } %>
+      <%= render "courses/new_fields_holder", form: form, except_keys: [] do |fields| %>
+        <%= render 'form_fields', form: fields %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -5,7 +5,12 @@
         <% if key == "error" %>
           <h3 class="govuk-<%= key %>-summary__title" id="<%= key %>-summary-heading" data-error-message="<%= value %>"><%= value %></h3>
         <% else %>
-          <h3 class="govuk-<%= key %>-summary__title" id="<%= key %>-summary-heading"><%= value %></h3>
+          <% if value.is_a?(Hash) %>
+            <h3 class="govuk-<%= key %>-summary__title" id="<%= key %>-summary-heading" data-qa="flash__<%= key %>__title"><%= value["title"] %></h3>
+            <p class="govuk-body" id="<%= key %>-summary-body"data-qa="flash__<%= key %>__body"><%= value["body"] %></h3>
+          <% else %>
+            <h3 class="govuk-<%= key %>-summary__title" id="<%= key %>-summary-heading"><%= value %></h3>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,18 +1,20 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <% flash.each do |key, value| %>
-      <div class="govuk-<%= key %>-summary" role="alert" aria-labelledby="<%= key %>-summary-heading" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="<%= key %>">
         <% if key == "error" %>
-          <h3 class="govuk-<%= key %>-summary__title" id="<%= key %>-summary-heading" data-error-message="<%= value %>"><%= value %></h3>
+          <div class="govuk-<%= key %>-summary" role="alert" aria-labelledby="<%= key %>-summary-heading" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="<%= key %>">
+            <h3 class="govuk-<%= key %>-summary__title" id="<%= key %>-summary-heading" data-error-message="<%= value %>"><%= value %></h3>
+          </div>
+        <% elsif key == "success_with_body" %>
+          <div class="govuk-success-summary" role="alert" aria-labelledby="success-summary-heading" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="<%= key %>">
+            <h3 class="govuk-success-summary__title" id="success-summary-heading" data-qa="flash__success__title"><%= value["title"] %></h3>
+            <p class="govuk-body" id="success-summary-body"data-qa="flash__success__body"><%= value["body"] %></h3>
+          </div>
         <% else %>
-          <% if value.is_a?(Hash) %>
-            <h3 class="govuk-<%= key %>-summary__title" id="<%= key %>-summary-heading" data-qa="flash__<%= key %>__title"><%= value["title"] %></h3>
-            <p class="govuk-body" id="<%= key %>-summary-body"data-qa="flash__<%= key %>__body"><%= value["body"] %></h3>
-          <% else %>
+          <div class="govuk-<%= key %>-summary" role="alert" aria-labelledby="<%= key %>-summary-heading" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="<%= key %>">
             <h3 class="govuk-<%= key %>-summary__title" id="<%= key %>-summary-heading"><%= value %></h3>
-          <% end %>
+          </div>
         <% end %>
-      </div>
     <% end %>
   </div>
 </div>

--- a/spec/features/courses/age_range_in_years/new_spec.rb
+++ b/spec/features/courses/age_range_in_years/new_spec.rb
@@ -17,7 +17,8 @@ feature "new course age range", type: :feature do
           study_mode: "full_time_or_part_time",
           gcse_subjects_required_using_level: true,
           applications_open_from: "2019-10-09",
-          start_date: "2019-10-09")
+          start_date: "2019-10-09",
+          accrediting_provider: build(:provider))
   end
 
   before do

--- a/spec/features/courses/applications_open/new_spec.rb
+++ b/spec/features/courses/applications_open/new_spec.rb
@@ -12,7 +12,8 @@ feature "new course applications open", type: :feature do
       provider: provider,
       study_mode: "full_time_or_part_time",
       gcse_subjects_required_using_level: true,
-      start_date: "2019-10-09"
+      start_date: "2019-10-09",
+      accrediting_provider: build(:provider)
     )
   end
   let(:recruitment_cycle) { build(:recruitment_cycle) }
@@ -54,7 +55,8 @@ feature "new course applications open", type: :feature do
         study_mode: "full_time_or_part_time",
         gcse_subjects_required_using_level: true,
         applications_open_from: "2019-10-09",
-        start_date: "2019-10-09"
+        start_date: "2019-10-09",
+        accrediting_provider: build(:provider)
       )
     end
 

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -113,25 +113,7 @@ feature "Course confirmation", type: :feature do
 
   context "Saving the course" do
     context "Successfully" do
-      scenario "It creates the course on the API" do
-        course.course_code = "A123"
-        stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
-        course_create_request = stub_api_v2_request(
-          "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-          "/providers/#{provider.provider_code}" \
-          "/courses",
-          course.to_jsonapi,
-          :post, 200
-        )
-
-        course_confirmation_page.save.click
-
-        expect(course_create_request).to have_been_made
-      end
-
-      scenario "It displays the course page when created" do
-        course.course_code = "A123"
-        stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+      let(:course_create_request) do
         stub_api_v2_request(
           "/recruitment_cycles/#{course.recruitment_cycle.year}" \
           "/providers/#{provider.provider_code}" \
@@ -139,10 +121,28 @@ feature "Course confirmation", type: :feature do
           course.to_jsonapi,
           :post, 200
         )
+      end
+
+      before do
+        course.course_code = "A123"
+        stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+        course_create_request
 
         course_confirmation_page.save.click
+      end
 
+      scenario "It creates the course on the API" do
+        expect(course_create_request).to have_been_made
+      end
+
+      scenario "It displays the course page when created" do
         expect(course_page).to be_displayed
+      end
+
+      scenario "It displays the success message on the course page" do
+        expect(course_page).to have_success_summary
+        expect(course_page.success_summary).to have_content("Your course has been created")
+        expect(course_page.success_summary).to have_content("Add the rest of your details and publish the course, so that candidates can find and apply to it.")
       end
     end
 

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -27,7 +27,7 @@ feature "Course confirmation", type: :feature do
             subjects: [],
           })
   end
-  let(:provider) { build(:provider) }
+  let(:provider) { build(:provider, accredited_body?: true) }
 
   before do
     stub_omniauth(provider: provider)
@@ -61,6 +61,24 @@ feature "Course confirmation", type: :feature do
 
       scenario "It displays the 'as soon as its open on find' message" do
         expect(course_confirmation_page.details.application_open_from.text).to eq("As soon as the course is on Find (recommended)")
+      end
+    end
+
+    context "When the provider is accredited" do
+      let(:provider) { build(:provider, accredited_body?: true) }
+
+      scenario "It shows the apprenticeship details" do
+        expect(course_confirmation_page.details).to have_apprenticeship
+        expect(course_confirmation_page.details).not_to have_fee_or_salary
+      end
+    end
+
+    context "When the provider is not accredited" do
+      let(:provider) { build(:provider, accredited_body?: false) }
+
+      scenario "It shows the fee or salary details" do
+        expect(course_confirmation_page.details).not_to have_apprenticeship
+        expect(course_confirmation_page.details).to have_fee_or_salary
       end
     end
 

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -75,10 +75,16 @@ feature "Course confirmation", type: :feature do
 
     context "When the provider is not accredited" do
       let(:provider) { build(:provider, accredited_body?: false) }
+      let(:accredited_body) { build(:provider) }
+      let(:course) { build(:course, provider: provider, accrediting_provider: accredited_body) }
 
       scenario "It shows the fee or salary details" do
         expect(course_confirmation_page.details).not_to have_apprenticeship
         expect(course_confirmation_page.details).to have_fee_or_salary
+      end
+
+      scenario "It shows the accrediting body" do
+        expect(course_confirmation_page.details.accredited_body.text).to eq(accredited_body.provider_name)
       end
     end
 

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -24,6 +24,7 @@ feature "Course confirmation", type: :feature do
             start_dates: [],
             entry_requirements: [],
             qualifications: [],
+            subjects: [],
           })
   end
   let(:provider) { build(:provider) }
@@ -163,6 +164,16 @@ feature "Course confirmation", type: :feature do
 
       before do
         course_confirmation_page.details.edit_is_send.click
+      end
+
+      include_examples "goes to the edit page"
+    end
+
+    context "subjects" do
+      let(:destination_page) { PageObjects::Page::Organisations::Courses::NewSubjectsPage.new }
+
+      before do
+        course_confirmation_page.details.edit_subjects.click
       end
 
       include_examples "goes to the edit page"

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Course confirmation", type: :feature do
-  let(:recruitment_cycle) { build(:recruitment_cycle) }
+  let(:recruitment_cycle) { build(:recruitment_cycle, application_start_date: "2019-08-08") }
   let(:course_confirmation_page) do
     PageObjects::Page::Organisations::CourseConfirmation.new
   end
@@ -55,26 +55,36 @@ feature "Course confirmation", type: :feature do
     stub_api_v2_build_course
   end
 
-  scenario "viewing the course details page" do
-    expect(course_confirmation_page.title).to have_content(
-      "Check your answers before confirming",
-    )
+  context "Viewing the course details page" do
+    context "When the application open from date is the recruitment cycle start date" do
+      let(:course) { build(:course, applications_open_from: recruitment_cycle.application_start_date) }
 
-    expect(course_confirmation_page.details.level.text).to eq(course.level.capitalize)
-    expect(course_confirmation_page.details.is_send.text).to eq("No")
-    expect(course_confirmation_page.details.subjects.text).to include("English")
-    expect(course_confirmation_page.details.subjects.text).to include("Mathematics")
-    expect(course_confirmation_page.details.age_range.text).to eq("11 to 16")
-    expect(course_confirmation_page.details.study_mode.text).to eq("Full time")
-    expect(course_confirmation_page.details.locations.text).to eq("Site one Site two")
-    expect(course_confirmation_page.details.application_open_from.text).to eq("1 January 2019")
-    expect(course_confirmation_page.details.start_date.text).to eq("January 2019")
-    expect(course_confirmation_page.details.name.text).to eq("English")
-    expect(course_confirmation_page.details.description.text).to eq("PGCE with QTS full time")
-    expect(course_confirmation_page.details.entry_requirements.text).to include("Maths GCSE: Taking")
-    expect(course_confirmation_page.details.entry_requirements.text).to include("English GCSE: Must have")
-    expect(course_confirmation_page.preview.name.text).to include("English")
-    expect(course_confirmation_page.preview.description.text).to include("PGCE with QTS full time")
+      scenario "It displays the 'as soon as its open on find' message" do
+        expect(course_confirmation_page.details.application_open_from.text).to eq("As soon as the course is on Find (recommended)")
+      end
+    end
+
+    scenario "it displays the correct information" do
+      expect(course_confirmation_page.title).to have_content(
+        "Check your answers before confirming",
+      )
+
+      expect(course_confirmation_page.details.level.text).to eq(course.level.capitalize)
+      expect(course_confirmation_page.details.is_send.text).to eq("No")
+      expect(course_confirmation_page.details.subjects.text).to include("English")
+      expect(course_confirmation_page.details.subjects.text).to include("Mathematics")
+      expect(course_confirmation_page.details.age_range.text).to eq("11 to 16")
+      expect(course_confirmation_page.details.study_mode.text).to eq("Full time")
+      expect(course_confirmation_page.details.locations.text).to eq("Site one Site two")
+      expect(course_confirmation_page.details.application_open_from.text).to eq("1 January 2019")
+      expect(course_confirmation_page.details.start_date.text).to eq("January 2019")
+      expect(course_confirmation_page.details.name.text).to eq("English")
+      expect(course_confirmation_page.details.description.text).to eq("PGCE with QTS full time")
+      expect(course_confirmation_page.details.entry_requirements.text).to include("Maths GCSE: Taking")
+      expect(course_confirmation_page.details.entry_requirements.text).to include("English GCSE: Must have")
+      expect(course_confirmation_page.preview.name.text).to include("English")
+      expect(course_confirmation_page.preview.description.text).to include("PGCE with QTS full time")
+    end
   end
 
   context "Saving the course" do

--- a/spec/features/courses/fee_or_salary/new_spec.rb
+++ b/spec/features/courses/fee_or_salary/new_spec.rb
@@ -7,7 +7,7 @@ feature "new course fee or salary", type: :feature do
 
   let(:course) { build(:course, :new, provider: provider) }
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, provider: provider) }
+  let(:course) { build(:course, provider: provider, accrediting_provider: build(:provider)) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
   before do

--- a/spec/features/courses/level/new_spec.rb
+++ b/spec/features/courses/level/new_spec.rb
@@ -14,6 +14,7 @@ feature "New course level", type: :feature do
           gcse_subjects_required_using_level: true,
           applications_open_from: "2019-10-09",
           start_date: "2019-10-09",
+          accrediting_provider: build(:provider),
           edit_options: {
             subjects: [],
           })

--- a/spec/features/courses/outcome/new_spec.rb
+++ b/spec/features/courses/outcome/new_spec.rb
@@ -5,7 +5,7 @@ feature "new course outcome", type: :feature do
     PageObjects::Page::Organisations::Courses::NewOutcomePage.new
   end
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, provider: provider) }
+  let(:course) { build(:course, provider: provider, accrediting_provider: build(:provider)) }
   let(:empty_build_course_request) { stub_api_v2_build_course }
 
   before do

--- a/spec/features/courses/start_date/new_spec.rb
+++ b/spec/features/courses/start_date/new_spec.rb
@@ -4,7 +4,7 @@ feature "New course start date", type: :feature do
   let(:new_start_date_page) { PageObjects::Page::Organisations::CourseStartDate.new }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
   let(:provider) { build(:provider) }
-  let(:course) { build(:course, provider: provider, start_date: nil) }
+  let(:course) { build(:course, provider: provider, start_date: nil, accrediting_provider: build(:provider)) }
 
   before do
     stub_omniauth

--- a/spec/features/courses/study_mode/new_spec.rb
+++ b/spec/features/courses/study_mode/new_spec.rb
@@ -17,6 +17,7 @@ feature "new course study mode", type: :feature do
       study_mode: "full_time",
       applications_open_from: "2019-10-09",
       start_date: "2019-10-09",
+      accrediting_provider: build(:provider),
     )
   end
   let(:provider) { build(:provider) }

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -12,11 +12,22 @@ feature "New course level", type: :feature do
   let(:biology) { build(:subject, :biology) }
   let(:subjects) { [english, biology] }
   let(:edit_options) { { subjects: subjects, age_range_in_years: [] } }
-  let(:course) { build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true, edit_options: edit_options) }
+  let(:course) do
+    build(:course,
+          :new,
+          provider: provider,
+          level: level,
+          gcse_subjects_required_using_level: true,
+          edit_options: edit_options,
+          applications_open_from: DateTime.new(2019).utc.iso8601,
+          study_mode: "full_time")
+  end
 
   before do
     stub_omniauth
     stub_api_v2_resource(provider)
+    stub_api_v2_resource(provider.recruitment_cycle)
+    stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_new_resource(course)
     stub_api_v2_build_course
     stub_api_v2_build_course
@@ -105,6 +116,16 @@ feature "New course level", type: :feature do
         expect(new_subjects_page.error_flash.text).to include("Subjects Invalid")
       end
     end
+
+    scenario "sends user back to course confirmation" do
+      stub_api_v2_build_course(subjects_ids: [english.id])
+      visit_new_subjects_page(goto_confirmation: true)
+
+      new_subjects_page.subjects_fields.select(english.subject_name).click
+      new_subjects_page.continue.click
+
+      expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+    end
   end
 
   context "Page title" do
@@ -125,5 +146,15 @@ feature "New course level", type: :feature do
         expect(new_subjects_page.title.text).to eq("Select a secondary subject")
       end
     end
+  end
+
+private
+
+  def visit_new_subjects_page(**query_params)
+    visit new_provider_recruitment_cycle_courses_subjects_path(
+      provider.provider_code,
+      provider.recruitment_cycle.year,
+      query_params,
+    )
   end
 end

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -20,7 +20,8 @@ feature "New course level", type: :feature do
           gcse_subjects_required_using_level: true,
           edit_options: edit_options,
           applications_open_from: DateTime.new(2019).utc.iso8601,
-          study_mode: "full_time")
+          study_mode: "full_time",
+          accrediting_provider: build(:provider))
   end
 
   before do

--- a/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
@@ -13,6 +13,7 @@ module PageObjects
           element :age_range, '[data-qa="course__age_range"]'
           element :edit_apprenticeship, '[data-qa="course__edit_apprenticeship_link"]'
           element :apprenticeship, '[data-qa="course__apprenticeship"]'
+          element :fee_or_salary, '[data-qa="course__fee_or_salary"]'
           element :edit_is_send, '[data-qa="course__edit_is_send_link"]'
           element :is_send, '[data-qa="course__is_send"]'
           element :subjects, '[data-qa="course__subjects"]'

--- a/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
@@ -22,6 +22,7 @@ module PageObjects
           element :study_mode, '[data-qa="course__study_mode"]'
           element :edit_locations, '[data-qa="course__edit_locations_link"]'
           element :locations, '[data-qa="course__locations"]'
+          element :accredited_body, '[data-qa="course__accredited_body"]'
           element :edit_application_open_from, '[data-qa="course__edit_application_open_from_link"]'
           element :application_open_from, '[data-qa="course__application_open_from"]'
           element :edit_start_date, '[data-qa="course__edit_start_date_link"]'

--- a/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
@@ -16,6 +16,7 @@ module PageObjects
           element :edit_is_send, '[data-qa="course__edit_is_send_link"]'
           element :is_send, '[data-qa="course__is_send"]'
           element :subjects, '[data-qa="course__subjects"]'
+          element :edit_subjects, '[data-qa="course__edit_subjects_link"]'
           element :edit_study_mode, '[data-qa="course__edit_study_mode_link"]'
           element :study_mode, '[data-qa="course__study_mode"]'
           element :edit_locations, '[data-qa="course__edit_locations_link"]'

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -147,7 +147,7 @@ module Helpers
   end
 
   def stub_api_v2_build_course(params = {})
-    jsonapi_response = course.to_jsonapi(include: %i[subjects sites provider])
+    jsonapi_response = course.to_jsonapi(include: %i[subjects sites provider accrediting_provider])
     jsonapi_response[:data][:meta] = course.meta
     jsonapi_response[:data][:errors] = course_errors_to_json_api(course)
     stub_api_v2_request(


### PR DESCRIPTION
### Context

- Updates to the confirmation page to bring it in line with the prototype

### Changes proposed in this pull request

![course_confirmation](https://user-images.githubusercontent.com/976254/70155917-fe01be80-16aa-11ea-9a7b-ad4824572130.gif)

- Add a change link for subjects (and support the confirmation redirect)
- Update applications open to display a user friendly message
- Display fee or salary / apprenticeship dependent on the provider type
- Update the title for the confirmation page
- Display accredited body information where appropriate
- Display a success message when a course is created

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
