### PR TITLE
[2569] Show help text when provider has a single location

### DIFF
--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -165,13 +165,24 @@
                     <% end %>
                   </ul>
                 <% end %>
+
+                <% if course.provider.sites.count < 2 %>
+                  <p data-qa="course__locations__help" class="govuk-!-margin-top-1 app-courses-locations-list__help-text">
+                    You can’t change this because you only have 1 location
+                  </p>
+                  <p class="govuk-!-margin-top-1">
+                  <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="<%= provider_locations_path %>">Manage your locations</a>
+                  </p>
+                <% end %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                <%= course_creation_change_button(
-                  "locations",
-                  "locations",
-                  :new_provider_recruitment_cycle_courses_locations_path
-                ) %>
+                <% if @course.provider.sites.count > 1 %>
+                  <%= course_creation_change_button(
+                    "locations",
+                    "locations",
+                    :new_provider_recruitment_cycle_courses_locations_path
+                  ) %>
+                <% end %>
               </dd>
             </div>
 

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -38,6 +38,10 @@ $button-colour: #00823b;
   }
 }
 
+.app-courses-locations-list__help-text {
+  color: govuk-colour("dark-grey");
+}
+
 .app-courses-locations-list li:last-child {
   margin-bottom: 0;
 }

--- a/spec/features/courses/age_range_in_years/new_spec.rb
+++ b/spec/features/courses/age_range_in_years/new_spec.rb
@@ -7,7 +7,7 @@ feature "new course age range", type: :feature do
   let(:new_outcome_page) do
     PageObjects::Page::Organisations::Courses::NewOutcomePage.new
   end
-  let(:provider) { build(:provider) }
+  let(:provider) { build(:provider, sites: [build(:site), build(:site)]) }
   let(:recruitment_cycle) { build(:recruitment_cycle) }
   let(:course) do
     build(:course,

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -57,10 +57,18 @@ feature "Course confirmation", type: :feature do
 
   context "Viewing the course details page" do
     context "When the application open from date is the recruitment cycle start date" do
-      let(:course) { build(:course, applications_open_from: recruitment_cycle.application_start_date) }
+      let(:course) { build(:course, applications_open_from: recruitment_cycle.application_start_date, provider: provider) }
 
       scenario "It displays the 'as soon as its open on find' message" do
         expect(course_confirmation_page.details.application_open_from.text).to eq("As soon as the course is on Find (recommended)")
+      end
+    end
+
+    context "When the provider has a single site" do
+      let(:provider) { build(:provider, accredited_body?: true, sites: [build(:site)]) }
+
+      scenario "It displays the help text" do
+        expect(course_confirmation_page.details).to have_single_location_help_text
       end
     end
 

--- a/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_confirmation.rb
@@ -33,6 +33,7 @@ module PageObjects
           element :entry_requirements, '[data-qa="course__entry_requirements"]'
           element :edit_qualifications, '[data-qa="course__edit_qualifications_link"]'
           element :qualifications, '[data-qa="course__qualifications"]'
+          element :single_location_help_text, '[data-qa="course__locations__help"]'
         end
 
         section :preview, '[data-qa="course__preview"]' do


### PR DESCRIPTION
### Context

When a provider has a single location - they are not able to edit their locations for the course. Currently, a change link is shown that doesn't work.

### Changes proposed in this pull request
- Don't show the change link on a provider with a single location
- Show help text when there is one location
- Create link to manage locations which opens in a new tab

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
