### PR TITLE
[2695] Fixed tests that was polluted by ordering

### DIFF
--- a/end-to-end-tests/cypress/integration/_publicly_visible/index.js
+++ b/end-to-end-tests/cypress/integration/_publicly_visible/index.js
@@ -1,3 +1,11 @@
+// NOTE: This tests needs to proceed before any other tests, as these
+// tests demostrates the ability of what can be accessiblity by the
+// user with out logging in.
+// SEE:
+// https://github.com/cypress-io/cypress/issues/5723
+// https://github.com/cypress-io/cypress/issues/781
+
+
 import publicly_visble_pages from "../../fixtures/publicly_visible/pages.json";
 
 const baseUrl = Cypress.config().baseUrl;


### PR DESCRIPTION
### Context
Tests that checks for pages being publicly visible occurs after tests that have logged the user in, leading to false positives.

### Changes proposed in this pull request
Amended the folder name to start with an underscore therefore when running all tests it starts off with the user not logged in

### Guidance to review
![image](https://user-images.githubusercontent.com/470137/70923732-3e086000-2020-11ea-829d-f5ecc70b2947.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
