### PR TITLE
[2568] Edit course subordinate subjects

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -35,6 +35,9 @@
           <%= course.sorted_subjects %>
         </dd>
         <dd class="govuk-summary-list__actions">
+          <%= link_to subjects_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_subjects_link" } do %>
+            Change<span class="govuk-visually-hidden"> subjects</span>
+          <% end %>
         </dd>
       </div>
 

--- a/spec/site_prism/page_objects/page/organisations/course_subjects.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_subjects.rb
@@ -6,6 +6,8 @@ module PageObjects
 
         element :subjects_fields, '[data-qa="course__subjects"]'
         element :master_subject_fields, '[data-qa="course__master_subject"]'
+        element :subordinate_subject_accordion, '[data-qa="course__subordinate_subject_accordion"]'
+        element :subordinate_subject_fields, '[data-qa="course__subordinate_subjects"]'
         element :save, '[data-qa="course__save"]'
       end
     end


### PR DESCRIPTION
### Context
As it stands the subordinate subject field on the edit page (added because we added the functionality for course creation) does not do anything.

### Changes proposed in this pull request
Make this field function as expected, allowing the user to modify the subordinate subject.

### Guidance to review
Try modifying an existing course's master and subordinate subjects.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
