### PR TITLE
[2537] Require login on/providers/suggest

### DIFF
--- a/app/controllers/provider_suggestions_controller.rb
+++ b/app/controllers/provider_suggestions_controller.rb
@@ -1,6 +1,4 @@
 class ProviderSuggestionsController < ApplicationController
-  skip_before_action :authenticate
-
   def suggest
     suggestions = ProviderSuggestion.suggest(params[:query])
       .map { |provider| { code: provider.provider_code, name: provider.provider_name } }

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -1,67 +1,79 @@
 require "rails_helper"
 
 describe "Providers", type: :request do
-  before do
-    stub_omniauth
-    get(auth_dfe_callback_path)
-  end
+  context "when the user is authenticated" do
+    before do
+      stub_omniauth
+      get(auth_dfe_callback_path)
+    end
 
-  describe "GET index" do
-    let(:path) { root_path } # providers_path redirects to root, and the list is rendered from there
-    context "with 1 provider" do
-      it "redirects to providers show" do
-        current_recruitment_cycle = build(:recruitment_cycle)
+    describe "GET index" do
+      let(:path) { root_path } # providers_path redirects to root, and the list is rendered from there
+      context "with 1 provider" do
+        it "redirects to providers show" do
+          current_recruitment_cycle = build(:recruitment_cycle)
+          provider = build(:provider)
+          stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
+          stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers", provider.to_jsonapi)
+          get(path)
+          expect(response).to redirect_to provider_path(provider.provider_code)
+        end
+      end
+
+      context "with 2 or more providers" do
+        it "renders providers index" do
+          current_recruitment_cycle = build(:recruitment_cycle)
+          provider1 = build(:provider, include_counts: [:courses])
+          provider2 = build(:provider, include_counts: [:courses])
+          providers = [provider1, provider2]
+          stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
+          stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers", resource_list_to_jsonapi(providers))
+          get(path)
+          expect(response.body).to include("Organisations")
+          expect(response.body).to include(provider1.provider_name)
+        end
+      end
+
+      context "user has no providers" do
+        it "shows no-providers page" do
+          current_recruitment_cycle = build(:recruitment_cycle)
+          stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
+          stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers", jsonapi(:providers_response, data: []))
+          get(path)
+          expect(response).to have_http_status(:forbidden)
+          expect(response.body).to include("We don’t know which organisation you’re part of")
+        end
+      end
+    end
+
+    describe "GET show" do
+      it "render providers show" do
         provider = build(:provider)
-        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers", provider.to_jsonapi)
-        get(path)
-        expect(response).to redirect_to provider_path(provider.provider_code)
-      end
-    end
-
-    context "with 2 or more providers" do
-      it "renders providers index" do
-        current_recruitment_cycle = build(:recruitment_cycle)
-        provider1 = build(:provider, include_counts: [:courses])
-        provider2 = build(:provider, include_counts: [:courses])
-        providers = [provider1, provider2]
-        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers", resource_list_to_jsonapi(providers))
-        get(path)
-        expect(response.body).to include("Organisations")
-        expect(response.body).to include(provider1.provider_name)
-      end
-    end
-
-    context "user has no providers" do
-      it "shows no-providers page" do
         current_recruitment_cycle = build(:recruitment_cycle)
         stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers", jsonapi(:providers_response, data: []))
-        get(path)
-        expect(response).to have_http_status(:forbidden)
-        expect(response.body).to include("We don’t know which organisation you’re part of")
+        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}", provider.to_jsonapi)
+        get(provider_path(provider.provider_code))
+        expect(response.body).to include(provider.provider_name)
+      end
+
+      context "provider does not exist" do
+        it "renders not found" do
+          current_recruitment_cycle = build(:recruitment_cycle)
+          stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
+          stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers/foo", {}, :get, 404)
+          get(provider_path("foo"))
+          expect(response.body).to include("Page not found")
+        end
       end
     end
   end
 
-  describe "GET show" do
-    it "render providers show" do
-      provider = build(:provider)
-      current_recruitment_cycle = build(:recruitment_cycle)
-      stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-      stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{provider.provider_code}", provider.to_jsonapi)
-      get(provider_path(provider.provider_code))
-      expect(response.body).to include(provider.provider_name)
-    end
+  context "when the user is not authenticated" do
+    describe "GET suggest" do
+      it "redirects to signin" do
+        get "/providers/suggest"
 
-    context "provider does not exist" do
-      it "renders not found" do
-        current_recruitment_cycle = build(:recruitment_cycle)
-        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}", current_recruitment_cycle.to_jsonapi)
-        stub_api_v2_request("/recruitment_cycles/#{current_recruitment_cycle.year}/providers/foo", {}, :get, 404)
-        get(provider_path("foo"))
-        expect(response.body).to include("Page not found")
+        expect(response).to redirect_to("http://www.example.com/signin")
       end
     end
   end


### PR DESCRIPTION
## Context

Attempts to visit `/providers/suggest` whilst unauthenticated resulted
in a 500 rather than redirecting to signin.

![](https://trello-attachments.s3.amazonaws.com/5dcd4c022dd1184345903378/1097x541/7b8a702d76edc58a05f6bc288ea67a0d/image.png)

### Changes proposed in this pull request

Require authentication in the controller to remedy this and redirect the
user appropriately.

### Guidance to review

There is a big diff in the spec that has been caused by moving the majority of the existing specs into an 'authenticated' context to allow the new spec to be in an 'unauthenticated' one.  The actual new code is only 48 onwards.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
