### PR TITLE
[2640] Add error handling to modern language selection

### DIFF
--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -59,6 +59,10 @@ module Courses
 
   private
 
+    def error_keys
+      [:subjects]
+    end
+
     def strip_non_language_subjects
       @course.subjects.reject { |s| available_languages_ids.include?(s.id) }
     end
@@ -89,7 +93,7 @@ module Courses
     end
 
     def build_course_params
-      params[:course][:subjects_ids] += params[:course][:language_ids]
+      params[:course][:subjects_ids] += params[:course][:language_ids] if params[:course][:language_ids]
       params[:course].delete :language_ids
     end
   end

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -85,6 +85,16 @@ feature "new modern language", type: :feature do
       )
       expect(new_modern_languages_page).to be_displayed
     end
+
+    context "Error handling" do
+      scenario do
+        course.errors.add(:subjects, "Invalid")
+        stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id])
+        visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id] })
+        new_modern_languages_page.continue.click
+        expect(new_modern_languages_page.error_flash.text).to include("Subjects Invalid")
+      end
+    end
   end
 
   context "without modern language selected" do


### PR DESCRIPTION
### Context

The backend now supports additional validations, to test these when developing the frontend had to be developed to connect to them. 

This adds support to the modern langauges page

### Changes proposed in this pull request

### Guidance to review

- Check out the branch `2640-create-a-course-validation-changes` (or master if it is merged) on MCBE
- Attempt to create a modern langauges course with no selection

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
