### PR TITLE
[2676] Fix equivalency_test locales

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,7 @@ en:
         label: "2: Taking the GCSE"
         help: "You will consider applicants with a pending GCSE. But UCAS will block applications from anyone who needs to take an equivalency test."
         details_label: "Taking the GCSE"
-      equivalency_test:
+      equivalence_test:
         label: "3: Equivalency test"
         help: "You will consider applicants who need to take an equivalency test, as well as those with a pending GCSE."
         details_label: "Equivalency test"

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -37,7 +37,7 @@ FactoryBot.define do
           entry_requirements: %i[
             must_have_qualification_at_application_time
             expect_to_achieve_before_training_begins
-            equivalency_test
+            equivalence_test
           ],
           qualifications: qualifications,
           age_range_in_years: age_range_in_years,

--- a/spec/features/courses/details_spec.rb
+++ b/spec/features/courses/details_spec.rb
@@ -122,7 +122,7 @@ feature "Course details", type: :feature do
         provider: provider,
         gcse_subjects_required: %w[maths science],
         english: "expect_to_achieve_before_training_begins",
-        science: "equivalency_test",
+        science: "equivalence_test",
         age_range_in_years: nil,
       )
     end

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -7,7 +7,7 @@ feature "Edit course entry requirements", type: :feature do
   let(:provider) { build(:provider) }
   let(:edit_options) {
     {
-      entry_requirements: %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalency_test],
+      entry_requirements: %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
     }
   }
 
@@ -44,7 +44,7 @@ feature "Edit course entry requirements", type: :feature do
         provider: provider,
         maths: "must_have_qualification_at_application_time",
         english: "expect_to_achieve_before_training_begins",
-        science: "equivalency_test",
+        science: "equivalence_test",
         gcse_subjects_required: %w[maths english science],
       )
     end


### PR DESCRIPTION
### Context
Fix for https://github.com/DFE-Digital/manage-courses-frontend/pull/867

### Changes proposed in this pull request
The backend/API sends `equivalence_test` so that needed to remain.

### Guidance to review
🚢 

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
