### PR TITLE
[2676] Rename Equivalence test to Equivalency test

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,10 +51,10 @@ en:
         label: "2: Taking the GCSE"
         help: "You will consider applicants with a pending GCSE. But UCAS will block applications from anyone who needs to take an equivalency test."
         details_label: "Taking the GCSE"
-      equivalence_test:
-        label: "3: Equivalence test"
+      equivalency_test:
+        label: "3: Equivalency test"
         help: "You will consider applicants who need to take an equivalency test, as well as those with a pending GCSE."
-        details_label: "Equivalence test"
+        details_label: "Equivalency test"
       not_required:
         details_label: "No requirement"
         help: "You will receive applications from candidates who will not have a grade C (or 4) or above."

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -37,7 +37,7 @@ FactoryBot.define do
           entry_requirements: %i[
             must_have_qualification_at_application_time
             expect_to_achieve_before_training_begins
-            equivalence_test
+            equivalency_test
           ],
           qualifications: qualifications,
           age_range_in_years: age_range_in_years,

--- a/spec/features/courses/details_spec.rb
+++ b/spec/features/courses/details_spec.rb
@@ -122,7 +122,7 @@ feature "Course details", type: :feature do
         provider: provider,
         gcse_subjects_required: %w[maths science],
         english: "expect_to_achieve_before_training_begins",
-        science: "equivalence_test",
+        science: "equivalency_test",
         age_range_in_years: nil,
       )
     end
@@ -131,7 +131,7 @@ feature "Course details", type: :feature do
       course_details_page.load_with_course(course)
       expect(course_details_page).to have_entry_requirements
       expect(course_details_page.entry_requirements).to have_content("Maths GCSE: Taking")
-      expect(course_details_page.entry_requirements).to have_content("Science GCSE: Equivalence test")
+      expect(course_details_page.entry_requirements).to have_content("Science GCSE: Equivalency test")
       expect(course_details_page.entry_requirements).not_to have_content("English GCSE")
       expect(course_details_page.age_range).to have_content("Unknown")
     end

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -7,7 +7,7 @@ feature "Edit course entry requirements", type: :feature do
   let(:provider) { build(:provider) }
   let(:edit_options) {
     {
-      entry_requirements: %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
+      entry_requirements: %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalency_test],
     }
   }
 
@@ -44,7 +44,7 @@ feature "Edit course entry requirements", type: :feature do
         provider: provider,
         maths: "must_have_qualification_at_application_time",
         english: "expect_to_achieve_before_training_begins",
-        science: "equivalence_test",
+        science: "equivalency_test",
         gcse_subjects_required: %w[maths english science],
       )
     end
@@ -74,7 +74,7 @@ feature "Edit course entry requirements", type: :feature do
       ].each do |subject|
         expect(entry_requirements_page.send(subject)).to have_field("1. Must have the GCSE (least flexible)")
         expect(entry_requirements_page.send(subject)).to have_field("2: Taking the GCSE")
-        expect(entry_requirements_page.send(subject)).to have_field("3: Equivalence test")
+        expect(entry_requirements_page.send(subject)).to have_field("3: Equivalency test")
       end
     end
 
@@ -86,7 +86,7 @@ feature "Edit course entry requirements", type: :feature do
       [
         ["maths_requirements", "1. Must have the GCSE (least flexible)"],
         ["english_requirements", "2: Taking the GCSE"],
-        ["science_requirements", "3: Equivalence test"],
+        ["science_requirements", "3: Equivalency test"],
       ].each do |subject, field_name|
         expect(entry_requirements_page.send(subject)).to have_field(field_name, checked: true)
       end
@@ -136,7 +136,7 @@ feature "Edit course entry requirements", type: :feature do
       ].each do |subject|
         expect(entry_requirements_page.send(subject)).to have_field("1. Must have the GCSE (least flexible)")
         expect(entry_requirements_page.send(subject)).to have_field("2: Taking the GCSE")
-        expect(entry_requirements_page.send(subject)).to have_field("3: Equivalence test")
+        expect(entry_requirements_page.send(subject)).to have_field("3: Equivalency test")
       end
     end
 

--- a/spec/features/courses/entry_requirements/new_spec.rb
+++ b/spec/features/courses/entry_requirements/new_spec.rb
@@ -64,7 +64,7 @@ feature "new course entry_requirements", type: :feature do
       ].each do |subject|
         expect(new_entry_requirements_page.send(subject)).to have_field("1. Must have the GCSE (least flexible)")
         expect(new_entry_requirements_page.send(subject)).to have_field("2: Taking the GCSE")
-        expect(new_entry_requirements_page.send(subject)).to have_field("3: Equivalence test")
+        expect(new_entry_requirements_page.send(subject)).to have_field("3: Equivalency test")
       end
 
       choose("course_maths_expect_to_achieve_before_training_begins")
@@ -105,7 +105,7 @@ feature "new course entry_requirements", type: :feature do
       ].each do |subject|
         expect(new_entry_requirements_page.send(subject)).to have_field("1. Must have the GCSE (least flexible)")
         expect(new_entry_requirements_page.send(subject)).to have_field("2: Taking the GCSE")
-        expect(new_entry_requirements_page.send(subject)).to have_field("3: Equivalence test")
+        expect(new_entry_requirements_page.send(subject)).to have_field("3: Equivalency test")
       end
 
       choose("course_english_expect_to_achieve_before_training_begins")


### PR DESCRIPTION
### Context
Content issue

### Changes proposed in this pull request
- Rename Equivalence test to Equivalency test

### Guidance to review
🚢 

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
