### PR TITLE
[2512] Change environment variable prefix from SETTINGS__ to PTT__

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ file
 ```
 
 ```bash
-export SETTINGS__FILE__BASED__SETTINGS__ENV1="bar"
+export PTT__FILE__BASED__PTT__ENV1="bar"
 ```
 
 ```ruby

--- a/azure/template.json
+++ b/azure/template.json
@@ -247,15 +247,15 @@
                 "value": "[parameters('webpackerDevHost')]"
               },
               {
-                "name": "SETTINGS__DFE_SIGNIN__SECRET",
+                "name": "PTT__DFE_SIGNIN__SECRET",
                 "value": "[parameters('dfeSignInSecret')]"
               },
               {
-                "name": "SETTINGS__MANAGE_BACKEND__SECRET",
+                "name": "PTT__MANAGE_BACKEND__SECRET",
                 "value": "[parameters('settingsManageBackendSecret')]"
               },
               {
-                "name": "SETTINGS__GOOGLE__MAPS_API_KEY",
+                "name": "PTT__GOOGLE__MAPS_API_KEY",
                 "value": "[parameters('settingsGoogleMapsAPIKey')]"
               },
               {
@@ -267,11 +267,11 @@
                 "value": "0"
               },
               {
-                "name": "SETTINGS__LOGSTASH__HOST",
+                "name": "PTT__LOGSTASH__HOST",
                 "value": "[parameters('logstashHost')]"
               },
               {
-                "name": "SETTINGS__LOGSTASH__PORT",
+                "name": "PTT__LOGSTASH__PORT",
                 "value": "[parameters('logstashPort')]"
               }
             ]

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -21,7 +21,7 @@ Config.setup do |config|
 
   # Define ENV variable prefix deciding which variables to load into config.
   #
-  config.env_prefix = "SETTINGS"
+  config.env_prefix = "PTT"
 
   # What string to use as level separator for settings loaded from ENV variables. Default value of '.' works well
   # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where

--- a/config/settings/pentest.yml
+++ b/config/settings/pentest.yml
@@ -1,7 +1,7 @@
 dfe_signin:
   issuer: https://signin-test-oidc-as.azurewebsites.net
   profile: https://signin-test-pfl-as.azurewebsites.net
-  secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
+  secret: please_change_me # Override with PTT__DFE_SIGNIN__SECRET
   base_url: https://www.pen.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://signin-test-sup-as.azurewebsites.net/users
 manage_backend:

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,6 +1,6 @@
 dfe_signin:
   issuer: https://oidc.signin.education.gov.uk
-  secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
+  secret: please_change_me # Override with PTT__DFE_SIGNIN__SECRET
   profile: https://profile.signin.education.gov.uk
   base_url: https://www.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://support.signin.education.gov.uk/users

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,7 +1,7 @@
 dfe_signin:
   issuer: https://signin-test-oidc-as.azurewebsites.net
   profile: https://signin-test-pfl-as.azurewebsites.net
-  secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
+  secret: please_change_me # Override with PTT__DFE_SIGNIN__SECRET
   base_url: https://www.qa.publish-teacher-training-courses.service.gov.uk
 manage_backend:
   base_url: https://api2.qa.publish-teacher-training-courses.service.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,7 +1,7 @@
 dfe_signin:
   issuer: https://pp-oidc.signin.education.gov.uk
   profile: https://pp-profile.signin.education.gov.uk
-  secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
+  secret: please_change_me # Override with PTT__DFE_SIGNIN__SECRET
   base_url: https://www.staging.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://pp-support.signin.education.gov.uk/users
 manage_backend:

--- a/maintenance/filebeat.yml
+++ b/maintenance/filebeat.yml
@@ -3,7 +3,7 @@ filebeat.config.modules:
   reload.enabled: false
 
 output.logstash:
-  hosts: ["${SETTINGS__LOGSTASH__HOST}:${SETTINGS__LOGSTASH__PORT}"]
+  hosts: ["${PTT__LOGSTASH__HOST}:${PTT__LOGSTASH__PORT}"]
   loadbalance: true
   ssl.enabled: true
 

--- a/maintenance/template.json
+++ b/maintenance/template.json
@@ -119,11 +119,11 @@
           "appServiceAppSettings": {
             "value": [
               {
-                "name": "SETTINGS__LOGSTASH__HOST",
+                "name": "PTT__LOGSTASH__HOST",
                 "value": "[parameters('logstashHost')]"
               },
               {
-                "name": "SETTINGS__LOGSTASH__PORT",
+                "name": "PTT__LOGSTASH__PORT",
                 "value": "[parameters('logstashPort')]"
               }
             ]


### PR DESCRIPTION
### Context
Our applications currently make use of a number of variables, as such it is easy to confuse which environment variable is for which application.

### Changes proposed in this pull request
Any environment variable previously prefixed with `SETTINGS__` will now be prefixed by `PTT__`

### Guidance to review
This will need changes to azure I presume. @rizzkhan1  
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
