### PR TITLE
2700 setup tracing on azure pipeline commands

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ variables:
 
 steps:
 - script: |
+    set -x
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
     IMAGE_NAME_WITH_TAG=$(IMAGE_NAME):$GIT_SHORT_SHA
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
@@ -33,6 +34,7 @@ steps:
     addDefaultLabels: false
 
 - script: |
+    set -x
     docker run --name test-run-image -d $(IMAGE_NAME)
     docker exec test-run-image rake "parallel:spec[,, -O .azure_parallel]"
     docker cp test-run-image:/app/rspec-output .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,6 @@ variables:
 
 steps:
 - script: |
-    set -x
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
     IMAGE_NAME_WITH_TAG=$(IMAGE_NAME):$GIT_SHORT_SHA
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,10 @@ variables:
 
 steps:
 - script: |
+    set -x
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
     IMAGE_NAME_WITH_TAG=$(IMAGE_NAME):$GIT_SHORT_SHA
+    set +x
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG;]$IMAGE_NAME_WITH_TAG"
   displayName: 'Set version number'


### PR DESCRIPTION
### Context
The Azure DevOps pipelines don't display what commands are running so it can be hard to understand what's happening just from the output.

### Changes proposed in this pull request
Add set -x to all the steps' jobs in the build pipeline to enable built-in shell tracing.

### Guidance to review
:shipit:
