### PR TITLE
[2763] Fix dan's code

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -18,7 +18,7 @@ class Provider < Base
   end
 
   def full_address
-    [address1, address2, address3, address4, postcode].select(&:present?).join("<br> ").html_safe
+    [address1, address2, address3, address4, postcode].map { |line| ERB::Util.html_escape(line) }.select(&:present?).join("<br> ").html_safe
   end
 
   def rolled_over?

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -22,6 +22,6 @@ class Site < Base
   ].freeze
 
   def full_address
-    [address1, address2, address3, address4, postcode].select(&:present?).join(", ").html_safe
+    [address1, address2, address3, address4, postcode].select(&:present?).join(", ")
   end
 end


### PR DESCRIPTION
### Context
Manage Courses Frontend can be fiddled with via site and provider addresses.

### Changes proposed in this pull request
Patch the thing by encoding untrusted input (either by explicitly encoding it or removing the use of `.html_safe()` depending on suitability.

### Guidance to review
Steps to reproduce:
Modify address data in site or provider contact information such that it contains HTML. The HTML should appear where it is rendered such as on the edit locations page.

PoC: https://www.qa.publish-teacher-training-courses.service.gov.uk/organisations/2AT/2020/courses/3CXF/locations

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
