### PR TITLE
[2614] Outcome page reorder choices

### DIFF
--- a/app/controllers/courses/outcome_controller.rb
+++ b/app/controllers/courses/outcome_controller.rb
@@ -1,8 +1,17 @@
 module Courses
   class OutcomeController < ApplicationController
     include CourseBasicDetailConcern
+    before_action :order_edit_options, only: %i[edit new]
 
   private
+
+    def order_edit_options
+      @course.meta["edit_options"]["qualifications"] = if @course.level == "further_education"
+                                                         %w[pgce pgde]
+                                                       else
+                                                         %w[pgce_with_qts qts pgde_with_qts]
+                                                       end
+    end
 
     def current_step
       :outcome

--- a/app/controllers/courses/outcome_controller.rb
+++ b/app/controllers/courses/outcome_controller.rb
@@ -6,11 +6,11 @@ module Courses
   private
 
     def order_edit_options
-      ensure_edit_options_are_equal
+      qualification_options = @course.meta["edit_options"]["qualifications"]
       @course.meta["edit_options"]["qualifications"] = if @course.level == "further_education"
-                                                         non_qts_qualifications
+                                                         non_qts_qualifications(qualification_options)
                                                        else
-                                                         qts_qualifications
+                                                         qts_qualifications(qualification_options)
                                                        end
     end
 
@@ -18,24 +18,24 @@ module Courses
       :outcome
     end
 
-    def ensure_edit_options_are_equal
-      qualification_options = @course.meta["edit_options"]["qualifications"]
+    def qts_qualifications(edit_options)
+      options = %w[pgce_with_qts qts pgde_with_qts]
 
-      if @course.level == "further_education"
-        if qualification_options.sort != non_qts_qualifications.sort
-          raise "Non QTS qualification options do not match"
-        end
-      elsif qualification_options.sort != qts_qualifications.sort
+      if edit_options.sort != options.sort
+        raise "Non QTS qualification options do not match"
+      end
+
+      options
+    end
+
+    def non_qts_qualifications(edit_options)
+      options = %w[pgce pgde]
+
+      if edit_options.sort != options.sort
         raise "QTS qualification options do not match"
       end
-    end
 
-    def qts_qualifications
-      %w[pgce_with_qts qts pgde_with_qts]
-    end
-
-    def non_qts_qualifications
-      %w[pgce pgde]
+      options
     end
 
     def errors

--- a/app/controllers/courses/outcome_controller.rb
+++ b/app/controllers/courses/outcome_controller.rb
@@ -6,15 +6,36 @@ module Courses
   private
 
     def order_edit_options
+      ensure_edit_options_are_equal
       @course.meta["edit_options"]["qualifications"] = if @course.level == "further_education"
-                                                         %w[pgce pgde]
+                                                         non_qts_qualifications
                                                        else
-                                                         %w[pgce_with_qts qts pgde_with_qts]
+                                                         qts_qualifications
                                                        end
     end
 
     def current_step
       :outcome
+    end
+
+    def ensure_edit_options_are_equal
+      qualification_options = @course.meta["edit_options"]["qualifications"]
+
+      if @course.level == "further_education"
+        if qualification_options.sort != non_qts_qualifications.sort
+          raise "Non QTS qualification options do not match"
+        end
+      elsif qualification_options.sort != qts_qualifications.sort
+        raise "QTS qualification options do not match"
+      end
+    end
+
+    def qts_qualifications
+      %w[pgce_with_qts qts pgde_with_qts]
+    end
+
+    def non_qts_qualifications
+      %w[pgce pgde]
     end
 
     def errors

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -28,9 +28,9 @@ FactoryBot.define do
 
         qualifications = case level
                          when :further_education
-                           %w[pgce pdge]
+                           %w[pgce pgde]
                          else
-                           %w[qts pgce_with_qts pgde_with_qts]
+                           %w[pgce_with_qts qts pgde_with_qts]
                          end
 
         {
@@ -65,6 +65,7 @@ FactoryBot.define do
                         "July #{recruitment_cycle.year.to_i + 1}"],
           study_modes: %w[full_time part_time full_time_or_part_time],
           funding_type: %w[fee apprenticeship salary],
+          subjects: [],
         }
       end
       gcse_subjects_required_using_level { false }
@@ -90,7 +91,7 @@ FactoryBot.define do
     funding_type { "fee" }
     applications_open_from { DateTime.new(2019).utc.iso8601 }
     is_send? { false }
-    level { "secondary" }
+    level { :secondary }
     about_course { nil }
     interview_process { nil }
     how_school_placements_work { nil }

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -17,15 +17,7 @@ feature "Course confirmation", type: :feature do
           subjects: [
             build(:subject, :english),
             build(:subject, :mathematics),
-          ],
-          edit_options: {
-            age_range_in_years: [],
-            study_modes: [],
-            start_dates: [],
-            entry_requirements: [],
-            qualifications: [],
-            subjects: [],
-          })
+          ])
   end
   let(:provider) { build(:provider, accredited_body?: true, sites: [site1, site2]) }
 
@@ -102,7 +94,7 @@ feature "Course confirmation", type: :feature do
       expect(course_confirmation_page.title).to have_content(
         "Check your answers before confirming",
       )
-      expect(course_confirmation_page.details.level.text).to eq(course.level.capitalize)
+      expect(course_confirmation_page.details.level.text).to eq(course.level.to_s.capitalize)
       expect(course_confirmation_page.details.is_send.text).to eq("No")
       expect(course_confirmation_page.details.subjects.text).to include("English")
       expect(course_confirmation_page.details.subjects.text).to include("Mathematics")
@@ -300,7 +292,7 @@ private
       "Check your answers before confirming",
     )
 
-    expect(course_confirmation_page.details.level.text).to eq(course.level.capitalize)
+    expect(course_confirmation_page.details.level.text).to eq(course.level.to_s.capitalize)
     expect(course_confirmation_page.details.is_send.text).to eq("No")
     expect(course_confirmation_page.details.subjects.text).to include("English")
     expect(course_confirmation_page.details.subjects.text).to include("Mathematics")

--- a/spec/features/courses/outcome/edit_spec.rb
+++ b/spec/features/courses/outcome/edit_spec.rb
@@ -20,9 +20,6 @@ feature "Edit course outcome", type: :feature do
     let(:course) do
       build(
         :course,
-        edit_options: {
-          qualifications: %w[qts pgce_with_qts pgde_with_qts],
-        },
         provider: provider,
       )
     end
@@ -77,9 +74,7 @@ feature "Edit course outcome", type: :feature do
     let(:course) do
       build(
         :course,
-        edit_options: {
-          qualifications: %w[pgce pgde],
-        },
+        level: :further_education,
         qualification: "pgde",
         provider: provider,
       )
@@ -103,9 +98,6 @@ feature "Edit course outcome", type: :feature do
     let(:course) do
       build(
         :course,
-        edit_options: {
-          qualifications: %w[qts],
-        },
         provider: provider,
         qualification: "something_else",
       )


### PR DESCRIPTION
### Context

In order to bring the prototype in line with the application, we need to order the choices for outcomes. 

Originally this was done in the backend, but as it is display logic, it was better suited to the frontend with some checks to have assurance there are no extra options needed to be displayed

### Changes proposed in this pull request

- Order options for outcomes
- Add checks for provided edit options

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
