### PR TITLE
[2640] Support new validation added for course creation

### DIFF
--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -1,7 +1,7 @@
 module Courses
   class ApplicationsOpenController < ApplicationController
     before_action :build_recruitment_cycle
-    before_action :build_course_params, only: :update
+    before_action :build_course_params, only: %i[update continue]
     include CourseBasicDetailConcern
 
     def update
@@ -9,7 +9,6 @@ module Courses
     end
 
     def continue
-      build_course_params
       super
     end
 

--- a/app/controllers/courses/apprenticeship_controller.rb
+++ b/app/controllers/courses/apprenticeship_controller.rb
@@ -9,7 +9,7 @@ module Courses
     end
 
     def error_keys
-      [:funding_type]
+      %i[funding_type program_type]
     end
   end
 end

--- a/app/controllers/courses/fee_or_salary_controller.rb
+++ b/app/controllers/courses/fee_or_salary_controller.rb
@@ -9,7 +9,7 @@ module Courses
     end
 
     def error_keys
-      [:funding_type]
+      %i[funding_type program_type]
     end
   end
 end

--- a/app/controllers/courses/sites_controller.rb
+++ b/app/controllers/courses/sites_controller.rb
@@ -53,6 +53,10 @@ module Courses
       :location
     end
 
+    def error_keys
+      [:sites]
+    end
+
     def set_default_site
       params["course"] ||= {}
       params["course"]["sites_ids"] = [@provider.sites.first.id]

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -3,6 +3,8 @@
   <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
+<%= render 'shared/errors' %>
+
 <h1 class="govuk-heading-xl">Pick the locations for this course</h1>
 
 <%= form_for course,

--- a/spec/features/courses/apprenticeship/new_spec.rb
+++ b/spec/features/courses/apprenticeship/new_spec.rb
@@ -68,6 +68,7 @@ feature "new course apprenticeship", type: :feature do
     let(:course) do
       c = build(:course, provider: provider)
       c.errors.add(:funding_type, "Invalid")
+      c.errors.add(:program_type, "Invalid")
       c
     end
 
@@ -76,6 +77,7 @@ feature "new course apprenticeship", type: :feature do
       new_apprenticeship_page.funding_type_fields.apprenticeship.click
       new_apprenticeship_page.continue.click
       expect(new_apprenticeship_page.error_flash.text).to include("Funding type Invalid")
+      expect(new_apprenticeship_page.error_flash.text).to include("Program type Invalid")
     end
   end
 

--- a/spec/features/courses/fee_or_salary/new_spec.rb
+++ b/spec/features/courses/fee_or_salary/new_spec.rb
@@ -57,6 +57,7 @@ feature "new course fee or salary", type: :feature do
     let(:course) do
       c = build(:course, provider: provider)
       c.errors.add(:funding_type, "Invalid")
+      c.errors.add(:program_type, "Invalid")
       c
     end
 
@@ -65,6 +66,7 @@ feature "new course fee or salary", type: :feature do
       new_fee_or_salary_page.funding_type_fields.fee.click
       new_fee_or_salary_page.continue.click
       expect(new_fee_or_salary_page.error_flash.text).to include("Funding type Invalid")
+      expect(new_fee_or_salary_page.error_flash.text).to include("Program type Invalid")
     end
   end
 

--- a/spec/features/courses/sites/new_spec.rb
+++ b/spec/features/courses/sites/new_spec.rb
@@ -94,6 +94,19 @@ feature "New course sites" do
     end
   end
 
+  context "Error handling" do
+    let(:course) do
+      c = build(:course, provider: provider, site_ids: [])
+      c.errors.add(:sites, "Invalid")
+      c
+    end
+
+    scenario do
+      new_locations_page.continue.click
+      expect(new_locations_page.error_flash.text).to include("Sites Invalid")
+    end
+  end
+
   context "with only one site" do
     let(:full_or_part_time) { PageObjects::Page::Organisations::Courses::NewStudyModePage.new }
     let(:sites) { [site2] }


### PR DESCRIPTION
### Context

Validation has been added in the backend (see: https://github.com/DFE-Digital/manage-courses-backend/pull/1052 & https://github.com/DFE-Digital/manage-courses-backend/pull/1062) which requires the frontend to be linked to the keys for the error

### Changes proposed in this pull request

- Add error keys to the relevant pages to display validation errors from the backend

**Note**

This PR does not cover age range with years with custom validation, as that is currently handled in the frontend of the controller and will be solved in future PRs

### Guidance to review

- Check out `2640-create-a-course-validation-changes` on MCBE (unless it has been merged)
- Run through course creation
- Try to create a course without submitting anything

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
