### PR TITLE
[2683] Make cookies, privacy and new features none authenticated

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate, only: %i[guidance accessibility terms]
+  skip_before_action :authenticate, only: %i[guidance accessibility terms cookies privacy new_features]
 
   def accessibility; end
 

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -4,16 +4,12 @@ feature "View pages", type: :feature do
   let(:new_features_page) { PageObjects::Page::NewFeaturesPage.new }
 
   scenario "Environment label and class are read from settings" do
-    stub_omniauth
-
     visit "/cookies"
     expect(find(".app-tag--#{Settings.environment.selector_name}")).to have_content(Settings.environment.label)
     expect(page).to have_selector(".app-header__container--#{Settings.environment.selector_name}")
   end
 
   scenario "Navigate to /cookies" do
-    stub_omniauth
-
     visit "/cookies"
     expect(find("h1")).to have_content("Cookies")
   end
@@ -24,15 +20,11 @@ feature "View pages", type: :feature do
   end
 
   scenario "Navigate to /privacy-policy" do
-    stub_omniauth
-
     visit "/privacy-policy"
     expect(find("h1")).to have_content("Privacy policy")
   end
 
   scenario "Navigate to /new-features" do
-    stub_omniauth
-
     new_features_page.load
     expect(new_features_page.title).to have_content("New features coming to Publish")
   end


### PR DESCRIPTION
### Context
No need to authenticate these static pages

### Changes proposed in this pull request
Remove authentication from static content and legal pages

### Guidance to review
`/cookies`
`/privacy-policy`
`/new-features`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
