### PR TITLE
[2677] Add guidance and links for non-admin users requesting PE courses

### DIFF
--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -21,3 +21,12 @@
     <% end %>
   </div>
 </div>
+
+<div class="govuk-grid-row", data-qa="course__google_form_link" >
+  <% if !current_user["admin"] && @course.level == "secondary" %>
+    <h2 class="govuk-heading-m"> Adding a Physical education course?<h2/>
+    <p class="govuk-body-s">You’ll need to fill in a
+      <%= link_to "separate google form", add_course_url(current_user['info']['email'], @provider, is_current_cycle: true), link_class: "govuk-link", rel: "noopener noreferrer", target: "_blank" %>
+      as places are limited.</p>
+  <% end %>
+</div>

--- a/spec/site_prism/page_objects/page/organisations/courses/new_subjects_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_subjects_page.rb
@@ -9,6 +9,7 @@ module PageObjects
           element :subordinate_subject_accordion, '[data-qa="course__subordinate_subject_accordion"]'
           element :subordinate_subjects_fields, '[data-qa="course__subordinate_subjects"]'
           element :continue, '[data-qa="course__save"]'
+          element :google_form_link, '[data-qa="course__google_form_link"]'
         end
       end
     end


### PR DESCRIPTION
### Context

PE courses should not be able to be created by providers as we need to ensure they have been allocated places.

### Changes proposed in this pull request
- If the user is an admin allow PE creation as normal
- If not add guidance linking them to a google form

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
