### PR TITLE
[2677] Move PE google form link above continue

### DIFF
--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -13,16 +13,17 @@
                   method: :get do |form| %>
       <%= render "courses/new_fields_holder", form: form, except_keys: [] do |fields| %>
         <%= render 'form_fields', form: fields %>
+
+        <div class="govuk-grid-row", data-qa="course__google_form_link" >
+          <% if !current_user["admin"] && @course.level == "secondary" %>
+            <h2 class="govuk-heading-m"> Adding a Physical education course?<h2/>
+            <p class="govuk-body-s">You’ll need to fill in a
+              <%= link_to "separate google form", add_course_url(current_user['info']['email'], @provider, is_current_cycle: true), link_class: "govuk-link", rel: "noopener noreferrer", target: "_blank" %>
+              as places are limited.</p>
+          <% end %>
+        </div>
+        
       <% end %>
     <% end %>
   </div>
-</div>
-
-<div class="govuk-grid-row", data-qa="course__google_form_link" >
-  <% if !current_user["admin"] && @course.level == "secondary" %>
-    <h2 class="govuk-heading-m"> Adding a Physical education course?<h2/>
-    <p class="govuk-body-s">You’ll need to fill in a
-      <%= link_to "separate google form", add_course_url(current_user['info']['email'], @provider, is_current_cycle: true), link_class: "govuk-link", rel: "noopener noreferrer", target: "_blank" %>
-      as places are limited.</p>
-  <% end %>
 </div>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -14,15 +14,14 @@
       <%= render "courses/new_fields_holder", form: form, except_keys: [] do |fields| %>
         <%= render 'form_fields', form: fields %>
 
-        <div class="govuk-grid-row", data-qa="course__google_form_link" >
+        <div data-qa="course__google_form_link" >
           <% if !current_user["admin"] && @course.level == "secondary" %>
             <h2 class="govuk-heading-m"> Adding a Physical education course?<h2/>
             <p class="govuk-body-s">You’ll need to fill in a
-              <%= link_to "separate google form", add_course_url(current_user['info']['email'], @provider, is_current_cycle: true), link_class: "govuk-link", rel: "noopener noreferrer", target: "_blank" %>
-              as places are limited.</p>
+              <%= link_to "separate Google Form", add_course_url(current_user['info']['email'], @provider, is_current_cycle: true), class: "govuk-link", rel: "noopener noreferrer", target: "_blank" %>,
+            as PE places are limited.</p>
           <% end %>
         </div>
-        
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
### Context

Jesse noticed that the google form link for PE courses should be above the continue button on the subjects new page

### Changes proposed in this pull request

- Move the link above the continue button


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
