### PR TITLE
[2701] highlight errors on fields in create course flow

### DIFF
--- a/app/views/courses/_course_length.html.erb
+++ b/app/views/courses/_course_length.html.erb
@@ -1,4 +1,4 @@
-<div id="course_length_wrapper" class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors[:course_length]&.any?) %>">
+<%= render "shared/error_wrapper", error_keys: [:course_length], data_qa: "course__length" do %>
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h2 class="govuk-fieldset__heading">Course length</h2>
@@ -36,4 +36,4 @@
       </div>
     </div>
   </fieldset>
-</div>
+<% end %>

--- a/app/views/courses/_course_length.html.erb
+++ b/app/views/courses/_course_length.html.erb
@@ -4,7 +4,7 @@
       <h2 class="govuk-fieldset__heading">Course length</h2>
     </legend>
 
-    <%= render "shared/error_messages", field: :course_length %>
+    <%= render "shared/error_messages", error_keys: [:course_length] %>
 
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">

--- a/app/views/courses/accredited_body/_provider_search_field.html.erb
+++ b/app/views/courses/accredited_body/_provider_search_field.html.erb
@@ -3,7 +3,7 @@
     for: 'course_accredited_body',
     class: 'govuk-label' do %>
     Name of accredited body
-    <%= render "shared/error_messages", field: :accredited_body %>
+    <%= render "shared/error_messages", error_keys: [:accredited_body] %>
     <span class="govuk-hint">Enter the name or provider code</span>
   <% end %>
   <%= form.text_field :accredited_body,

--- a/app/views/courses/accredited_body/_provider_search_field.html.erb
+++ b/app/views/courses/accredited_body/_provider_search_field.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:accredited_body]&.any?) %>">
+<%= render "shared/error_wrapper", error_keys: [:accredited_body], data_qa: "course__provider_search" do %>
   <%= form.label :accredited_body,
     for: 'course_accredited_body',
     class: 'govuk-label' do %>
@@ -10,4 +10,4 @@
     autocomplete: 'off',
     class: 'govuk-input govuk-!-width-two-thirds' %>
   <div id="provider-autocomplete" class="govuk-body govuk-!-width-two-thirds"></div>
-</div>
+<% end %>

--- a/app/views/courses/age_range/_form_fields.html.erb
+++ b/app/views/courses/age_range/_form_fields.html.erb
@@ -19,7 +19,7 @@
   <div class="govuk-radios__conditional <%= 'govuk-radios__conditional--hidden' if !course.other_age_range? %>" id="other-container">
     <p class="govuk-body">Enter an age range in years, for example: 5 to 11. The course must cover 4 or more school years.</p>
     <%= render "shared/error_messages", error_keys: [:age_range_in_years_from] %>
-    <div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years_from].present?) %>">
+    <%= render "shared/error_wrapper", error_keys: [:age_range_in_years_from], data_qa: "course__age_range_in_years_from" do %>
       <label class="govuk-label" for="course_course_age_range_in_years_other_from">From</label>
       <%= form.number_field 'course_age_range_in_years_other_from',
           min: 0,
@@ -28,9 +28,9 @@
           class: 'govuk-input govuk-input--width-2' ,
           data: { qa: "course__age_range_in_years_other_from_input"}
       %>
-    </div>
+    <% end %>
     <%= render "shared/error_messages", error_keys: [:age_range_in_years_to] %>
-    <div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years_to].present?) %>">
+    <%= render "shared/error_wrapper", error_keys: [:age_range_in_years_to], data_qa: "course__age_range_in_years_to" do %>
       <label class="govuk-label" for="course_course_age_range_in_years_other_to">To</label>
       <%= form.number_field 'course_age_range_in_years_other_to',
           min: 4,
@@ -39,6 +39,6 @@
           class: 'govuk-input govuk-input--width-2',
           data: { qa: "course__age_range_in_years_other_to_input"}
       %>
-    </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/courses/age_range/_form_fields.html.erb
+++ b/app/views/courses/age_range/_form_fields.html.erb
@@ -18,7 +18,7 @@
   </div>
   <div class="govuk-radios__conditional <%= 'govuk-radios__conditional--hidden' if !course.other_age_range? %>" id="other-container">
     <p class="govuk-body">Enter an age range in years, for example: 5 to 11. The course must cover 4 or more school years.</p>
-    <%= render "shared/error_messages", field: :age_range_in_years_from if @errors %>
+    <%= render "shared/error_messages", error_keys: [:age_range_in_years_from] %>
     <div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years_from].present?) %>">
       <label class="govuk-label" for="course_course_age_range_in_years_other_from">From</label>
       <%= form.number_field 'course_age_range_in_years_other_from',
@@ -29,7 +29,7 @@
           data: { qa: "course__age_range_in_years_other_from_input"}
       %>
     </div>
-    <%= render "shared/error_messages", field: :age_range_in_years_to if @errors %>
+    <%= render "shared/error_messages", error_keys: [:age_range_in_years_to] %>
     <div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years_to].present?) %>">
       <label class="govuk-label" for="course_course_age_range_in_years_other_to">To</label>
       <%= form.number_field 'course_age_range_in_years_other_to',

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -20,7 +20,7 @@
               Specify an age range
             </h1>
           </legend>
-          <%= render "shared/error_messages", field: :age_range_in_years if @errors %>
+          <%= render "shared/error_messages", error_keys: [:age_range_in_years] %>
           <%= render 'form_fields', form: form %>
         </fieldset>
       </div>

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -10,9 +10,8 @@
     <%= form_with model: course,
           url: age_range_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
           method: :put do |form| %>
-      <div
-        class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years]&.any?) %>"
-        data-qa="course__age_range_in_years">
+
+      <%= render "shared/error_wrapper", error_keys: [:age_range_in_years], data_qa: "course__age_range_in_years" do %>
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
             <h1 class="govuk-fieldset__heading">
@@ -23,7 +22,7 @@
           <%= render "shared/error_messages", error_keys: [:age_range_in_years] %>
           <%= render 'form_fields', form: form %>
         </fieldset>
-      </div>
+      <% end %>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
         class: "govuk-button", data: { qa: 'course__save' }

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -14,9 +14,7 @@
                   method: :get do |form| %>
 
       <%= render "courses/new_fields_holder", form: form, except_keys: [:age_range_in_years] do |fields| %>
-        <div
-          class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:age_range_in_years]&.any?) %>"
-          data-qa="course__age_range_in_years">
+        <%= render "shared/error_wrapper", error_keys: [:age_range_in_years], data_qa: "course__age_range_in_years" do %>
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
               <h1 class="govuk-fieldset__heading">
@@ -26,7 +24,7 @@
             <%= render "shared/error_messages", error_keys: [:age_range_in_years] %>
             <%= render 'form_fields', form: fields %>
           </fieldset>
-        </div>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -23,7 +23,7 @@
                 Specify an age range
               </h1>
             </legend>
-            <%= render "shared/error_messages", field: :age_range_in_years if @errors %>
+            <%= render "shared/error_messages", error_keys: [:age_range_in_years] %>
             <%= render 'form_fields', form: fields %>
           </fieldset>
         </div>

--- a/app/views/courses/apprenticeship/_form_fields.html.erb
+++ b/app/views/courses/apprenticeship/_form_fields.html.erb
@@ -1,7 +1,4 @@
-<div
-  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors&.[](:funding_type)&.any? || @errors&.[](:program_type)&.any?) %>"
-  data-qa="course__funding_type">
-
+<%= render "shared/error_wrapper", error_keys: [:funding_type, :program_type], data_qa: "course__funding_type" do %>
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading">
@@ -20,7 +17,7 @@
                 'Yes',
                 value: 'apprenticeship',
                 class: 'govuk-label govuk-radios__label',
-                data: { qa: 'course__funding_type_apprenticeship' }%>
+                data: { qa: 'course__funding_type_apprenticeship' } %>
       </div>
 
       <div class="govuk-radios__item">
@@ -35,4 +32,4 @@
       </div>
     </div>
   </fieldset>
-</div>
+<% end %>

--- a/app/views/courses/apprenticeship/_form_fields.html.erb
+++ b/app/views/courses/apprenticeship/_form_fields.html.erb
@@ -9,8 +9,7 @@
       </h1>
     </legend>
 
-    <%= render "shared/error_messages", field: :funding_type if @errors&.[](:funding_type) %>
-    <%= render "shared/error_messages", field: :program_type if @errors&.[](:program_type) %>
+    <%= render "shared/error_messages", error_keys: [:funding_type, :program_type] %>
 
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">

--- a/app/views/courses/apprenticeship/_form_fields.html.erb
+++ b/app/views/courses/apprenticeship/_form_fields.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:funding_type]&.any?) %>"
+  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors&.[](:funding_type)&.any? || @errors&.[](:program_type)&.any?) %>"
   data-qa="course__funding_type">
 
   <fieldset class="govuk-fieldset">
@@ -9,7 +9,9 @@
       </h1>
     </legend>
 
-    <%= render "shared/error_messages", field: :funding_type if @errors %>
+    <%= render "shared/error_messages", field: :funding_type if @errors&.[](:funding_type) %>
+    <%= render "shared/error_messages", field: :program_type if @errors&.[](:program_type) %>
+
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
         <%= form.radio_button :funding_type,

--- a/app/views/courses/fee_or_salary/_form_fields.html.erb
+++ b/app/views/courses/fee_or_salary/_form_fields.html.erb
@@ -1,7 +1,4 @@
-<div
-  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:funding_type]&.any?) %>"
-  data-qa="course__funding_type">
-
+<%= render "shared/error_wrapper", error_keys: [:funding_type], data_qa: "course__funding_type" do %>
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading">
@@ -48,4 +45,4 @@
       </div>
     </div>
   </fieldset>
-</div>
+<% end %>

--- a/app/views/courses/fee_or_salary/_form_fields.html.erb
+++ b/app/views/courses/fee_or_salary/_form_fields.html.erb
@@ -10,7 +10,7 @@
       <br>
     </legend>
 
-    <%= render "shared/error_messages", field: :funding_type if @errors %>
+    <%= render "shared/error_messages", error_keys: [:funding_type] %>
     <div class="govuk-radios" data-module="govuk-radios">
       <div class="govuk-radios__item">
         <%= form.radio_button :funding_type,

--- a/app/views/courses/level/_form_fields.html.erb
+++ b/app/views/courses/level/_form_fields.html.erb
@@ -1,14 +1,11 @@
-<div class="govuk-form-group"
-  data-qa="course__level">
-  <div class="govuk-radios govuk-radios" data-module="govuk-radios">
-    <% %i[primary secondary further_education].each do |level| %>
-      <div class="govuk-radios__item">
-        <%= form.radio_button :level, level,
-          class: 'govuk-radios__input',
-          data: { qa: "course__#{level}" } %>
-        <%= form.label :level, value: level,
-          class: 'govuk-label govuk-radios__label' %>
-      </div>
-    <% end %>
-  </div>
+<div class="govuk-radios govuk-radios" data-module="govuk-radios">
+  <% %i[primary secondary further_education].each do |level| %>
+    <div class="govuk-radios__item">
+      <%= form.radio_button :level, level,
+        class: 'govuk-radios__input',
+        data: { qa: "course__#{level}" } %>
+      <%= form.label :level, value: level,
+        class: 'govuk-label govuk-radios__label' %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -25,7 +25,7 @@
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
               <h2 class="govuk-fieldset__heading">Level</h2>
             </legend>
-            <%= render "shared/error_messages", field: :level if @errors %>
+            <%= render "shared/error_messages", error_keys: [:level] %>
             <%= render 'form_fields', form: fields %>
           </fieldset>
         </div>

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -17,10 +17,7 @@
                   method: :get do |form| %>
 
       <%= render "courses/new_fields_holder", form: form, except_keys: [:level] do |fields| %>
-        <div
-          class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors.any?) %>"
-          data-qa="course__level"
-        >
+        <%= render "shared/error_wrapper", error_keys: [:level], data_qa: "course__level" do %>
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
               <h2 class="govuk-fieldset__heading">Level</h2>
@@ -28,7 +25,7 @@
             <%= render "shared/error_messages", error_keys: [:level] %>
             <%= render 'form_fields', form: fields %>
           </fieldset>
-        </div>
+        <% end %>
 
         <h2 class="govuk-heading-m remove-top-margin">
           Special educational needs and disability (SEND)

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -18,7 +18,7 @@
 
       <%= render "courses/new_fields_holder", form: form, except_keys: [:level] do |fields| %>
         <div
-          class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors.any?) %>"
+          class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors.any?) %>"
           data-qa="course__level"
         >
           <fieldset class="govuk-fieldset">

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -17,8 +17,18 @@
                   method: :get do |form| %>
 
       <%= render "courses/new_fields_holder", form: form, except_keys: [:level] do |fields| %>
-        <h2 class="govuk-heading-m remove-top-margin">Level</h2>
-        <%= render 'form_fields', form: fields %>
+        <div
+          class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors.any?) %>"
+          data-qa="course__level"
+        >
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h2 class="govuk-fieldset__heading">Level</h2>
+            </legend>
+            <%= render "shared/error_messages", field: :level if @errors %>
+            <%= render 'form_fields', form: fields %>
+          </fieldset>
+        </div>
 
         <h2 class="govuk-heading-m remove-top-margin">
           Special educational needs and disability (SEND)

--- a/app/views/courses/modern_languages/edit.erb
+++ b/app/views/courses/modern_languages/edit.erb
@@ -20,7 +20,7 @@
               Change modern languages
             </h1>
           </legend>
-          <%= render "shared/error_messages", field: :subjects if @errors %>
+          <%= render "shared/error_messages", error_keys: [:subjects] %>
           <%= render 'courses/modern_languages/form_fields', form: form %>
         </fieldset>
       </div>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -5,33 +5,37 @@
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl">Pick the locations for this course</h1>
-
 <%= form_for course,
   url: continue_provider_recruitment_cycle_courses_locations_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-  method: :get do |f| %>
-  <%= render 'shared/course_creation_hidden_fields',
-    form: f,
-    course_creation_params: @course_creation_params,
-    except_keys: [:sites_ids]
-  %>
-
-  <div class="govuk-form-group">
-    <div class="govuk-checkboxes">
-      <%= f.fields_for :site_statuses, @provider.sites.sort_by(&:location_name) do |sf| %>
-        <% site = sf.object %>
-        <div class="govuk-checkboxes__item">
-          <%= sf.check_box 'selected', checked: course.has_site?(site), class: 'govuk-checkboxes__input' %>
-          <%= sf.label 'selected', class: 'govuk-label govuk-checkboxes__label'  do %>
-            <strong data-qa="site__name"><%= site.location_name %></strong>
-          <% end %>
-          <span class="govuk-hint govuk-checkboxes__hint">
-            <%= site.full_address %>
-          </span>
+  method: :get do |form| %>
+  <%= render "courses/new_fields_holder", form: form, except_keys: [:sites_ids] do |fields| %>
+    <div
+      class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors&.[](:sites)&.any?) %>"
+      data-qa="course__sites">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading" data-qa="page-heading">
+            Pick the locations for this course
+          </h1>
+        </legend>
+        <%= render "shared/error_messages", field: :sites if @errors %>
+        <div class="govuk-form-group">
+          <div class="govuk-checkboxes">
+            <%= fields.fields_for :site_statuses, @provider.sites.sort_by(&:location_name) do |sfields| %>
+              <% site = sfields.object %>
+              <div class="govuk-checkboxes__item">
+                <%= sfields.check_box 'selected', checked: course.has_site?(site), class: 'govuk-checkboxes__input' %>
+                <%= sfields.label 'selected', class: 'govuk-label govuk-checkboxes__label'  do %>
+                  <strong data-qa="site__name"><%= site.location_name %></strong>
+                <% end %>
+                <span class="govuk-hint govuk-checkboxes__hint">
+                  <%= site.full_address %>
+                </span>
+              </div>
+            <% end %>
+          </div>
         </div>
-      <% end %>
+      </fieldset>
     </div>
-  </div>
-
-  <%= f.submit "Continue", class: "govuk-button", data: { qa: 'course__save' } %>
+  <% end %>
 <% end %>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -18,7 +18,7 @@
             Pick the locations for this course
           </h1>
         </legend>
-        <%= render "shared/error_messages", field: :sites if @errors %>
+        <%= render "shared/error_messages", error_keys: [:sites] %>
         <div class="govuk-form-group">
           <div class="govuk-checkboxes">
             <%= fields.fields_for :site_statuses, @provider.sites.sort_by(&:location_name) do |sfields| %>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -9,9 +9,7 @@
   url: continue_provider_recruitment_cycle_courses_locations_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
   method: :get do |form| %>
   <%= render "courses/new_fields_holder", form: form, except_keys: [:sites_ids] do |fields| %>
-    <div
-      class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors&.[](:sites)&.any?) %>"
-      data-qa="course__sites">
+    <%= render "shared/error_wrapper", error_keys: [:sites], data_qa: "course__sites" do %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-fieldset__heading" data-qa="page-heading">
@@ -36,6 +34,6 @@
           </div>
         </div>
       </fieldset>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/courses/study_mode/_form_fields.html.erb
+++ b/app/views/courses/study_mode/_form_fields.html.erb
@@ -9,7 +9,7 @@
       </h1>
     </legend>
 
-    <%= render "shared/error_messages", field: :study_modes if @errors %>
+    <%= render "shared/error_messages", error_keys: [:study_modes] %>
     <div class="govuk-radios" data-module="govuk-radios">
       <% @course.meta['edit_options']['study_modes'].each do |value| %>
         <div class="govuk-radios__item">

--- a/app/views/courses/study_mode/_form_fields.html.erb
+++ b/app/views/courses/study_mode/_form_fields.html.erb
@@ -1,7 +1,4 @@
-
-<div
-  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:study_mode]&.any?) %>"
-  data-qa="course__study_mode">
+<%= render "shared/error_wrapper", error_keys: [:study_mode], data_qa: "course__study_mode" do %>
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading">
@@ -24,5 +21,4 @@
       <% end %>
     </div>
   </fieldset>
-</div>
-
+<% end %>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -1,6 +1,5 @@
-<div
-  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors&.[](:subjects)&.any?) %>"
-  data-qa="course__subjects">
+<%= render "shared/error_wrapper", error_keys: [:subjects], data_qa: "course__subjects" do %>
+
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading" data-qa="page-heading">
@@ -38,4 +37,4 @@
       </div>
     <% end %>
   </fieldset>
-</div>
+<% end %>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -1,25 +1,41 @@
-<div class="govuk-form-group">
-  <%= form.label :master_subject_id, subject_input_label(@course), class: 'govuk-label' %>
-  <%= form.select :master_subject_id, options_for_select(course.selectable_subjects, @course.subjects.first&.id), { include_blank: true }, data: { qa: 'course__subjects' }, class: "govuk-select" %>
-</div>
+<div
+  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:subjects]&.any?) %>"
+  data-qa="course__subjects">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading" data-qa="page-heading">
+        <% if course.course_code %>
+          <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+        <% end %>
 
-<% if course.level == "secondary" %>
-  <div style="margin-bottom: -20px">
-    <details class="govuk-details" role="group" data-qa="course__subordinate_subject_accordion">
-      <summary class="govuk-details__summary" role="button">
-        <span class="govuk-details__summary-text">
-          Add a second subject (optional)
-        </span>
-      </summary>
-      <div class="govuk-details__text" id="details-content-c2b172cf-d259-4213-90bc-50d9d169a20f" aria-hidden="true">
-        <p>Your first subject is the main one. It will appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
+        <%= subject_page_title(@course) %>
+      </h1>
+    </legend>
+    <%= render "shared/error_messages", field: :subjects if @errors %>
+    <div class="govuk-form-group">
+      <%= form.label :master_subject_id, subject_input_label(@course), class: 'govuk-label' %>
+      <%= form.select :master_subject_id, options_for_select(course.selectable_subjects, @course.subjects.first&.id), { include_blank: true }, data: { qa: 'course__master_subject' }, class: "govuk-select" %>
+    </div>
 
-        <div class="govuk-form-group">
-          <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>
-          <span class="govuk-hint">For example ‘Physics with Mathematics’</span>
-          <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subjects, @course.subjects.second&.id || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
-        </div>
+    <% if course.level == "secondary" %>
+      <div style="margin-bottom: -20px">
+        <details class="govuk-details" role="group" data-qa="course__subordinate_subject_accordion">
+          <summary class="govuk-details__summary" role="button">
+            <span class="govuk-details__summary-text">
+              Add a second subject (optional)
+            </span>
+          </summary>
+          <div class="govuk-details__text" id="details-content-c2b172cf-d259-4213-90bc-50d9d169a20f" aria-hidden="true">
+            <p>Your first subject is the main one. It will appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
+
+            <div class="govuk-form-group">
+              <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>
+              <span class="govuk-hint">For example ‘Physics with Mathematics’</span>
+              <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subjects, @course.subjects.second&.id || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
+            </div>
+          </div>
+        </details>
       </div>
-    </details>
-  </div>
-<% end %>
+    <% end %>
+  </fieldset>
+</div>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -11,7 +11,7 @@
         <%= subject_page_title(@course) %>
       </h1>
     </legend>
-    <%= render "shared/error_messages", field: :subjects if @errors %>
+    <%= render "shared/error_messages", error_keys: [:subjects] %>
     <div class="govuk-form-group">
       <%= form.label :master_subject_id, subject_input_label(@course), class: 'govuk-label' %>
       <%= form.select :master_subject_id, options_for_select(course.selectable_subjects, @course.subjects.first&.id), { include_blank: true }, data: { qa: 'course__master_subject' }, class: "govuk-select" %>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:subjects]&.any?) %>"
+  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors&.[](:subjects)&.any?) %>"
   data-qa="course__subjects">
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">

--- a/app/views/courses/subjects/edit.erb
+++ b/app/views/courses/subjects/edit.erb
@@ -11,20 +11,7 @@
           url: subjects_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
           method: :put do |form| %>
 
-      <div
-        class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:subjects]&.any?) %>"
-        data-qa="course__subjects_section">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-fieldset__heading">
-              <span class="govuk-caption-xl"><%= course.name_and_code %></span>
-              Change subjects
-            </h1>
-          </legend>
-          <%= render "shared/error_messages", field: :subjects if @errors %>
-          <%= render 'form_fields', form: form %>
-        </fieldset>
-      </div>
+      <%= render 'form_fields', form: form %>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
         class: "govuk-button", data: { qa: 'course__save' }

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -4,9 +4,6 @@
 <% end %>
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl">
-  <%= subject_page_title(@course) %>
-</h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: continue_provider_recruitment_cycle_courses_subjects_path(
@@ -14,7 +11,6 @@
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
-
       <%= render "courses/new_fields_holder", form: form, except_keys: [] do |fields| %>
         <%= render 'form_fields', form: fields %>
       <% end %>

--- a/app/views/courses/vacancies/_single_site.html.erb
+++ b/app/views/courses/vacancies/_single_site.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:change_vacancies_confirmation]&.any?) %>">
+<%= render "shared/error_wrapper", error_keys: [:change_vacancies_confirmation], data_qa: "course__change_vacancies_confirmation" do %>
   <% if @errors && @errors[:change_vacancies_confirmation]&.any? %>
     <span id="change_vacancies_confirmation-error" class="govuk-error-message">
       <% @errors[:change_vacancies_confirmation].each do |error| %>
@@ -19,4 +19,4 @@
       <% end %>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/shared/_edit_options_radio_buttons.html.erb
+++ b/app/views/shared/_edit_options_radio_buttons.html.erb
@@ -5,7 +5,7 @@
   data-qa="course__<%= field %>">
   <fieldset class="govuk-fieldset">
     <%= legend %>
-    <%= render "shared/error_messages", field: field if @errors %>
+    <%= render "shared/error_messages", error_keys: [field] %>
     <% @course.meta['edit_options'][key].each_with_index do |value| %>
       <% help = t("edit_options.#{key}.#{value}.help") %>
       <% label = t("edit_options.#{key}.#{value}.label") %>

--- a/app/views/shared/_edit_options_radio_buttons.html.erb
+++ b/app/views/shared/_edit_options_radio_buttons.html.erb
@@ -1,8 +1,7 @@
 <% legend ||= false %>
 <% bold_labels ||= false %>
-<div
-  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[field]&.any?) %>"
-  data-qa="course__<%= field %>">
+
+<%= render "shared/error_wrapper", error_keys: [field], data_qa: "course__#{field}" do %>
   <fieldset class="govuk-fieldset">
     <%= legend %>
     <%= render "shared/error_messages", error_keys: [field] %>
@@ -29,4 +28,4 @@
       </div>
     <% end %>
   </fieldset>
-</div>
+<% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if @errors&.[](field)&.any? %>
-  <span id="<%= field.to_s %>-error" class="govuk-error-message">
+  <span id="<%= field.to_s %>-error" class="govuk-error-message" data-qa="inline-error-<%= field.to_s %>">
     <% @errors[field].each do |error| %>
       <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
     <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,6 +1,6 @@
-<% if @errors&.[](field)&.any? %>
+<% @errors&.slice(*error_keys)&.each do |field, value| %>
   <span id="<%= field.to_s %>-error" class="govuk-error-message" data-qa="inline-error-<%= field.to_s %>">
-    <% @errors[field].each do |error| %>
+    <% value&.each do |error| %>
       <div><span class="govuk-visually-hidden">Error:</span> <%= error %></div>
     <% end %>
   </span>

--- a/app/views/shared/_error_wrapper.html.erb
+++ b/app/views/shared/_error_wrapper.html.erb
@@ -1,0 +1,5 @@
+<div
+  class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors&.slice(*error_keys)&.values&.compact&.any?) %>"
+  data-qa="<%= data_qa %>">
+  <%= yield %>
+</div>

--- a/app/views/shared/_form_field.html.erb
+++ b/app/views/shared/_form_field.html.erb
@@ -15,7 +15,7 @@
     }.merge(defined?(id) ? { for: id } : {})
   %>
 
-  <%= render "shared/error_messages", field: field %>
+  <%= render "shared/error_messages", error_keys: [field] %>
 
   <%= yield([field, options]) %>
 </div>

--- a/app/views/shared/_form_field.html.erb
+++ b/app/views/shared/_form_field.html.erb
@@ -9,7 +9,7 @@
   }.merge(defined?(id) ? { id: id } : {})
 %>
 
-<div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors[field]&.any?) %>">
+<%= render "shared/error_wrapper", error_keys: [field], data_qa: "course__#{field}" do %>
   <%= form.label field, label, {
       class: cns("govuk-label", "govuk-label--s": label_bold)
     }.merge(defined?(id) ? { for: id } : {})
@@ -18,4 +18,4 @@
   <%= render "shared/error_messages", error_keys: [field] %>
 
   <%= yield([field, options]) %>
-</div>
+<% end %>

--- a/app/views/ucas_contacts/alerts.html.erb
+++ b/app/views/ucas_contacts/alerts.html.erb
@@ -54,7 +54,7 @@
 
         <div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:share_with_ucas_permission]&.any?) %>">
         <div class="govuk-checkboxes" data-module="checkboxes">
-          <%= render 'shared/error_messages', field: :share_with_ucas_permission %>
+          <%= render 'shared/error_messages', error_keys: [:share_with_ucas_permission] %>
           <div class="govuk-checkboxes__item">
             <%= form.check_box :share_with_ucas_permission,
                                   checked: false,

--- a/app/views/ucas_contacts/alerts.html.erb
+++ b/app/views/ucas_contacts/alerts.html.erb
@@ -52,7 +52,7 @@
                              data: { qa: 'ucas_contacts__application_alert_contact' }%>
       </div>
 
-        <div class="<%= cns("govuk-form-group", "govuk-form-group--error": @errors && @errors[:share_with_ucas_permission]&.any?) %>">
+      <%= render "shared/error_wrapper", error_keys: [:share_with_ucas_permission], data_qa: "course__share_with_ucas_permission" do %>
         <div class="govuk-checkboxes" data-module="checkboxes">
           <%= render 'shared/error_messages', error_keys: [:share_with_ucas_permission] %>
           <div class="govuk-checkboxes__item">
@@ -67,7 +67,7 @@
             <% end %>
           </div>
         </div>
-      </div>
+      <% end %>
 
       <hr class="govuk-section-break govuk-section-break--l">
 

--- a/spec/features/courses/apprenticeship/new_spec.rb
+++ b/spec/features/courses/apprenticeship/new_spec.rb
@@ -64,7 +64,7 @@ feature "new course apprenticeship", type: :feature do
     it_behaves_like "a course creation page"
   end
 
-  fcontext "Error handling" do
+  context "Error handling" do
     let(:course) do
       c = build(:course, provider: provider)
       c.errors.add(:funding_type, "Invalid")

--- a/spec/features/courses/apprenticeship/new_spec.rb
+++ b/spec/features/courses/apprenticeship/new_spec.rb
@@ -64,7 +64,7 @@ feature "new course apprenticeship", type: :feature do
     it_behaves_like "a course creation page"
   end
 
-  context "Error handling" do
+  fcontext "Error handling" do
     let(:course) do
       c = build(:course, provider: provider)
       c.errors.add(:funding_type, "Invalid")
@@ -72,12 +72,20 @@ feature "new course apprenticeship", type: :feature do
       c
     end
 
-    scenario do
+    scenario "error flash" do
       visit_new_apprenticeship_page
       new_apprenticeship_page.funding_type_fields.apprenticeship.click
       new_apprenticeship_page.continue.click
       expect(new_apprenticeship_page.error_flash.text).to include("Funding type Invalid")
       expect(new_apprenticeship_page.error_flash.text).to include("Program type Invalid")
+    end
+
+    scenario "inline error messages" do
+      visit_new_apprenticeship_page
+      new_apprenticeship_page.funding_type_fields.apprenticeship.click
+      new_apprenticeship_page.continue.click
+      expect(new_apprenticeship_page.funding_type_error.text).to include("Error: Funding type Invalid")
+      expect(new_apprenticeship_page.program_type_error.text).to include("Error: Program type Invalid")
     end
   end
 

--- a/spec/features/courses/level/new_spec.rb
+++ b/spec/features/courses/level/new_spec.rb
@@ -73,9 +73,14 @@ feature "New course level", type: :feature do
       c
     end
 
-    scenario do
+    scenario "error flash" do
       new_level_page.continue.click
       expect(new_level_page.error_flash.text).to include("Level Invalid")
+    end
+
+    scenario "inline error messages" do
+      new_level_page.continue.click
+      expect(new_level_page.error_messages.text).to include("Error: Level Invalid")
     end
   end
 

--- a/spec/features/courses/sites/new_spec.rb
+++ b/spec/features/courses/sites/new_spec.rb
@@ -101,9 +101,14 @@ feature "New course sites" do
       c
     end
 
-    scenario do
+    scenario "error flash" do
       new_locations_page.continue.click
       expect(new_locations_page.error_flash.text).to include("Sites Invalid")
+    end
+
+    scenario "inline error messages" do
+      new_locations_page.continue.click
+      expect(new_locations_page.error_messages.text).to include("Error: Sites Invalid")
     end
   end
 

--- a/spec/features/courses/subjects/edit_spec.rb
+++ b/spec/features/courses/subjects/edit_spec.rb
@@ -44,7 +44,7 @@ feature "Edit course subjects", type: :feature do
       subjects_page.load_with_course(course)
       edit_subject_stub = stub_api_v2_resource(course, method: :patch)
 
-      subjects_page.subjects_fields.select(subjects.first.subject_name)
+      subjects_page.master_subject_fields.select(subjects.first.subject_name)
       subjects_page.save.click
       expect(languages_page).to be_displayed
 
@@ -78,7 +78,7 @@ feature "Edit course subjects", type: :feature do
       subjects_page.load_with_course(course)
       edit_subject_stub = stub_api_v2_resource(course, method: :patch)
 
-      subjects_page.subjects_fields.select(subjects.first.subject_name)
+      subjects_page.master_subject_fields.select(subjects.first.subject_name)
       subjects_page.save.click
       expect(course_details_page).to be_displayed
       expect(edit_subject_stub).not_to have_been_made

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -118,7 +118,7 @@ feature "New course level", type: :feature do
         stub_api_v2_build_course(subjects_ids: [nil])
       end
 
-      scenario do
+      scenario "error flash" do
         new_subjects_page.continue.click
         expect(new_subjects_page.error_flash.text).to include("Subjects Invalid")
       end

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -122,6 +122,11 @@ feature "New course level", type: :feature do
         new_subjects_page.continue.click
         expect(new_subjects_page.error_flash.text).to include("Subjects Invalid")
       end
+
+      scenario "inline error messages" do
+        new_subjects_page.continue.click
+        expect(new_subjects_page.error_messages.text).to include("Error: Subjects Invalid")
+      end
     end
 
     scenario "sends user back to course confirmation" do

--- a/spec/site_prism/page_objects/page/organisations/course_subjects.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_subjects.rb
@@ -5,6 +5,7 @@ module PageObjects
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/subjects"
 
         element :subjects_fields, '[data-qa="course__subjects"]'
+        element :master_subject_fields, '[data-qa="course__master_subject"]'
         element :save, '[data-qa="course__save"]'
       end
     end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
@@ -5,6 +5,9 @@ module PageObjects
         class NewApprenticeshipPage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/apprenticeship/new{?query*}"
 
+          element :funding_type_error, '[data-qa="inline-error-funding_type"]'
+          element :program_type_error, '[data-qa="inline-error-program_type"]'
+          
           section :funding_type_fields, '[data-qa="course__funding_type"]' do
             element :apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'
             element :fee, '[data-qa="course__funding_type_fee"]'

--- a/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_apprenticeship_page.rb
@@ -7,7 +7,7 @@ module PageObjects
 
           element :funding_type_error, '[data-qa="inline-error-funding_type"]'
           element :program_type_error, '[data-qa="inline-error-program_type"]'
-          
+
           section :funding_type_fields, '[data-qa="course__funding_type"]' do
             element :apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'
             element :fee, '[data-qa="course__funding_type_fee"]'

--- a/spec/site_prism/page_objects/page/organisations/courses/new_course_base.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_course_base.rb
@@ -5,6 +5,7 @@ module PageObjects
         class NewCourseBase < CourseBase
           element :success_summary, ".govuk-success-summary"
           element :error_flash, ".govuk-error-summary"
+          element :error_messages, ".govuk-error-message"
           element :continue, '[data-qa="course__save"]'
           element :back, '[data-qa="page-back"]'
         end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_locations_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_locations_page.rb
@@ -5,6 +5,7 @@ module PageObjects
         class NewLocationsPage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/locations/new{?query*}"
 
+          element :title, '[data-qa="page-heading"]'
           elements :site_names, '[data-qa="site__name"]'
         end
       end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_subjects_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_subjects_page.rb
@@ -5,7 +5,9 @@ module PageObjects
         class NewSubjectsPage < NewCourseBase
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/subjects/new{?query*}"
 
+          element :title, '[data-qa="page-heading"]'
           element :subjects_fields, '[data-qa="course__subjects"]'
+          element :master_subject_fields, '[data-qa="course__master_subject"]'
           element :subordinate_subject_accordion, '[data-qa="course__subordinate_subject_accordion"]'
           element :subordinate_subjects_fields, '[data-qa="course__subordinate_subjects"]'
           element :continue, '[data-qa="course__save"]'


### PR DESCRIPTION
### Context
During DAC user testing we discovered that it was very important that users be able to see the error in the same place as the incorrect data especially if they were using high zooms or screen readers.  

### Changes proposed in this pull request  
Apply the appropriate formatting for fields with errors, according to https://design-system.service.gov.uk/components/error-summary/  
The red indicator as well as the small message as seen below was previously missing:
![image](https://user-images.githubusercontent.com/41294831/71180146-7c449000-2269-11ea-8924-301d3e6a26d1.png)
Also includes some refactoring here and there to make the create course pages more consistent and easier to work with.

### Guidance to review
You may need to checkout `2640-create-a-course-validation-changes` on the backend

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
