### PR TITLE
[1591] Add courses as accredited body section to org show page

### DIFF
--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -34,6 +34,7 @@
     <% else %>
       <%= render partial: 'recruitment_cycles/about_organisation', locals: { provider: @provider, year: Settings.current_cycle } %>
       <%= render partial: 'recruitment_cycles/courses_info', locals: { provider: @provider, year: Settings.current_cycle } %>
+      <%= render partial: 'recruitment_cycles/courses_accredited_body', locals: { provider: @provider } %>
       <%= render partial: 'recruitment_cycles/locations_info', locals: { provider: @provider, year: Settings.current_cycle } %>
     <% end %>
   </div>

--- a/app/views/recruitment_cycles/_courses_accredited_body.html.erb
+++ b/app/views/recruitment_cycles/_courses_accredited_body.html.erb
@@ -1,4 +1,4 @@
-<% if @provider.accredited_body? %>
+<% if @provider.accredited_body? && current_user["admin"]%>
   <div class="govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-m"><%= link_to "Courses as an accredited body","#", class: "govuk-link", data: { qa: 'courses_as_accredited_body_link' } %></h2>
       <p class="govuk-body">Use this section to:</p>

--- a/app/views/recruitment_cycles/_courses_accredited_body.html.erb
+++ b/app/views/recruitment_cycles/_courses_accredited_body.html.erb
@@ -1,0 +1,10 @@
+<% if @provider.accredited_body? %>
+  <div class="govuk-!-margin-bottom-8">
+    <h2 class="govuk-heading-m"><%= link_to "Courses as an accredited body","#", class: "govuk-link", data: { qa: 'courses_as_accredited_body_link' } %></h2>
+      <p class="govuk-body">Use this section to:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
+        <li>see who lists you as their accredited body</li>
+        <li>see which courses you’re the accredited body for</li>
+      </ul>
+    </div>
+  <% end %>

--- a/spec/features/providers/show_spec.rb
+++ b/spec/features/providers/show_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+feature "Show providers", type: :feature do
+  let(:organisation_show_page) { PageObjects::Page::Organisations::OrganisationShow.new }
+  let(:provider) { build :provider }
+
+  before do
+    stub_omniauth
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(provider.recruitment_cycle)
+  end
+
+  context "When the provider is not accredited" do
+    it "does not have show the courses as an accredited body link" do
+      visit provider_path(provider.provider_code)
+      expect { organisation_show_page.courses_as_accredited_body_link }.to raise_error(Capybara::ElementNotFound)
+    end
+  end
+
+  context "When the provider is not accredited" do
+    let(:provider) { build :provider, accredited_body?: true }
+
+    it "does not have show the courses as an accredited body link" do
+      visit provider_path(provider.provider_code)
+
+      expect(organisation_show_page.courses_as_accredited_body_link.text).to eq("Courses as an accredited body")
+    end
+  end
+end

--- a/spec/features/providers/show_spec.rb
+++ b/spec/features/providers/show_spec.rb
@@ -3,11 +3,14 @@ require "rails_helper"
 feature "Show providers", type: :feature do
   let(:organisation_show_page) { PageObjects::Page::Organisations::OrganisationShow.new }
   let(:provider) { build :provider }
+  let(:user) { build :user }
+  let(:access_request) { build :access_request }
 
   before do
-    stub_omniauth
+    stub_omniauth(user: user)
     stub_api_v2_resource(provider)
     stub_api_v2_resource(provider.recruitment_cycle)
+    stub_api_v2_resource_collection([access_request])
   end
 
   context "When the provider is not accredited" do
@@ -17,13 +20,23 @@ feature "Show providers", type: :feature do
     end
   end
 
-  context "When the provider is not accredited" do
+  context "When the provider is accredited" do
     let(:provider) { build :provider, accredited_body?: true }
 
-    it "does not have show the courses as an accredited body link" do
-      visit provider_path(provider.provider_code)
+    context "and the user is not an admin"  do
+      it "does not have show the courses as an accredited body link" do
+        visit provider_path(provider.provider_code)
+        expect { organisation_show_page.courses_as_accredited_body_link }.to raise_error(Capybara::ElementNotFound)
+      end
+    end
 
-      expect(organisation_show_page.courses_as_accredited_body_link.text).to eq("Courses as an accredited body")
+    context "and the user is an admin" do
+      let(:user) { build :user, :admin }
+
+      it "does shows the courses as an accredited body link" do
+        visit provider_path(provider.provider_code)
+        expect(organisation_show_page.courses_as_accredited_body_link.text).to eq("Courses as an accredited body")
+      end
     end
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/organisation_show.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_show.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Organisations
+      class OrganisationShow < CourseBase
+        set_url "/organisations/{provider_code}/"
+
+        element :courses_as_accredited_body_link, "[data-qa=courses_as_accredited_body_link]"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

The organisation#show page ('organisations/A01') should display a 'Courses as an accredited body' link if the organisation is an accredited provider.


https://manage-courses-prototype.herokuapp.com/

### Changes proposed in this pull request

- Add an additional section on the org#show page for the above
- Currently hidden from non-admin users (to be removed later)

### Guidance for review
Future PRs will include:

This will include a page to display all the training providers and an additional page which shows the courses accredited by the provider run by each training provider

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
