### PR TITLE
[2403] Remove content_status and last_published_date from provider

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -25,14 +25,6 @@ class Provider < Base
     Settings.rollover
   end
 
-  def has_unpublished_changes?
-    content_status == "published_with_unpublished_changes"
-  end
-
-  def is_published?
-    content_status == "published"
-  end
-
 private
 
   def post_base_url

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -9,40 +9,4 @@ describe Provider do
       expect(publish_endpoint).to have_been_requested
     end
   end
-
-  describe "#has_unpublished_changes?" do
-    context "is published with unpublished changes" do
-      let(:provider) { build(:provider, content_status: "published_with_unpublished_changes") }
-
-      it "returns true" do
-        expect(provider.has_unpublished_changes?).to eq(true)
-      end
-    end
-
-    context "is published" do
-      let(:provider) { build(:provider, content_status: "published") }
-
-      it "return false" do
-        expect(provider.has_unpublished_changes?).to eq(false)
-      end
-    end
-  end
-
-  describe "#is_published?" do
-    context "is published with unpublished changes" do
-      let(:provider) { build(:provider, content_status: "published_with_unpublished_changes") }
-
-      it "returns true" do
-        expect(provider.is_published?).to eq(false)
-      end
-    end
-
-    context "is published" do
-      let(:provider) { build(:provider, content_status: "published") }
-
-      it "return false" do
-        expect(provider.is_published?).to eq(true)
-      end
-    end
-  end
 end


### PR DESCRIPTION
### Context
Provider enrichments are no longer in use, these fields are leftover from them.

### Changes proposed in this pull request
Remove any references to providers' `content_status` or `last_published_date` and correct any tests broken by this.

### Guidance to review
Needs to be checked by @fofr but things seem to still work.  

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
