### PR TITLE
[2664] - Clean up Azure test output config

### DIFF
--- a/.azure_parallel
+++ b/.azure_parallel
@@ -1,4 +1,5 @@
+--require spec_helper
 --no-profile
---format progress
+--format documentation
 --format RspecJunitFormatter
 --out rspec-output/rspec-output<%= ENV['TEST_ENV_NUMBER'] %>.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ steps:
 
 - script: |
     docker run --name test-run-image -d $(IMAGE_NAME)
-    docker exec test-run-image rake parallel:spec
+    docker exec test-run-image rake "parallel:spec[,, -O .azure_parallel]"
     docker cp test-run-image:/app/rspec-output .
     docker stop test-run-image
     docker rm test-run-image


### PR DESCRIPTION
### Context
- Create an rspec file specifically for CI and use this when running specs

### Changes proposed in this pull request
- removal of local parallel spec rspec config

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
